### PR TITLE
Remove ./ from binarys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Fixed
+* Remove './' from bin paths in package.json
 
 3.2.0 - (April 26, 2018)
 ----------

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "url": "https://github.com/cerner/terra-toolkit/issues"
   },
   "bin": {
-    "tt:aggregate-translations": "./bin/aggregate-translations.js",
-    "tt:serve": "./bin/serve.js",
-    "tt:serve-static": "./bin/serve-static.js"
+    "tt:aggregate-translations": "bin/aggregate-translations.js",
+    "tt:serve": "bin/serve.js",
+    "tt:serve-static": "bin/serve-static.js"
   },
   "scripts": {
     "clean:all": "npm run clean:compiled && npm run clean:dependencies",


### PR DESCRIPTION
### Summary
The ./ may be causing this issue: https://github.com/cerner/terra-toolkit/issues/96. Removing these does not cause ill effects on current browsers.

@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
