### PR TITLE
Remove postinstall script which caused installation Failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: required
 jdk: oraclejdk8
 before_script:
   - sudo apt-get update && sudo apt-get install oracle-java8-installer
+  - npm run compile
 script:
   - npm test
   - npm run danger

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Changelog
 
 Unreleased
 ----------
+* Remove postinstall script which caused installation failure
+
+1.1.0 - (June 28, 2017)
+------------------
 ### Dependency Additions/Updates
 * The following changes removed any coupling to the terra-core repository. Additionally, default configuration was added to webpack and nightwatch setup to remove the need for any nightwatch testing configuration at package level for terra components.
 * Added webpack.config.js and nightwatch.conf.js files. These provides a default test setup for the nightwatch scripts. The webpack config file assumes package-level testing with examples living within the 'repo_name'-site package.

--- a/package.json
+++ b/package.json
@@ -23,12 +23,14 @@
     "url": "https://github.com/cerner/terra-toolkit/issues"
   },
   "scripts": {
-    "clean": "rimraf ./node_modules",
-    "clean:install": "npm run clean && npm install",
-    "compile": "$(npm bin)/babel src --out-dir lib --copy-files",
+    "clean:all": "npm run clean:compiled && npm run clean:dependencies",
+    "clean:compiled": "rimraf ./lib",
+    "clean:dependencies": "rimraf ./node_modules",
+    "clean:install": "npm run clean:all && npm install && npm run compile:build",
+    "compile": "npm run clean:compiled && npm run compile:build",
+    "compile:build": "$(npm bin)/babel src --out-dir lib --copy-files",
     "danger": "danger",
     "lint": "eslint --ext .js,.jsx .",
-    "postinstall": "npm run compile",
     "pretest": "npm run lint",
     "release:major": "npm test && node ./scripts/release/release.js major",
     "release:minor": "npm test && node ./scripts/release/release.js minor",

--- a/scripts/release/release.js
+++ b/scripts/release/release.js
@@ -3,7 +3,7 @@ const shell = require('shelljs');
 
 const releaseType = process.argv[2] || 'patch';
 
-if (shell.exec(`npm run compile && npm version ${releaseType} -m "Released version %s" && npm publish && git push`).code !== 0) {
+if (shell.exec(`npm run compile && npm run lint && npm version ${releaseType} -m "Released version %s" && npm publish && git push`).code !== 0) {
   shell.exit(1);
 }
 


### PR DESCRIPTION
#In the newest release of terra-toolkit, running `npm install terra-toolkit` results in an installation failure due to the post install script `"postinstall": "npm run compile"`. This script was added to compile the src files for testing in Travis CI. This PR removes this post install script and moves the command to the .travis.yml file. 

@cerner/terra 