### PR TITLE
update and refactor deps to allow passive updates from consumer projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Refactored dependencies to make webpack and nightwatch peer dependencies.
 
 2.0.0 - (August 31, 2017)
 ------------------

--- a/package.json
+++ b/package.json
@@ -37,47 +37,50 @@
     "release:patch": "npm test && node ./scripts/release/release.js patch",
     "nightwatch": "nightwatch",
     "nightwatch:port-provided": "nightwatch -c tests/test.nightwatch.conf.js",
-    "test": "npm run nightwatch && npm run nightwatch:port-provided"
+    "test": "npm run compile && npm run nightwatch && npm run nightwatch:port-provided"
   },
   "dependencies": {
-    "autoprefixer": "^6.7.7",
-    "babel-loader": "^7.0.0",
-    "babel-polyfill": "^6.23.0",
     "chromedriver": "^2.31.0",
-    "css-loader": "^0.28.0",
-    "extract-text-webpack-plugin": "^2.1.0",
-    "file-loader": "^0.11.1",
     "glob": "^7.1.1",
-    "html-webpack-plugin": "^2.28.0",
-    "json-loader": "^0.5.4",
     "load-json-file": "^2.0.0",
-    "nightwatch": "^0.9.12",
-    "node-sass": "^4.5.2",
-    "postcss-loader": "^1.3.3",
-    "raw-loader": "^0.5.1",
-    "sass-loader": "^6.0.3",
-    "shelljs": "^0.7.6",
-    "style-loader": "^0.16.1",
-    "webpack": "^2.6.1",
-    "webpack-dev-server": "^2.4.5"
+    "shelljs": "^0.7.6"
   },
   "peerDependencies": {
     "react": "^15.4.2",
-    "react-dom": "^15.4.2"
+    "react-dom": "^15.4.2",
+    "webpack": "^3.6.0",
+    "webpack-dev-server": "^2.9.1",
+    "nightwatch": "^0.9.12"
   },
   "devDependencies": {
+    "autoprefixer": "^6.7.7",
     "babel-cli": "^6.24.1",
     "babel-core": "^6.24.1",
+    "babel-loader": "^7.0.0",
+    "babel-polyfill": "^6.23.0",
     "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-preset-es2015": "^6.24.1",
+    "css-loader": "^0.28.7",
     "danger": "^1.0.0",
     "eslint": "^3.19.0",
     "eslint-config-airbnb": "^14.1.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.9.0",
+    "extract-text-webpack-plugin": "^2.1.0",
+    "file-loader": "^0.11.1",
+    "html-webpack-plugin": "^2.30.0",
+    "json-loader": "^0.5.4",
+    "nightwatch": "^0.9.12",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
-    "rimraf": "^2.6.1"
+    "rimraf": "^2.6.1",
+    "webpack": "^3.6.0",
+    "webpack-dev-server": "^2.9.1",
+    "node-sass": "^4.5.2",
+    "postcss-loader": "^2.0.6",
+    "style-loader": "^0.19.0",
+    "raw-loader": "^0.5.1",
+    "sass-loader": "^6.0.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
   "dependencies": {
     "chromedriver": "^2.31.0",
     "glob": "^7.1.1",
-    "load-json-file": "^2.0.0",
-    "shelljs": "^0.7.6"
+    "load-json-file": "^2.0.0"
   },
   "peerDependencies": {
     "react": "^15.4.2",
@@ -79,6 +78,7 @@
     "webpack-dev-server": "^2.9.1",
     "node-sass": "^4.5.2",
     "postcss-loader": "^2.0.6",
+    "shelljs": "^0.7.6",
     "style-loader": "^0.19.0",
     "raw-loader": "^0.5.1",
     "sass-loader": "^6.0.6"


### PR DESCRIPTION
### Summary
Move testing dependencies into devDependencies and made webpack and nightwatch peer dependencies. This makes it easier for consuming projects to update independent of toolkit.