### PR TITLE
Add a new Express Dev server service.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,4 @@ script:
 branches:
   only:
     - master
-cache:
-  directories:
-    - node_modules
+cache: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,10 @@ Unreleased
 ----------
 ### Added
 * Added deprecation warning when using Nightwatch.
+* New Express Dev Server Service for running tests against.
 
 ### Fixed
 * Bumped up the wdio timeout to account for long running screenshot comparisons.
-
-### Added
-* New Express Dev Server Service for running tests against.
 
 2.8.1 - (February 23, 2018)
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Unreleased
 ----------
 ### Added
 * Added deprecation warning when using Nightwatch.
-* New Express Dev Server Service for running tests against.
+* New Express Dev Server Service for running tests against. Webpack-dev-server is in [maintenance mode](https://github.com/webpack/webpack-dev-server#project-in-maintenance).
 
 ### Fixed
 * Bumped up the wdio timeout to account for long running screenshot comparisons.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Unreleased
 ### Fixed
 * Bumped up the wdio timeout to account for long running screenshot comparisons.
 
+### Added
+* New Express Dev Server Service for running tests against.
+
 2.8.1 - (February 23, 2018)
 ----------
 ### Fixed

--- a/docs/ExpressDevServerService.md
+++ b/docs/ExpressDevServerService.md
@@ -1,0 +1,36 @@
+# ExpressDevServer Service
+ExpressDevServer Service is provided as a convenience to start an express server and return a promise when the webpack compiler is complete. This enables test setup to be complete before testing is began. This service must be provided as a service to webdriver.io to host your test pages.
+
+## Options
+
+In the wdio.conf.js you can pass a configuration object with the following structure:
+
+* **webpackConfig** - the webpack configuration used to start the express server. Must be provided to use this service.
+* **expressDevServer** - the webpack-dev-server configuration to be passed to the webpack-dev-server. Defaults to { index: 'index.html', port: '8080' }.
+
+```js
+// wdio.conf.js
+const wdioConf = require('terra-toolkit/wdio/conf');
+const webpackConfig = require('./webpack.config.js');
+const ExpressDevService = require('terra-toolkit/wdio/services/index').ExpressDevService;
+const localIP = require('ip');
+
+const port = 8080;
+
+const config = {
+  ...wdioConf.config,
+
+  // Point base URL at the site to be tested for correct webdriver.io setup
+  baseUrl: `http://${localIP.address()}:${port}`,
+
+  // Configuration for WebpackDev service
+  webpackConfig,
+  expressDevServer: {
+    port,
+  },
+
+  service = wdioConf.config.services.concat([ExpressDevService]);
+};
+
+exports.config = config;
+```

--- a/docs/ExpressDevServerService.md
+++ b/docs/ExpressDevServerService.md
@@ -3,10 +3,10 @@ ExpressDevServer Service is provided as a convenience to start an express server
 
 ## Options
 
-In the wdio.conf.js you can pass a configuration object with the following structure:
-
-* **webpackConfig** - the webpack configuration used to start the express server. Must be provided to use this service.
-* **expressDevServer** - the webpack-dev-server configuration to be passed to the webpack-dev-server. Defaults to { index: 'index.html', port: '8080' }.
+| Name  | Required | Default Value | Description |
+| ------------- | ------------- | ------------- | ------------- |
+| **webpackConfig**  | true | `undefined` | The webpack configuration used to start the express server. |
+| **expressDevServer**  | false | `{ index: 'index.html', port: '8080' }` | The webpack-dev-server configuration to be passed to the webpack-dev-server. |
 
 ```js
 // wdio.conf.js

--- a/docs/Wdio_Utility.md
+++ b/docs/Wdio_Utility.md
@@ -31,11 +31,9 @@ To run the webdriver.io test running, the [webdriver.io configuration options](h
 * `VisualRegressionService` - uses wdio-screenshot to capture screenshots and run visual regression testing.
     - See [here](https://github.com/zinserjan/wdio-visual-regression-service#configuration) for configuration information.
 
-In addition to the default webdriver.io services enabled in the config, a webpack dev server or static server service must be specified to actually run the site:
-- Terra-toolkit provides the `WebpackDevService` to start a webpack-dev-server and returns a promise when the webpack compiler is completed.
-    - See [here](https://github.com/cerner/terra-toolkit/blob/master/docs/TerraService.md) for configuration information.
-- Webdriver.io provides the `wdio-static-server-service` to run a static file server.
-    - See [here](https://github.com/leadpages/wdio-static-server-service#configuration) for configuration information.
+In addition to the default webdriver.io services enabled in the config, a Express dev server must be specified to actually run the site:
+- Terra-toolkit provides the `ExpressDevService` to start an express server and returns a promise when the webpack compiler is completed.
+    - See [here](https://github.com/cerner/terra-toolkit/blob/master/docs/ExpressDevServerService.md) for configuration information.
 
 Finally, the `baseUrl` of the site to be tested must be specified. Use the [ip](https://www.npmjs.com/package/ip) npm package to obtain the IP address for the SeleniumDocker instance.
 
@@ -43,7 +41,7 @@ Finally, the `baseUrl` of the site to be tested must be specified. Use the [ip](
 // An example of a full mono-repo configuration file:
 const wdioConf = require('terra-toolkit/wdio/conf');
 const webpackConfig = require('./webpack.config.js');
-const WebPackDevService = require('terra-toolkit/lib/wdio/services').WebPackDevService;
+const ExpressDevService = require('terra-toolkit/lib/wdio/services').ExpressDevService;
 const localIP = require('ip');
 
 const port = 8080;
@@ -64,12 +62,14 @@ const config = {
   baseUrl: `http://${localIP.address()}:${port}`,
   specs: [specs],
 
-  // Use Terra-toolkit's WebPackDevService
-  services: wdioConf.config.services.concat([WebPackDevService]),
+  // Use Terra-toolkit's ExpressDevService
+  services: wdioConf.config.services.concat([ExpressDevService]),
 
-  // Configuration for WebPackDevService
+  // Configuration for ExpressDevService
   webpackConfig,
-  webpackPort: port,
+  expressDevServer: {
+    port,
+  },
 };
 
 exports.config = config;

--- a/docs/WebpackDevServerService.md
+++ b/docs/WebpackDevServerService.md
@@ -1,4 +1,7 @@
 # WebpackDevServer Service
+
+**This service has been deprecated in favor of the ExpressDevServerService**
+
 WebpackDevServer Service is provided as a convenience to start a webpack-dev-server and return a promise when the webpack compiler is complete. This enables test setup to be complete before testing is began. This service is utilized by the the default nightwatch configuration and must be provided as a service to webdriver.io if the webpack-dev-server is used to host your test pages.
 
 ## Options

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,9 +20,8 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
       "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
-      "dev": true,
       "requires": {
-        "mime-types": "2.1.17",
+        "mime-types": "2.1.18",
         "negotiator": "0.6.1"
       }
     },
@@ -1142,7 +1141,6 @@
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
       "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
-      "dev": true,
       "requires": {
         "bytes": "3.0.0",
         "content-type": "1.0.4",
@@ -1153,7 +1151,7 @@
         "on-finished": "2.3.0",
         "qs": "6.5.1",
         "raw-body": "2.3.2",
-        "type-is": "1.6.15"
+        "type-is": "1.6.16"
       }
     },
     "bonjour": {
@@ -1373,8 +1371,7 @@
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
-      "dev": true
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "caller-path": {
       "version": "0.1.0",
@@ -1833,14 +1830,12 @@
     "content-disposition": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
-      "dev": true
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
     },
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-      "dev": true
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "content-type-parser": {
       "version": "1.0.2",
@@ -1857,14 +1852,12 @@
     "cookie": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
-      "dev": true
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
     },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
-      "dev": true
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "core-js": {
       "version": "2.5.2",
@@ -1875,8 +1868,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cosmiconfig": {
       "version": "2.2.2",
@@ -2306,7 +2298,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -2408,8 +2399,7 @@
     "depd": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
-      "dev": true
+      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
     },
     "des.js": {
       "version": "1.0.0",
@@ -2424,8 +2414,7 @@
     "destroy": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-      "dev": true
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "detect-indent": {
       "version": "4.0.0",
@@ -2578,8 +2567,7 @@
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-      "dev": true
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "ejs": {
       "version": "2.5.7",
@@ -2621,10 +2609,9 @@
       "dev": true
     },
     "encodeurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
-      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=",
-      "dev": true
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "encoding": {
       "version": "0.1.12",
@@ -2666,7 +2653,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
       "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
-      "dev": true,
       "requires": {
         "prr": "0.0.0"
       }
@@ -2782,8 +2768,7 @@
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-      "dev": true
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -3109,8 +3094,7 @@
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-      "dev": true
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "event-emitter": {
       "version": "0.3.5",
@@ -3234,7 +3218,6 @@
       "version": "4.16.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
       "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
-      "dev": true,
       "requires": {
         "accepts": "1.3.4",
         "array-flatten": "1.1.1",
@@ -3245,7 +3228,7 @@
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "1.1.1",
-        "encodeurl": "1.0.1",
+        "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "etag": "1.8.1",
         "finalhandler": "1.1.0",
@@ -3255,7 +3238,7 @@
         "on-finished": "2.3.0",
         "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "2.0.2",
+        "proxy-addr": "2.0.3",
         "qs": "6.5.1",
         "range-parser": "1.2.0",
         "safe-buffer": "5.1.1",
@@ -3263,7 +3246,7 @@
         "serve-static": "1.13.1",
         "setprototypeof": "1.1.0",
         "statuses": "1.3.1",
-        "type-is": "1.6.15",
+        "type-is": "1.6.16",
         "utils-merge": "1.0.1",
         "vary": "1.1.2"
       },
@@ -3271,20 +3254,17 @@
         "array-flatten": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-          "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
-          "dev": true
+          "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
         },
         "setprototypeof": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-          "dev": true
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
         },
         "statuses": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
-          "dev": true
+          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
         }
       }
     },
@@ -3444,10 +3424,9 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
       "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
-      "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.1",
+        "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "on-finished": "2.3.0",
         "parseurl": "1.3.2",
@@ -3458,8 +3437,7 @@
         "statuses": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
-          "dev": true
+          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
         }
       }
     },
@@ -3555,20 +3533,18 @@
       "requires": {
         "asynckit": "0.4.0",
         "combined-stream": "1.0.5",
-        "mime-types": "2.1.17"
+        "mime-types": "2.1.18"
       }
     },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
-      "dev": true
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
     },
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-      "dev": true
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "fs-extra": {
       "version": "3.0.1",
@@ -5043,7 +5019,6 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
       "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-      "dev": true,
       "requires": {
         "depd": "1.1.1",
         "inherits": "2.0.3",
@@ -5138,8 +5113,7 @@
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-      "dev": true
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
     },
     "icss-replace-symbols": {
       "version": "1.1.0",
@@ -5338,10 +5312,9 @@
       "dev": true
     },
     "ipaddr.js": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
-      "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A=",
-      "dev": true
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
+      "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
     },
     "is-absolute-url": {
       "version": "2.1.0",
@@ -5602,8 +5575,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -6570,8 +6542,7 @@
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-      "dev": true
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "mem": {
       "version": "1.1.0",
@@ -6586,7 +6557,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
-      "dev": true,
       "requires": {
         "errno": "0.1.4",
         "readable-stream": "2.3.3"
@@ -6627,14 +6597,12 @@
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-      "dev": true
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-      "dev": true
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "micromatch": {
       "version": "2.3.11",
@@ -6680,12 +6648,18 @@
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-      "dev": true,
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
-        "mime-db": "1.30.0"
+        "mime-db": "1.33.0"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.33.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+          "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+        }
       }
     },
     "mimic-fn": {
@@ -6908,8 +6882,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "multicast-dns": {
       "version": "6.2.1",
@@ -6957,8 +6930,7 @@
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
-      "dev": true
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
     "netmask": {
       "version": "1.0.6",
@@ -7186,7 +7158,7 @@
           "requires": {
             "asynckit": "0.4.0",
             "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
+            "mime-types": "2.1.18"
           }
         },
         "har-validator": {
@@ -7255,7 +7227,7 @@
             "is-typedarray": "1.0.0",
             "isstream": "0.1.2",
             "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
+            "mime-types": "2.1.18",
             "oauth-sign": "0.8.2",
             "qs": "6.3.2",
             "stringstream": "0.0.5",
@@ -7432,7 +7404,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "dev": true,
       "requires": {
         "ee-first": "1.1.1"
       }
@@ -7733,8 +7704,7 @@
     "parseurl": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
-      "dev": true
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
     },
     "path-browserify": {
       "version": "0.0.0",
@@ -7774,8 +7744,7 @@
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
-      "dev": true
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "path-type": {
       "version": "1.1.0",
@@ -8608,8 +8577,7 @@
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
     "progress": {
       "version": "1.1.8",
@@ -8618,13 +8586,12 @@
       "dev": true
     },
     "proxy-addr": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
-      "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
-      "dev": true,
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
+      "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
       "requires": {
         "forwarded": "0.1.2",
-        "ipaddr.js": "1.5.2"
+        "ipaddr.js": "1.6.0"
       }
     },
     "proxy-agent": {
@@ -8646,8 +8613,7 @@
     "prr": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-      "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
-      "dev": true
+      "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -8683,8 +8649,7 @@
     "qs": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-      "dev": true
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
     "query-string": {
       "version": "4.3.4",
@@ -8777,14 +8742,12 @@
     "range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
-      "dev": true
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
     },
     "raw-body": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
       "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
-      "dev": true,
       "requires": {
         "bytes": "3.0.0",
         "http-errors": "1.6.2",
@@ -8874,7 +8837,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-      "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
@@ -9102,7 +9064,7 @@
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
         "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.17",
+        "mime-types": "2.1.18",
         "oauth-sign": "0.8.2",
         "performance-now": "2.1.0",
         "qs": "6.5.1",
@@ -9245,8 +9207,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-      "dev": true
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "sane": {
       "version": "1.6.0",
@@ -9383,12 +9344,11 @@
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
       "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
-      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "depd": "1.1.1",
         "destroy": "1.0.4",
-        "encodeurl": "1.0.1",
+        "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "etag": "1.8.1",
         "fresh": "0.5.2",
@@ -9403,14 +9363,12 @@
         "mime": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
-          "dev": true
+          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
         },
         "statuses": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
-          "dev": true
+          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
         }
       }
     },
@@ -9425,7 +9383,7 @@
         "debug": "2.6.9",
         "escape-html": "1.0.3",
         "http-errors": "1.6.2",
-        "mime-types": "2.1.17",
+        "mime-types": "2.1.18",
         "parseurl": "1.3.2"
       }
     },
@@ -9433,9 +9391,8 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
       "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
-      "dev": true,
       "requires": {
-        "encodeurl": "1.0.1",
+        "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "parseurl": "1.3.2",
         "send": "0.16.1"
@@ -9462,8 +9419,7 @@
     "setprototypeof": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
-      "dev": true
+      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
     },
     "sha.js": {
       "version": "2.4.9",
@@ -9744,8 +9700,7 @@
     "statuses": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-      "dev": true
+      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
     },
     "stdout-stream": {
       "version": "1.4.0",
@@ -9821,7 +9776,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -10184,13 +10138,27 @@
       "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ=="
     },
     "type-is": {
-      "version": "1.6.15",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
-      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
-      "dev": true,
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.17"
+        "mime-types": "2.1.18"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.33.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+          "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+        },
+        "mime-types": {
+          "version": "2.1.18",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+          "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+          "requires": {
+            "mime-db": "1.33.0"
+          }
+        }
       }
     },
     "typedarray": {
@@ -10319,8 +10287,7 @@
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-      "dev": true
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "upper-case": {
       "version": "1.1.3",
@@ -10405,8 +10372,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utila": {
       "version": "0.4.0",
@@ -10417,8 +10383,7 @@
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
-      "dev": true
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
       "version": "3.1.0",
@@ -10454,8 +10419,7 @@
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-      "dev": true
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "vendors": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -46,9 +46,12 @@
     "async": "^2.5.0",
     "axe-core": "^2.6.1",
     "chai": "^4.1.2",
+    "express": "^4.16.2",
     "glob": "^7.1.1",
     "ip": "^1.1.5",
-    "load-json-file": "^2.0.0"
+    "load-json-file": "^2.0.0",
+    "memory-fs": "^0.4.1",
+    "mime-types": "^2.1.18"
   },
   "peerDependencies": {
     "nightwatch": "^0.9.12",

--- a/src/nightwatch/nightwatch.config.js
+++ b/src/nightwatch/nightwatch.config.js
@@ -11,7 +11,7 @@ const seleniumHost = ip.address();
 
 const nightwatchConfig = (webpackConfig, srcFolders, providedPort) => {
   // eslint-disable-next-line no-console
-  console.error('WARNING: WebdriverIO should be used instead of Nightwatch.  Nightwatch will be deprecated in the future.');
+  console.warn('WARNING: WebdriverIO should be used instead of Nightwatch.  Nightwatch will be deprecated in the future.');
 
   if (providedPort) {
     port = providedPort;

--- a/src/wdio/services/ExpressDevServerService.js
+++ b/src/wdio/services/ExpressDevServerService.js
@@ -1,0 +1,109 @@
+import express from 'express';
+import webpack from 'webpack';
+import MemoryFS from 'memory-fs';
+import mime from 'mime-types';
+import path from 'path';
+
+
+export default class WebDevServerService {
+  async onPrepare(config) {
+    if (!config.webpackConfig) {
+      // eslint-disable-next-line no-console
+      console.log('[WebDevService] No webpack configuration provided');
+      return;
+    }
+
+    const webpackConfig = config.webpackConfig;
+    const port = config.webpackPort || 8080;
+
+    await WebDevServerService.startExpressDevServer(webpackConfig, port).then((server) => {
+      this.server = server;
+    });
+  }
+
+  async onComplete() {
+    await this.stop();
+  }
+
+  static startExpressDevServer(webpackConfig, port) {
+    return WebDevServerService.compile(webpackConfig).then((fs) => {
+      const app = express();
+
+      // Setup a catch all route, we can't use 'static' because we need to use a vfs
+      app.get('*', (req, res, next) => {
+        let filename = req.url;
+        // Setup a default to route / to the index.html file.
+        // Should this be configurable in the future?
+        if (filename === '/') {
+          filename = '/index.html';
+        }
+
+        const filepath = `${webpackConfig.output.path}${filename}`;
+
+        if (fs.existsSync(filepath)) {
+          res.setHeader('content-type', mime.contentType(path.extname(filename)));
+          res.send(fs.readFileSync(filepath));
+        } else {
+          next();
+        }
+      });
+
+      app.use((req, res, next) => {
+        const err = new Error(`Not Found: ${req.originalUrl}`);
+        err.status = 404;
+        next(err);
+      });
+
+      // error handler
+      app.use((err, req, res) => {
+        // set locals, only providing error in development
+        res.locals.message = err.message;
+        res.locals.error = err;
+
+        // render the error page
+        res.status(err.status || 500);
+        res.render('error');
+      });
+
+      const server = app.listen(port);
+      // eslint-disable-next-line no-console
+      console.log('[WebDevService] Express server started');
+
+      return server;
+    });
+  }
+
+  static compile(webpackConfig) {
+    return new Promise((resolve, reject) => {
+      const compiler = webpack(webpackConfig);
+      // setup a virtual file system to write webpack files to.
+      compiler.outputFileSystem = new MemoryFS();
+      // eslint-disable-next-line no-console
+      console.log('[WebDevService] Webpack compilation started');
+      compiler.run((err, stats) => {
+        if (err || stats.hasErrors()) {
+          // console.log(err);
+          // console.log(stats);
+          // eslint-disable-next-line no-console
+          console.log('[WebDevService] Webpack compiled unsuccessfully');
+          reject();
+        }
+        // eslint-disable-next-line no-console
+        console.log('[WebDevService] Webpack compiled successfully');
+        resolve(compiler.outputFileSystem);
+      });
+    });
+  }
+
+  stop() {
+    return new Promise((resolve) => {
+      // eslint-disable-next-line no-console
+      console.log('[WebDevService] Closing WebpackDevServer');
+      if (this.server) {
+        this.server.close();
+        this.server = null;
+      }
+      resolve();
+    });
+  }
+}

--- a/src/wdio/services/ExpressDevServerService.js
+++ b/src/wdio/services/ExpressDevServerService.js
@@ -13,7 +13,7 @@ export default class ExpressDevServerService {
     }
 
     const webpackConfig = config.webpackConfig;
-    const port = config.webpackPort || 8080;
+    const port = config.expressDevServer.port || 8080;
     const index = config.expressDevServer.index || 'index.html';
 
     await ExpressDevServerService.startExpressDevServer(webpackConfig, port, index).then((server) => {

--- a/src/wdio/services/ExpressDevServerService.js
+++ b/src/wdio/services/ExpressDevServerService.js
@@ -13,8 +13,8 @@ export default class ExpressDevServerService {
     }
 
     const webpackConfig = config.webpackConfig;
-    const port = config.expressDevServer.port || 8080;
-    const index = config.expressDevServer.index || 'index.html';
+    const port = ((config || {}).expressDevServer || {}).port || 8080;
+    const index = ((config || {}).expressDevServer || {}).index || 'index.html';
 
     await ExpressDevServerService.startExpressDevServer(webpackConfig, port, index).then((server) => {
       this.server = server;

--- a/src/wdio/services/WebpackDevServerService.js
+++ b/src/wdio/services/WebpackDevServerService.js
@@ -26,7 +26,7 @@ export default class WebDevServerService {
   startWebpackDevServer() {
     return new Promise((resolve, reject) => {
       // eslint-disable-next-line no-console
-      console.error('[WebDevService] WARNING: ExpressDevServer service should be used instead of the Terra provided WebpackDevServerService. See https://github.com/cerner/terra-toolkit/blob/master/docs/ExpressDevServerService.md');
+      console.warn('[WebDevService] WARNING: ExpressDevServer service should be used instead of the Terra provided WebpackDevServerService. See https://github.com/cerner/terra-toolkit/blob/master/docs/ExpressDevServerService.md');
       // eslint-disable-next-line no-console
       console.log('[WebDevService] Starting WebpackDevServer');
 

--- a/src/wdio/services/WebpackDevServerService.js
+++ b/src/wdio/services/WebpackDevServerService.js
@@ -26,6 +26,8 @@ export default class WebDevServerService {
   startWebpackDevServer() {
     return new Promise((resolve, reject) => {
       // eslint-disable-next-line no-console
+      console.error('[WebDevService] WARNING: ExpressDevServer service should be used instead of the Terra provided WebpackDevServerService. See https://github.com/cerner/terra-toolkit/blob/master/docs/ExpressDevServerService.md');
+      // eslint-disable-next-line no-console
       console.log('[WebDevService] Starting WebpackDevServer');
 
       this.compiler = webpack(this.webpackConfig);

--- a/src/wdio/services/index.js
+++ b/src/wdio/services/index.js
@@ -2,8 +2,10 @@ import AxeService from './AxeService';
 import TerraService from './TerraService';
 import SeleniumDockerService from './SeleniumDockerService';
 import WebpackDevServerService from './WebpackDevServerService';
+import ExpressDevServerService from './ExpressDevServerService';
 
 module.exports.Axe = new AxeService();
 module.exports.Terra = new TerraService();
 module.exports.SeleniumDocker = new SeleniumDockerService();
 module.exports.WebpackDevService = new WebpackDevServerService();
+module.exports.ExpressDevService = new ExpressDevServerService();

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -14,9 +14,6 @@ const config = {
 
   // Configuration for ExpressDevService
   webpackConfig,
-  expressDevServer: {
-    port,
-  },
 
   // Configuration for SeleniumDocker service
   seleniumDocker: {

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const wdioConf = require('./lib/wdio/conf');
-const WebpackDevService = require('./lib/wdio/services/index').WebpackDevService;
+const ExpressDevService = require('./lib/wdio/services/index').ExpressDevService;
 const webpackConfig = require('./tests/test.config.js');
 const localIP = require('ip');
 const path = require('path');
@@ -12,7 +12,7 @@ const config = {
   baseUrl: `http://${localIP.address()}:${webpackPort}`,
   specs: [path.join('.', 'tests', 'wdio', '**-spec.js')],
 
-  // Configuration for WebpackDevService
+  // Configuration for ExpressDevService
   webpackPort,
   webpackConfig,
 
@@ -32,6 +32,5 @@ const config = {
   },
 };
 
-
-config.services = wdioConf.config.services.concat([WebpackDevService]);
+config.services = wdioConf.config.services.concat([ExpressDevService]);
 exports.config = config;

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -5,16 +5,18 @@ const webpackConfig = require('./tests/test.config.js');
 const localIP = require('ip');
 const path = require('path');
 
-const webpackPort = 8080;
+const port = 8080;
 
 const config = {
   ...wdioConf.config,
-  baseUrl: `http://${localIP.address()}:${webpackPort}`,
+  baseUrl: `http://${localIP.address()}:${port}`,
   specs: [path.join('.', 'tests', 'wdio', '**-spec.js')],
 
   // Configuration for ExpressDevService
-  webpackPort,
   webpackConfig,
+  expressDevServer: {
+    port,
+  },
 
   // Configuration for SeleniumDocker service
   seleniumDocker: {


### PR DESCRIPTION
### Summary
Add a new simple express dev server as a drop in replacement for the webpack dev sever. 
This server webpacks the assets into a memory-fs and serves the files from there to avoid building artifacts. It does not offer hot reloading by design as that was causing some test instability.

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
