### PR TITLE
Updated nightwatch config to use docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ language: node_js
 sudo: required
 jdk: oraclejdk8
 dist: trusty
-addons:
-  chrome: stable
-  apt:
-    packages:
-      - oracle-java8-set-default
 before_script:
   - npm run compile
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 sudo: required
-jdk: oraclejdk8
 dist: trusty
 before_script:
   - npm run compile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Unreleased
 * Use path.join to allow for windows development
 * Removed sauce labs config and install java 8 in a different way for travis ci
 * Added webdriver.io testing utilities
+* Update nightwatch to use docker
 
 2.1.0 - (October 5, 2017)
 ------------------

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Terra Toolkit is a utility module used to facilitate independent development of 
 
 - Install with [npm](https://www.npmjs.com): `npm install terra-toolkit --save-dev`
 
+Terar toolkit uses docker to run selenium to ensure a consistent testing environment locally and in continuous integration build systems. To use nightwatch with terra toolkit you must install docker on your machine: https://www.docker.com/
+
+
 ## Webdriver.io Utility
 [Webdriver.io](http://webdriver.io/) is a framework for writing webdriver powered tests to validate functionality in browsers. Webdriver.io also provides easy services for setting up selenium, starting webpack and static servers, as well as accessibilty and visual regression testing.
 
@@ -36,9 +39,8 @@ To make testing easier, Terra toolkit provides default configuration that enable
 * Mocha test framework
 
 ### Setup
-1. Install docker on your machine: https://www.docker.com/
 
-2. In your root directory, create a `wdio.conf.js` file that inherits from Terra Toolkit's base config.
+1. In your root directory, create a `wdio.conf.js` file that inherits from Terra Toolkit's base config.
 
 ```js
 const wdioConf = require('terra-toolkit/wdio/conf');
@@ -262,10 +264,6 @@ expect(screenshots).to.not.matchReference();
 
 ## Nightwatch Utility
 Nightwatch.js is an easy to use Node.js based End-to-End (E2E) testing solution for browser based apps and websites. It uses the powerful W3C WebDriver API to perform commands and assertions on DOM elements. Full documentation regarding nightwatch can be found at http://nightwatchjs.org/.
-
-### Setup
-
-Nightwatch uses docker to ensure a consistent testing environment locally and in continuous integration build systems. To use nightwatch, install docker on your machine: https://www.docker.com/
 
 ### Configuration Setup
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Under the key `seleniumDocker` in your wdio.conf.js you can pass a configuration
 * **image** - The docker image to use for test runs. Defaults to `selenium/standalone-chrome` or `selenium/standalone-firefox` based on browser capabilities specified in config.
 * **retries** - Retry count to test for selenium being up. Default 500.
 * **retryInterval** - Retry interval in milliseconds to wait between retries for selenium to come up. Default 10.
+* **env** - An Object representing environment variables to set within the docker instance. Defaults to {}
 
 #### Example
 ```js
@@ -89,6 +90,9 @@ const config = {
   seleniumDocker: {
     // Disable if running in Travis
     enabled: !process.env.TRAVIS,
+    env: {
+      TZ: 'America/Chicago'
+    },
   },
 };
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Terra Toolkit is a utility module used to facilitate independent development of 
 
 - Install with [npm](https://www.npmjs.com): `npm install terra-toolkit --save-dev`
 
-Terar toolkit uses docker to run selenium to ensure a consistent testing environment locally and in continuous integration build systems. To use nightwatch with terra toolkit you must install docker on your machine: https://www.docker.com/
+Terra toolkit uses docker to run selenium to ensure a consistent testing environment locally and in continuous integration build systems. To use nightwatch with terra toolkit you must install docker on your machine: https://www.docker.com/
 
 
 ## Webdriver.io Utility

--- a/README.md
+++ b/README.md
@@ -263,6 +263,9 @@ expect(screenshots).to.not.matchReference();
 ## Nightwatch Utility
 Nightwatch.js is an easy to use Node.js based End-to-End (E2E) testing solution for browser based apps and websites. It uses the powerful W3C WebDriver API to perform commands and assertions on DOM elements. Full documentation regarding nightwatch can be found at http://nightwatchjs.org/.
 
+### Setup
+
+Nightwatch uses docker to ensure a consistent testing environment locally and in continuous integration build systems. To use nightwatch, install docker on your machine: https://www.docker.com/
 
 ### Configuration Setup
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "glob": "^7.1.1",
     "ip": "^1.1.5",
     "load-json-file": "^2.0.0",
-    "webdriverio": "^4.8.0",
+    "webdriverio": "4.8.0",
     "wdio-mocha-framework": "^0.5.11",
     "wdio-visual-regression-service": "^0.8.0",
     "wdio-static-server-service": "^1.0.0"

--- a/src/nightwatch/nightwatch.config.js
+++ b/src/nightwatch/nightwatch.config.js
@@ -32,6 +32,9 @@ const nightwatchConfig = (webpackConfig, srcFolders, providedPort) => {
       seleniumDocker: {
         enabled: !process.env.TRAVIS && !process.env.CI,
         cleanup: true,
+        env: {
+          TZ: 'America/Chicago',
+        },
       },
     }, [{ browserName: 'chrome' }]);
 

--- a/src/nightwatch/nightwatch.config.js
+++ b/src/nightwatch/nightwatch.config.js
@@ -22,7 +22,7 @@ const nightwatchConfig = (webpackConfig, srcFolders, providedPort) => {
 
   const startDriverAndServer = (done) => {
     const staticServerPromise = new Promise((resolve) => {
-      webpackServer.listen(port, '0.0.0.0', () => resolve());
+      webpackServer.listen(port, '0.0.0.0', resolve);
     });
 
     const dockerPromise = seleniumDocker.onPrepare({
@@ -35,7 +35,7 @@ const nightwatchConfig = (webpackConfig, srcFolders, providedPort) => {
       },
     }, [{ browserName: 'chrome' }]);
 
-    Promise.all([staticServerPromise, dockerPromise]).then(() => done());
+    Promise.all([staticServerPromise, dockerPromise]).then(done);
   };
 
   const stopDriverAndServer = (done) => {

--- a/src/wdio/conf.js
+++ b/src/wdio/conf.js
@@ -7,7 +7,7 @@ const path = require('path');
 exports.config = {
   specs: [path.join('.', 'tests', 'specs', '**', '*.js')],
 
-  maxInstances: 10,
+  maxInstances: 1,
 
   capabilities: [
     {

--- a/src/wdio/services/SeleniumDockerService.js
+++ b/src/wdio/services/SeleniumDockerService.js
@@ -69,8 +69,18 @@ export default class SeleniumDockerService {
     return new Promise((resolve, reject) => {
       if (this.config.enabled) {
         const containerId = this.getContainerId();
+
+        // Workaround for browser specific docker issues
+        // see https://github.com/SeleniumHQ/docker-selenium#running-the-images
+        let args = '';
+        if (this.browserName === 'chrome') {
+          args = '-v /dev/shm:/dev/shm';
+        } else if (this.browserName === 'firefox') {
+          args = '--shm-size 2g';
+        }
+
         if (!containerId) {
-          exec(`docker run --rm --cidfile ${this.cidfile} -p ${config.port}:4444 ${this.getImage()}`);
+          exec(`docker run -d --rm ${args} --cidfile ${this.cidfile} -p ${config.port}:4444 ${this.getImage()}`);
         }
         // Retry for 500 times up to 5 seconds for selenium to start
         retry({ times: this.config.retries, interval: this.config.retryInterval },

--- a/src/wdio/services/SeleniumDockerService.js
+++ b/src/wdio/services/SeleniumDockerService.js
@@ -58,6 +58,7 @@ export default class SeleniumDockerService {
       image: null, // The image name to use, defaults to selenium/standalone-${browser}
       retries: 500, // Retry count to test for selenium being up
       retryInterval: 10, // Retry interval in milliseconds to wait between retries for selenium to come up.
+      env: {}, // Environment variables to add to the container
       ...(config.seleniumDocker || {}),
     };
     this.host = config.host;
@@ -79,8 +80,10 @@ export default class SeleniumDockerService {
           args = '--shm-size 2g';
         }
 
+        const env = Object.keys(this.config.env).map(key => `-e ${key}=${this.config.env[key]}`).join(' ');
+
         if (!containerId) {
-          exec(`docker run -d --rm ${args} --cidfile ${this.cidfile} -p ${config.port}:4444 ${this.getImage()}`);
+          exec(`docker run -d --rm ${env} ${args} --cidfile ${this.cidfile} -p ${config.port}:4444 ${this.getImage()}`);
         }
         // Retry for 500 times up to 5 seconds for selenium to start
         retry({ times: this.config.retries, interval: this.config.retryInterval },

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -8,7 +8,6 @@ const staticServerPort = 4567;
 
 const config = {
   baseUrl: `http://${localIP.address()}:${staticServerPort}`,
-
   staticServerPort,
   staticServerLog: false,
   staticServerFolders: [


### PR DESCRIPTION
### Summary
Updated nightwatch to use dockerized selenium to keep consistency in our CI/local testing environments.

### Additional Details
Assuming consumers have docker, this change should be passive.

@cerner/terra


[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
