### PR TITLE
Re-enable cheap-source-map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Fixed
+* Re-enabale cheap-source-map, the source mapping level we had prior to webpack 4.
 
 3.3.1 - (May 4, 2018)
 ----------

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -106,7 +106,7 @@ const defaultWebpackConfig = (env = {}, argv = {}) => {
     output: {
       path: path.join(rootPath, 'build'),
     },
-    devtool: production ? undefined : 'cheap-module-eval-source-map',
+    devtool: production ? undefined : 'cheap-source-map',
     resolveLoader: {
       modules: [path.resolve(path.join(rootPath, 'node_modules'))],
     },


### PR DESCRIPTION
### Summary
This should let us debug our site more easily. I've only enabled this in dev.

@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
