### PR TITLE
Filter query params from assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Fixed
+* Allow serving static assets when they're requested using query params
 
 3.7.0 - (June 12, 2018)
 ----------

--- a/scripts/serve/serve-static.js
+++ b/scripts/serve/serve-static.js
@@ -57,7 +57,8 @@ const virtualApp = (site, index, fs) => {
       filename = `/${index}`;
     }
 
-    const filepath = `${site}${filename}`;
+    // Filter query params
+    const filepath = `${site}${filename}`.replace(/(\?).*/, '');
 
     if (fs.existsSync(filepath)) {
       res.setHeader('content-type', mime.contentType(path.extname(filename)));


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->
This allows serving static assets even when they're requested with query params.

### Additional Details
We're using this to serve image avatars, for example when `/personnel/{id}/photo?cache_image=true` is hit, the file at `/personnel/{id}/photo` will be served instead.

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
