### PR TITLE
Lock into a specific chrome version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_script:
   - npm run compile
 before_install:
   - docker pull selenium/standalone-chrome:3.11.0-californium
-  - docker run -d -p 4444:4444 selenium/standalone-chrome
+  - docker run -d -p 4444:4444 selenium/standalone-chrome:3.11.0-californium
 script:
   - npm test
   - npm run danger

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 before_script:
   - npm run compile
 before_install:
-  - docker pull selenium/standalone-chrome:3.11
+  - docker pull selenium/standalone-chrome:3.11.0-californium
   - docker run -d -p 4444:4444 selenium/standalone-chrome
 script:
   - npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Fixed
+* Lock into a specific version of chrome driver.
 
 3.1.0 - (April 25, 2018)
 ----------

--- a/src/wdio/docker-compose.yml
+++ b/src/wdio/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   selenium_hub:
-    image: 'selenium/hub:latest'
+    image: 'selenium/hub:3.11.0-californium'
     environment:
       GRID_THROW_ON_CAPABILITY_NOT_PRESENT: 'false'
       GRID_MAX_SESSION: 10

--- a/src/wdio/docker-compose.yml
+++ b/src/wdio/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     ports:
       - '4444:4444'
   chrome:
-    image: 'selenium/node-chrome:3.11'
+    image: 'selenium/node-chrome:3.11.0-californium'
     volumes:
       - /dev/shm:/dev/shm
     ports:
@@ -25,4 +25,4 @@ services:
       NODE_MAX_SESSION: 1
       TZ: 'America/Chicago'
       SCREEN_WIDTH: 1070
-      SCREEN_HEIGHT: 1025
+      SCREEN_HEIGHT: 1020


### PR DESCRIPTION
### Summary
We are locking in the version of chrome driver to attempt to avoid test thrashing.

@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
