### PR TITLE
Increase timeout for wdio tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Fixed
+* Bumped up the wdio timeout to account for long running screenshot comparisons.
 
 2.8.1 - (February 23, 2018)
 ----------

--- a/src/wdio/conf.js
+++ b/src/wdio/conf.js
@@ -58,5 +58,6 @@ exports.config = {
   framework: 'mocha',
   mochaOpts: {
     ui: 'bdd',
+    timeout: 20000,
   },
 };


### PR DESCRIPTION
### Summary
We're seeing errors like this popping up during screen shot comparison both locally and in travis-ci.
`1) Clinical Application Renders the Application with provided AppDelegate [default] to be within the mismatch tolerance:
Timeout of 10000ms exceeded. Try to reduce the run time or increase your timeout for test specs (http://webdriver.io/guide/testrunner/timeouts.html); if returning a Promise, ensure it resolves.`

This PR increases the timeout for the tests to allow for long running screenshot comparisons

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
