### PR TITLE
Windows seleniumdocker error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Changed path to use POSIX for SelemiumDockerService to fix Windows issue.
 
 3.8.0 - (June 15, 2018)
 ----------

--- a/src/wdio/services/SeleniumDockerService.js
+++ b/src/wdio/services/SeleniumDockerService.js
@@ -179,7 +179,7 @@ export default class SeleniumDockerService {
     http.get({
       host: this.host,
       port: this.port,
-      path: path.join(this.path || '/wd/hub', 'status'),
+      path: path.posix.join(this.path || '/wd/hub', 'status'),
     }, (res) => {
       const { statusCode } = res;
       if (statusCode !== 200) {


### PR DESCRIPTION
### Summary
This gets rid of an error message when SeleniumDocker is ensuring status on Windows. 
```
A service failed in the 'onPrepare' hook
Error: Request failed
```

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
