### PR TITLE
Add support for screenshot subtitles.

### DIFF
--- a/src/wdio/visualRegressionConf.js
+++ b/src/wdio/visualRegressionConf.js
@@ -3,15 +3,19 @@ import { LocalCompare } from 'wdio-visual-regression-service/compare';
 
 const testIdRegex = /\[([^)]+)\]/;
 
-function testName(parent, title) {
+function testName(parent, title, subtitle) {
   const matches = testIdRegex.exec(title);
   const parentName = parent.replace(/[\s+.]/g, '_');
   let name = title.trim().replace(/[\s+.]/g, '_');
   if (matches) {
     name = matches[1];
   }
+  let subtitleName = '';
+  if (subtitle) {
+    subtitleName = `[${subtitle.trim().replace(/[\s+.]/g, '_')}]`;
+  }
 
-  return `${parentName}[${name}]`;
+  return `${parentName}[${name}]${subtitleName}`;
 }
 
 function getScreenshotName(ref) {
@@ -20,7 +24,7 @@ function getScreenshotName(ref) {
     const browserWidth = context.meta.viewport.width;
     const browserHeight = context.meta.viewport.height;
     const testPath = path.dirname(context.test.file);
-    const name = testName(context.test.parent, context.test.title);
+    const name = testName(context.test.parent, context.test.title, context.options.subtitle);
     return path.join(testPath, '__snapshots__', ref, browserName, `${name}.${browserWidth}x${browserHeight}.png`);
   };
 }


### PR DESCRIPTION
### The Problem
If a single wdio test captures multiple screenshots, then all screenshots following the first will be compared against the first because they all share the same file name. 

### A Proposed Solution
This enhancement allows consumers to subtitle the file names of their screenshots to ensure uniqueness.

I have implemented this as an optional feature for consumers.  Here is a usage example:

```
let screenshots = browser.checkViewport({ viewports, subtitle: 'this is my subtitle' });
expect(screenshots).to.matchReference();
```

@cerner/terra