### PR TITLE
Reduce web pack log output from tt-serve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Unreleased
 ### Fixed
 * Allow serving static assets when they're requested using query params
 
+### Changed
+* Reduce log output for tt-serve (no children)
+
 3.7.0 - (June 12, 2018)
 ----------
 ### Updated

--- a/scripts/serve/serve.js
+++ b/scripts/serve/serve.js
@@ -11,6 +11,10 @@ const webpackServe = (options) => {
     config,
     ...(port) && { port },
     ...(host) && { host },
+    dev: { stats: {
+      colors: true,
+      children: false,
+    } },
   };
 
   serve(serveConfig);


### PR DESCRIPTION
### Summary
Reduce web pack log output from tt-serve.

@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
