### PR TITLE
Increase the timeout waiting for the selenium docker service to start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Increase the timeout waiting for the selenium docker service to start.
 
 3.1.1 - (April 25, 2018)
 ----------

--- a/config/wdio/services.default-config.js
+++ b/config/wdio/services.default-config.js
@@ -21,10 +21,10 @@ const seleniumDocker = {
   /* Weather or not the service should be ran. */
   enabled: true,
   /* Retry count to test for selenium being up. */
-  retries: 3000,
+  retries: 4000,
   /* The retry interval (in milliseconds) to wait between retries.
    */
-  retryInterval: 20,
+  retryInterval: 10,
   /* Docker compose file reference when deploying the docker selenium hub stack. */
   composeFile: path.join(__dirname, '..', '..', 'lib', 'wdio', 'docker-compose.yml'),
 };

--- a/config/wdio/services.default-config.js
+++ b/config/wdio/services.default-config.js
@@ -24,7 +24,7 @@ const seleniumDocker = {
   retries: 3000,
   /* The retry interval (in milliseconds) to wait between retries.
    */
-  retryInterval: 10,
+  retryInterval: 20,
   /* Docker compose file reference when deploying the docker selenium hub stack. */
   composeFile: path.join(__dirname, '..', '..', 'lib', 'wdio', 'docker-compose.yml'),
 };

--- a/config/wdio/services.default-config.js
+++ b/config/wdio/services.default-config.js
@@ -21,7 +21,7 @@ const seleniumDocker = {
   /* Weather or not the service should be ran. */
   enabled: true,
   /* Retry count to test for selenium being up. */
-  retries: 2000,
+  retries: 3000,
   /* The retry interval (in milliseconds) to wait between retries.
    */
   retryInterval: 10,


### PR DESCRIPTION
### Summary
I've updated this because we kept repeatedly getting time outs waiting in terra-clinical.

And because I love releasing terra-toolkit.

@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
