### PR TITLE
Remove node modules from basedir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog
 
 Unreleased
 ----------
-### Changed
+### Fixed
 * Updated the `baseScreenshotDir` option to allow for test reusability from terra repositories
 
 4.6.0 - (July 25, 2018)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,16 @@ Changelog
 
 Unreleased
 ----------
-### Added
-* Added sv and sv-SE to aggregated translations supported locales list
-
 ### Changed
 * Updated the `baseScreenshotDir` option to allow for test reusability from terra repositories
 
 ### Fixed
-* Only hash css assets in production mode for webpack config reusability in rails projects.
+* Only hash css assets in production mode for webpack config reusability in rails projects
+
+4.6.0 - (July 25, 2018)
+----------
+### Added
+* Added sv and sv-SE to aggregated translations supported locales list
 
 4.5.0 - (July 20, 2018)
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,14 @@ Changelog
 
 Unreleased
 ----------
-
-4.6.0 - (July 25, 2018)
-----------
 ### Added
 * Added sv and sv-SE to aggregated translations supported locales list
+
+### Changed
+* Updated the `baseScreenshotDir` option to allow for test reusability from terra repositories
+
+### Fixed
+* Only hash css assets in production mode for webpack config reusability in rails projects.
 
 4.5.0 - (July 20, 2018)
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,6 @@ Unreleased
 ### Changed
 * Updated the `baseScreenshotDir` option to allow for test reusability from terra repositories
 
-### Fixed
-* Only hash css assets in production mode for webpack config reusability in rails projects
-
 4.6.0 - (July 25, 2018)
 ----------
 ### Added

--- a/config/wdio/visualRegressionConf.js
+++ b/config/wdio/visualRegressionConf.js
@@ -70,7 +70,12 @@ function getScreenshotPath(ref) {
 
     const baseDir = global.browser.options.baseScreenshotDir;
     if (baseDir) {
-      testPath = baseDir + testPath.split(process.cwd())[1];
+      testPath = testPath.split(process.cwd())[1];
+      // Added to allow for test reusablility from terra repositories
+      if (testPath.includes('node_modules')) {
+        testPath = testPath.split('node_modules')[1];
+      }
+      testPath = baseDir + testPath;
     }
     const refDir = screenshotSetup[`${ref}Dir`];
 


### PR DESCRIPTION
### Summary
-  Updated the `baseScreenshotDir` option to allow for test reusability from terra repositories