### PR TITLE
Add hook to reset mouse position

### DIFF
--- a/src/wdio/conf.js
+++ b/src/wdio/conf.js
@@ -25,6 +25,32 @@ exports.config = {
   visualRegression,
   framework: 'mocha',
 
+  beforeHook() {
+    // Ensure the mouse starts in upper left corner before every test.
+    // This prevents unwanted hover effects during visual comparison.
+    // Note: moveTo() is deprecated, so this simulates that by creating an
+    // element that webdriver clicks on that is in the upper left corner of the
+    // screen.
+    // eslint-disable-next-line func-names, prefer-arrow-callback
+    global.browser.execute(function () {
+      // eslint-disable-next-line no-var
+      var div = document.createElement('div');
+      document.body.appendChild(div);
+      div.id = 'wdioMouseReset';
+      div.style.position = 'absolute';
+      div.style.top = 0;
+      div.style.left = 0;
+      div.style.width = '1px';
+      div.style.height = '1px';
+      div.style.zIndex = '9999999';
+      // eslint-disable-next-line func-names, prefer-arrow-callback
+      div.addEventListener('click', function () {
+        document.body.removeChild(div);
+      });
+    });
+    global.browser.click('#wdioMouseReset');
+  },
+
   axe: {
     inject: true,
   },


### PR DESCRIPTION
### Summary
Adds a beforeHook which resets the mouse to the upper top left corner of the screen. This prevents issues with screenshot  comparison where the mouse position is left over from the last test.