### PR TITLE
Add host option to tt:serve and tt:serve-static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Updated
+* tt:serve and tt:serve-static now take a --host option.
 
 3.5.0 - (May 22, 2018)
 ----------

--- a/scripts/serve/README.md
+++ b/scripts/serve/README.md
@@ -16,6 +16,7 @@ Serve is offered up as both a cli and a javascript function.
 | **--config**  | false | `undefined` | The webpack config to serve. |
 | **--port**  | false | `8080` | The port the server should listen on. |
 | **-p, --production | false | false | Passes the -p flag to the webpack config. |
+| **--host** | false |`undefined` | Sets the host that the server will listen on. eg. '10.10.10.1' |
 
 If no config is supplied tt:serve will first search for `webpack.config.js` in the working directory, if that is not found it will attempt to use the default webpack config supplied by terra-dev-site.
 
@@ -32,6 +33,7 @@ If no config is supplied tt:serve will first search for `webpack.config.js` in t
 | **config**  | true | `undefined` | The webpack config to serve. |
 | **port**  | false | `8080` | The port the server should listen on. |
 | **production | false | false | Passes the -p flag to the webpack config. |
+| **host** | false |`undefined` | Sets the host that the server will listen on. eg. '10.10.10.1' |
 #### In code
 ```javascript
 const serve = require('terra-toolkit/scripts/serve/serve');
@@ -54,6 +56,7 @@ Serve-static is offered up as both a cli and a javascript function.
 | **-p, --production | false | false | Passes the -p flag to the webpack config. |
 | **--site** | false | `undefined` | The relative path to the static site. This takes precedence over webpack config if both are passed.|
 | **--disk** | false | `false` | The webpack assets will be written to disk instead of a virtual file system. Only used when webpack config is passed |
+| **--host** | false |`undefined` | Sets the host that the server will listen on. eg. '10.10.10.1' |
 
 If no config is supplied tt:serve-static will first search for `webpack.config.js` in the working directory, if that is not found it will attempt to use the default webpack config supplied by terra-dev-site.
 
@@ -74,6 +77,8 @@ If no config is supplied tt:serve-static will first search for `webpack.config.j
 | **site** | false | `undefined` | The relative path to the static site. This takes precedence over webpack config if both are passed.|
 | **disk** | false | `false` | The webpack assets will be written to disk instead of a virtual file system. Only used when webpack config is passed |
 | **index** | false | `index.html` | The entry point for your site. Only used when webpack config is passed|
+| **host** | false |`undefined` | Sets the host that the server will listen on. eg. '10.10.10.1' |
+
 #### In code
 ```javascript
 const serveStatic = require('terra-toolkit/scripts/serve/serve-static');

--- a/scripts/serve/README.md
+++ b/scripts/serve/README.md
@@ -15,7 +15,7 @@ Serve is offered up as both a cli and a javascript function.
 | ------------- | ------------- | ------------- | ------------- |
 | **--config**  | false | `undefined` | The webpack config to serve. |
 | **--port**  | false | `8080` | The port the server should listen on. |
-| **-p, --production | false | false | Passes the -p flag to the webpack config. |
+| **-p, --production** | false | false | Passes the -p flag to the webpack config. |
 | **--host** | false |`undefined` | Sets the host that the server will listen on. eg. '10.10.10.1' |
 
 If no config is supplied tt:serve will first search for `webpack.config.js` in the working directory, if that is not found it will attempt to use the default webpack config supplied by terra-dev-site.
@@ -32,7 +32,7 @@ If no config is supplied tt:serve will first search for `webpack.config.js` in t
 | ------------- | ------------- | ------------- | ------------- |
 | **config**  | true | `undefined` | The webpack config to serve. |
 | **port**  | false | `8080` | The port the server should listen on. |
-| **production | false | false | Passes the -p flag to the webpack config. |
+| **production** | false | false | Passes the -p flag to the webpack config. |
 | **host** | false |`undefined` | Sets the host that the server will listen on. eg. '10.10.10.1' |
 #### In code
 ```javascript
@@ -53,7 +53,7 @@ Serve-static is offered up as both a cli and a javascript function.
 | ------------- | ------------- | ------------- | ------------- |
 | **--config**  | false | `undefined` | The webpack config to serve. |
 | **--port**  | false | `8080` | The port the server should listen on. |
-| **-p, --production | false | false | Passes the -p flag to the webpack config. |
+| **-p, --production** | false | false | Passes the -p flag to the webpack config. |
 | **--site** | false | `undefined` | The relative path to the static site. This takes precedence over webpack config if both are passed.|
 | **--disk** | false | `false` | The webpack assets will be written to disk instead of a virtual file system. Only used when webpack config is passed |
 | **--host** | false |`undefined` | Sets the host that the server will listen on. eg. '10.10.10.1' |
@@ -73,7 +73,7 @@ If no config is supplied tt:serve-static will first search for `webpack.config.j
 | ------------- | ------------- | ------------- | ------------- |
 | **config**  | true | `undefined` | The webpack config to serve. |
 | **port**  | false | `8080` | The port the server should listen on. |
-| **production | false | false | Passes the -p flag to the webpack config. |
+| **production** | false | false | Passes the -p flag to the webpack config. |
 | **site** | false | `undefined` | The relative path to the static site. This takes precedence over webpack config if both are passed.|
 | **disk** | false | `false` | The webpack assets will be written to disk instead of a virtual file system. Only used when webpack config is passed |
 | **index** | false | `index.html` | The entry point for your site. Only used when webpack config is passed|

--- a/scripts/serve/serve-cli.js
+++ b/scripts/serve/serve-cli.js
@@ -9,6 +9,7 @@ const loadDefaultWebpackConfig = require('./loadDefaultWebpackConfig');
 commander
   .version(packageJson.version)
   .option('--config <path>', 'The webpack config to serve.', undefined)
+  .option('--host <s>', 'Sets the host that the server will listen on. eg. \'10.10.10.1\'', undefined)
   .option('--port <n>', 'The port the server should listen on.', parseInt)
   .option('-p, --production', 'Passes the -p flag to the webpack config')
   .parse(process.argv);
@@ -17,6 +18,7 @@ const port = commander.port || process.env.PORT;
 
 serve({
   config: loadDefaultWebpackConfig(commander.config),
+  host: commander.host,
   port,
   production: commander.production,
 });

--- a/scripts/serve/serve-static-cli.js
+++ b/scripts/serve/serve-static-cli.js
@@ -10,6 +10,7 @@ commander
   .version(packageJson.version)
   .option('--config <path>', 'The webpack config to serve. Alias for <config>.', undefined)
   .option('--port <n>', 'The port the app should listen on', parseInt)
+  .option('--host <s>', 'Sets the host that the server will listen on. eg. \'10.10.10.1\'', undefined)
   .option('-p, --production', 'Passes the -p flag to the webpack config, if available.')
   .option('--site <path>', 'The relative path to the static site. This takes precidence over webpack config if both are passed.', undefined)
   .option('--disk', 'The webpack assets will be written to disk instead of a virtual file system.')
@@ -19,8 +20,9 @@ const port = commander.port || process.env.PORT;
 
 serve({
   config: loadDefaultWebpackConfig(commander.config),
-  site: commander.site,
   disk: commander.disk,
+  host: commander.host,
   port,
   production: commander.production,
+  site: commander.site,
 });

--- a/scripts/serve/serve-static.js
+++ b/scripts/serve/serve-static.js
@@ -107,14 +107,14 @@ const serveSite = (site, fs, index) => {
 
 // Generate a site if not provided and spin up an express server to serve the site.
 const serve = (options) => {
-  const { site, config, port, disk, index, production } = options;
+  const { site, config, port, disk, index, production, host } = options;
   const appPort = port || 8080;
   const appIndex = index || 'index.html';
 
   return generateSite(site, config, disk, production).then(
     ([sitePath, fs]) => serveSite(sitePath, fs, appIndex)).then(
     (app) => {
-      const server = app.listen(appPort);
+      const server = app.listen(appPort, host);
       console.log(`[Terra-Toolkit:serve-static] Server started listening at port:${appPort}`);
       return server;
     });

--- a/scripts/serve/serve.js
+++ b/scripts/serve/serve.js
@@ -1,15 +1,18 @@
 const serve = require('webpack-serve');
 
 const webpackServe = (options) => {
+  const { port, host } = options;
   let config = options.config;
   if (typeof config === 'function') {
     config = config(undefined, { p: options.production });
   }
 
-  const serveConfig = { config };
-  if (options.port) {
-    serveConfig.port = options.port;
-  }
+  const serveConfig = {
+    config,
+    ...(port) && { port },
+    ...(host) && { host },
+  };
+
   serve(serveConfig);
 };
 


### PR DESCRIPTION
### Summary
To be able to run tt:serve and tt:serve-static from plain docker containers the host needs to be able to be specified.

@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
