### PR TITLE
Lock wdio.maxInstance to 1 for selenium/hub:3:11:0-anatomy

### DIFF
--- a/src/wdio/conf.js
+++ b/src/wdio/conf.js
@@ -6,7 +6,7 @@ const path = require('path');
 
 exports.config = {
   specs: [path.join('.', 'tests', 'wdio', '**', '*-spec.js')],
-  maxInstances: 5,
+  maxInstances: 1,
   capabilities: [
     {
       browserName: 'chrome',


### PR DESCRIPTION
### Summary
Selenium released [3.11.0-anatomy](https://github.com/SeleniumHQ/docker-selenium/releases/tag/3.11.0-antimony) 03/11/18. 

Locally when using `selenium/hub:3.11.0-anatomy` the ChromeDriver instances were not being closed/cleaned as expected when using `wdio.maxInstances > 1`. We have not seen this error in Travis for our repos, because we were toggling `maxInstances` to be 1 with the `process.env.CI`varaible, where as locally `maxInstances`  is set to 5. This sets `maxInstances = 1` until this issue is resolved. 

This is being tracked on #57