### PR TITLE
Updating webpack.config with PostCSS/UglifyJS corrections

### DIFF
--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -51,6 +51,7 @@ const defaultWebpackConfig = (env = {}, argv = {}) => {
               ident: 'postcss',
               plugins() {
                 return [
+                  rtl(),
                   Autoprefixer({
                     browsers: [
                       'ie >= 10',
@@ -60,7 +61,6 @@ const defaultWebpackConfig = (env = {}, argv = {}) => {
                       'iOS >= 10',
                     ],
                   }),
-                  rtl(),
                 ];
               },
             },
@@ -129,6 +129,11 @@ const defaultWebpackConfig = (env = {}, argv = {}) => {
           cache: true,
           parallel: true,
           sourceMap: true,
+          uglifyOptions: {
+            compress: {
+              typeofs: false,
+            },
+          },
         }),
       ],
     },


### PR DESCRIPTION
### Summary
Doing two things here:

1. Reversing the execution order of our PostCSS plugins to fix #106. The following deployments in terra-core, terra-clinical, and terra-framework can be used to validate:
* https://terra-core-deployed-pr-1589.herokuapp.com/#/home
* https://terra-clinical-deployed-pr-348.herokuapp.com/#/home
* https://terra-framework-deploye-pr-201.herokuapp.com/#/home

2. Disabling the `typeofs` compression option for our UglifyJS production step. It is enabled by default but has known issues with IE10 support, so we're going to disable it. See 'typeofs' here for more: https://github.com/mishoo/UglifyJS2#compress-options. The `typeofs` option is the only one that calls out any specific incompatibility with our supported browser set.

The UglifyJS change isn't directly verifiable from the PR, but some folks who were seeing issues with this have independently confirmed that disabling the option corrected issues they were seeing in IE10.