### PR TITLE
Fix issue with containerized runs with port mapping

### DIFF
--- a/config/wdio/wdio.conf.js
+++ b/config/wdio/wdio.conf.js
@@ -10,7 +10,8 @@ const Repository = require('lerna/lib/Repository');
 const visualRegressionConfig = require('./visualRegressionConf');
 
 const ip = process.env.WDIO_EXTERNAL_HOST || localIP.address();
-const webpackPort = process.env.WDIO_EXTERNAL_PORT || 8080;
+const externalPort = process.env.WDIO_EXTERNAL_PORT || 8080;
+const internalPort = process.env.WDIO_INTERNAL_PORT || 8080;
 const ci = process.env.TRAVIS || process.env.CI;
 const locale = process.env.LOCALE;
 const formFactor = process.env.FORM_FACTOR;
@@ -41,10 +42,10 @@ const config = {
 
   visualRegression: visualRegressionConfig,
 
-  baseUrl: `http://${ip}:${webpackPort}`,
+  baseUrl: `http://${ip}:${externalPort}`,
 
   serveStatic: {
-    port: webpackPort,
+    port: internalPort,
   },
   ...locale && { locale },
   ...formFactor && { formFactor },

--- a/docs/Wdio_Utility.md
+++ b/docs/Wdio_Utility.md
@@ -47,6 +47,14 @@ const config = {
 exports.config = config;
 ```
 
+### Environment Variables
+
+In order to support tests running inside of a container and hitting an external selenium grid, 3 environment variables are provided:
+
+* `WDIO_INTERNAL_PORT` - This specifies the port for the ServeStaticService. This is the port that the server being tested against will actually run on.
+* `WDIO_EXTERNAL_PORT` - This specifies the external port that is mapped on the container to the WDIO_INTERNAL_PORT.
+* `WDIO_EXTERNAL_HOST` - This specifies the externally accessible name for the host on which the container is running.
+
 ## Writing Tests
 
 There are a few things to note about the webdriver.io configuration provided by Terra-Toolkit:


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->
Containerized runs need to be able to specify an internal port on which to run that is separate from the port that is used when being hit by a selenium grid.  Changes in terra-toolkit v4 made these end up being one and the same.  This will fix that issue.
