### PR TITLE
Update serve-cli.js serve-static-cli.js to not use the port environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Unreleased
 ----------
 ### Changed
-* Removed the environment variable for port from static and static-serve.
+* Removed the environment variable for port from static and static-serve
 
 4.3.0 - (July 17, 2018)
 ----------

--- a/scripts/serve/serve-cli.js
+++ b/scripts/serve/serve-cli.js
@@ -13,11 +13,11 @@ commander
   .option('-p, --production', 'Passes the -p flag to the webpack config')
   .parse(process.argv);
 
-const port = commander.port || process.env.PORT;
+const port = commander.port;
 
 serve({
   config: loadWebpackConfig(commander.config),
   host: commander.host,
-  port,
+  port: commander.port,
   production: commander.production,
 });

--- a/scripts/serve/serve-cli.js
+++ b/scripts/serve/serve-cli.js
@@ -13,8 +13,6 @@ commander
   .option('-p, --production', 'Passes the -p flag to the webpack config')
   .parse(process.argv);
 
-const port = commander.port;
-
 serve({
   config: loadWebpackConfig(commander.config),
   host: commander.host,

--- a/scripts/serve/serve-static-cli.js
+++ b/scripts/serve/serve-static-cli.js
@@ -16,13 +16,11 @@ commander
   .option('--disk', 'The webpack assets will be written to disk instead of a virtual file system.')
   .parse(process.argv);
 
-const port = commander.port || process.env.PORT;
-
 serve({
   config: loadWebpackConfig(commander.config),
   disk: commander.disk,
   host: commander.host,
-  port,
+  port: commander.port,
   production: commander.production,
   site: commander.site,
 });


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->
Remove the port environment variable for serve and serve-static.  I don't think it's serving any purpose (and it's actually causing problems in some cases.
