### PR TITLE
Add the ability to add custom selectors to wdio themeable tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 Unreleased
 ----------
 * Removed React dependency
+* Add options argument to themeEachCustomProperty method
 
 2.6.0 - (January 4, 2018)
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 Unreleased
 ----------
 * Removed React dependency
-* Add options argument to themeEachCustomProperty method
+* Add selector argument to themeEachCustomProperty method
+* Add default document global selector for Terra service to wdio config.
 
 2.6.0 - (January 4, 2018)
 ----------

--- a/src/wdio/conf.js
+++ b/src/wdio/conf.js
@@ -24,6 +24,9 @@ exports.config = {
   services: ['visual-regression', AxeService, TerraService, SeleniumDockerService],
   visualRegression,
   framework: 'mocha',
+  terra: {
+    selector: '[data-reactroot]',
+  },
 
   beforeHook() {
     // Ensure the mouse starts in upper left corner before every test.

--- a/src/wdio/services/TerraService.js
+++ b/src/wdio/services/TerraService.js
@@ -65,12 +65,13 @@ const beAccessible = (options) => {
 /**
 * Generates a test for each themed property given and runs a screenshot assertion.
 * @property {Object} customProperties - An object containing the CSS custom properties to assert.
+* @property {Object} options - Additional options for testing.
 */
-const themeEachCustomProperty = (customProperties) => {
+const themeEachCustomProperty = (customProperties, options = {}) => {
   Object.entries(customProperties).forEach(([key, value]) => {
     global.it(`themed [${key}]`, () => {
       global.browser.execute(`document.documentElement.style.setProperty('${key}', '${value}')`);
-      global.expect(global.browser.checkElement('[data-reactroot]')).to.matchReference();
+      global.expect(global.browser.checkElement(options.selector || '[data-reactroot]')).to.matchReference();
     });
   });
 };

--- a/src/wdio/services/TerraService.js
+++ b/src/wdio/services/TerraService.js
@@ -67,11 +67,21 @@ const beAccessible = (options) => {
 * @property {Object} customProperties - An object containing the CSS custom properties to assert.
 * @property {Object} options - Additional options for testing.
 */
-const themeEachCustomProperty = (customProperties, options = {}) => {
-  Object.entries(customProperties).forEach(([key, value]) => {
+const themeEachCustomProperty = (customSelector, customProperties) => {
+  let selector = global.browser.options.terra.selector;
+  let styleProperties = {};
+
+  if (typeof customSelector === 'string') {
+    selector = customSelector;
+    styleProperties = customProperties || styleProperties;
+  } else {
+    styleProperties = customSelector || styleProperties;
+  }
+
+  Object.entries(styleProperties).forEach(([key, value]) => {
     global.it(`themed [${key}]`, () => {
       global.browser.execute(`document.documentElement.style.setProperty('${key}', '${value}')`);
-      global.expect(global.browser.checkElement(options.selector || '[data-reactroot]')).to.matchReference();
+      global.expect(global.browser.checkElement(selector)).to.matchReference();
     });
   });
 };
@@ -79,6 +89,7 @@ const themeEachCustomProperty = (customProperties, options = {}) => {
 const matchScreenshot = (param1, param2) => {
   let name = 'default';
   let options = {};
+
   if (typeof param1 === 'string') {
     name = param1;
     options = param2 || options;
@@ -86,7 +97,7 @@ const matchScreenshot = (param1, param2) => {
     options = param1 || options;
   }
 
-  const selector = options.selector || '[data-reactroot]';
+  const selector = options.selector || global.browser.options.terra.selector;
   const viewports = options.viewports || [];
 
   global.it(`[${name}] matches screenshot`, () => {

--- a/src/wdio/services/TerraService.js
+++ b/src/wdio/services/TerraService.js
@@ -64,19 +64,13 @@ const beAccessible = (options) => {
 
 /**
 * Generates a test for each themed property given and runs a screenshot assertion.
-* @property {Object} customProperties - An object containing the CSS custom properties to assert.
-* @property {Object} options - Additional options for testing.
+* @property {Array} args - An object containing the CSS custom properties to assert.
 */
-const themeEachCustomProperty = (customSelector, customProperties) => {
-  let selector = global.browser.options.terra.selector;
-  let styleProperties = {};
-
-  if (typeof customSelector === 'string') {
-    selector = customSelector;
-    styleProperties = customProperties || styleProperties;
-  } else {
-    styleProperties = customSelector || styleProperties;
-  }
+const themeEachCustomProperty = (...args) => {
+  // If more than 1 argument, selector is first
+  const selector = args.length > 1 ? args[0] : global.browser.options.terra.selector;
+  // Style properties are always last.
+  const styleProperties = args[args.length - 1];
 
   Object.entries(styleProperties).forEach(([key, value]) => {
     global.it(`themed [${key}]`, () => {
@@ -86,16 +80,11 @@ const themeEachCustomProperty = (customSelector, customProperties) => {
   });
 };
 
-const matchScreenshot = (param1, param2) => {
-  let name = 'default';
-  let options = {};
-
-  if (typeof param1 === 'string') {
-    name = param1;
-    options = param2 || options;
-  } else {
-    options = param1 || options;
-  }
+const matchScreenshot = (...args) => {
+  // If more than 1 argument, name is first
+  const name = args.length > 1 ? args[0] : 'default';
+  // test options are always last.
+  const options = args[args.length - 1] || {};
 
   const selector = options.selector || global.browser.options.terra.selector;
   const viewports = options.viewports || [];

--- a/tests/wdio/theme-spec.js
+++ b/tests/wdio/theme-spec.js
@@ -6,4 +6,11 @@ describe('themeEachCustomProperty', () => {
     '--color': 'red',
     '--font-size': '50px',
   });
+
+  Terra.should.themeEachCustomProperty({
+    '--color': 'red',
+    '--font-size': '50px',
+  }, {
+    selector: '.test',
+  });
 });

--- a/tests/wdio/theme-spec.js
+++ b/tests/wdio/theme-spec.js
@@ -7,10 +7,11 @@ describe('themeEachCustomProperty', () => {
     '--font-size': '50px',
   });
 
-  Terra.should.themeEachCustomProperty({
-    '--color': 'red',
-    '--font-size': '50px',
-  }, {
-    selector: '.test',
-  });
+  Terra.should.themeEachCustomProperty(
+    '.test',
+    {
+      '--color': 'red',
+      '--font-size': '50px',
+    },
+  );
 });

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -30,6 +30,9 @@ const config = {
       }],
     },
   },
+  terra: {
+    selector: '[data-reactroot]',
+  },
 };
 
 

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -30,9 +30,6 @@ const config = {
       }],
     },
   },
-  terra: {
-    selector: '[data-reactroot]',
-  },
 };
 
 


### PR DESCRIPTION
### Summary
React 16 removed the [data-reactroot] (see https://github.com/facebook/react/issues/10971) element we defined for looking for react components. As a result, we need to add the ability to specify a custom selector that can be passed into the themeable test.
