### PR TITLE
Update ExpressDevServerService.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Improved error logging for the Express Dev Server Service.
 
 2.10.0 - (April 10, 2018)
 ----------

--- a/src/wdio/services/ExpressDevServerService.js
+++ b/src/wdio/services/ExpressDevServerService.js
@@ -8,7 +8,7 @@ export default class ExpressDevServerService {
   async onPrepare(config) {
     if (!config.webpackConfig) {
       // eslint-disable-next-line no-console
-      console.log('[ExpresDevService] No webpack configuration provided');
+      console.log('[ExpressDevService] No webpack configuration provided');
       return;
     }
 
@@ -68,7 +68,7 @@ export default class ExpressDevServerService {
 
       const server = app.listen(port);
       // eslint-disable-next-line no-console
-      console.log('[ExpresDevService] Express server started');
+      console.log('[ExpressDevService] Express server started');
 
       return server;
     });
@@ -80,15 +80,15 @@ export default class ExpressDevServerService {
       // setup a virtual file system to write webpack files to.
       compiler.outputFileSystem = new MemoryFS();
       // eslint-disable-next-line no-console
-      console.log('[ExpresDevService] Webpack compilation started');
+      console.log('[ExpressDevService] Webpack compilation started');
       compiler.run((err, stats) => {
         if (err || stats.hasErrors()) {
           // eslint-disable-next-line no-console
-          console.log('[ExpresDevService] Webpack compiled unsuccessfully');
+          console.log('[ExpressDevService] Webpack compiled unsuccessfully');
           reject(err || new Error(stats.toJson().errors));
         }
         // eslint-disable-next-line no-console
-        console.log('[ExpresDevService] Webpack compiled successfully');
+        console.log('[ExpressDevService] Webpack compiled successfully');
         resolve(compiler.outputFileSystem);
       });
     });
@@ -97,7 +97,7 @@ export default class ExpressDevServerService {
   stop() {
     return new Promise((resolve) => {
       // eslint-disable-next-line no-console
-      console.log('[ExpresDevService] Closing WebpackDevServer');
+      console.log('[ExpressDevService] Closing WebpackDevServer');
       if (this.server) {
         this.server.close();
         this.server = null;

--- a/src/wdio/services/ExpressDevServerService.js
+++ b/src/wdio/services/ExpressDevServerService.js
@@ -85,7 +85,7 @@ export default class ExpressDevServerService {
         if (err || stats.hasErrors()) {
           // eslint-disable-next-line no-console
           console.log('[ExpresDevService] Webpack compiled unsuccessfully');
-          reject();
+          reject(err || new Error(stats.toJson().errors));
         }
         // eslint-disable-next-line no-console
         console.log('[ExpresDevService] Webpack compiled successfully');


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

I spent some time debugging someone's express dev server and realized we could have some better logging on errors up front.  This will accomplish that.  It changes

```
/Users/rm012685/test_bed/orion-content-search-js/node_modules/webdriverio/build/lib/cli.js:446
                throw e;
                ^

TypeError: Cannot read property 'stack' of undefined
    at Launcher._callee2$ (/Users/rm012685/test_bed/orion-content-search-js/node_modules/webdriverio/build/lib/launcher.js:417:106)
    at tryCatch (/Users/rm012685/test_bed/orion-content-search-js/node_modules/regenerator-runtime/runtime.js:62:40)
    at Generator.invoke [as _invoke] (/Users/rm012685/test_bed/orion-content-search-js/node_modules/regenerator-runtime/runtime.js:296:22)
    at Generator.prototype.(anonymous function) [as throw] (/Users/rm012685/test_bed/orion-content-search-js/node_modules/regenerator-runtime/runtime.js:114:21)
    at step (/Users/rm012685/test_bed/orion-content-search-js/node_modules/babel-runtime/helpers/asyncToGenerator.js:17:30)
    at /Users/rm012685/test_bed/orion-content-search-js/node_modules/babel-runtime/helpers/asyncToGenerator.js:30:13
    at <anonymous>
    at process._tickDomainCallback (internal/process/next_tick.js:228:7)
```

to

```
A service failed in the 'onPrepare' hook
Error: ./node_modules/terra-button-group/lib/ButtonGroup.scss
Module build failed: ModuleBuildError: Module build failed: Error: No PostCSS Config found in: /Users/rm012685/test_bed/orion-content-search-js/node_modules/terra-button-group/lib
    at /Users/rm012685/test_bed/orion-content-search-js/node_modules/postcss-load-config/index.js:51:26
    at <anonymous>
    at runLoaders (/Users/rm012685/test_bed/orion-content-search-js/node_modules/webpack/lib/NormalModule.js:195:19)
    at /Users/rm012685/test_bed/orion-content-search-js/node_modules/loader-runner/lib/LoaderRunner.js:364:11
    at /Users/rm012685/test_bed/orion-content-search-js/node_modules/loader-runner/lib/LoaderRunner.js:230:18
    at context.callback (/Users/rm012685/test_bed/orion-content-search-js/node_modules/loader-runner/lib/LoaderRunner.js:111:13)
    at Promise.resolve.then.then.catch (/Users/rm012685/test_bed/orion-content-search-js/node_modules/postcss-loader/lib/index.js:196:71)
    at <anonymous>
 @ ./node_modules/terra-button-group/lib/ButtonGroup.scss
 @ ./node_modules/terra-button-group/lib/ButtonGroup.js
 @ ./src/content-search/ContentSearchView.jsx
 @ ./tests/wdio/content-search/ContentSearchApplication.jsx
 @ ./src/site/Index.jsx
    at /Users/rm012685/test_bed/orion-content-search-js/node_modules/terra-toolkit/lib/wdio/services/ExpressDevServerService.js:141:27
    at emitRecords.err (/Users/rm012685/test_bed/orion-content-search-js/node_modules/webpack/lib/Compiler.js:265:13)
    at Compiler.emitRecords (/Users/rm012685/test_bed/orion-content-search-js/node_modules/webpack/lib/Compiler.js:371:38)
    at emitAssets.err (/Users/rm012685/test_bed/orion-content-search-js/node_modules/webpack/lib/Compiler.js:258:10)
    at applyPluginsAsyncSeries1.err (/Users/rm012685/test_bed/orion-content-search-js/node_modules/webpack/lib/Compiler.js:364:12)
    at next (/Users/rm012685/test_bed/orion-content-search-js/node_modules/webpack/node_modules/tapable/lib/Tapable.js:218:11)
    at Compiler.compiler.plugin (/Users/rm012685/test_bed/orion-content-search-js/node_modules/webpack/lib/performance/SizeLimitsPlugin.js:99:4)
    at Compiler.applyPluginsAsyncSeries1 (/Users/rm012685/test_bed/orion-content-search-js/node_modules/webpack/node_modules/tapable/lib/Tapable.js:222:13)
    at Compiler.afterEmit (/Users/rm012685/test_bed/orion-content-search-js/node_modules/webpack/lib/Compiler.js:361:9)
    at require.forEach.err (/Users/rm012685/test_bed/orion-content-search-js/node_modules/webpack/lib/Compiler.js:350:15)
```

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
