### PR TITLE
Update doc for aggregate-translations CLI

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,6 +12,7 @@ Cerner Corporation
 - Alex Bezek [@alex-bezek]
 - Noah Benham [@noahbenham]
 - Ben Boersma [@BenBoersma]
+- Daniel Vu [@dv297]
 
 [@emilyrohrbough]: https://github.com/emilyrohrbough
 [@brettjankord]: https://github.com/bjankord
@@ -25,3 +26,4 @@ Cerner Corporation
 [@alex-bezek]: https://github.com/alex-bezek
 [@noahbenham]: https://github.com/noahbenham
 [@BenBoersma]: https://github.com/BenBoersma
+[@dvv297]: https://github.com/dv297

--- a/docs/AggregateTranslations.md
+++ b/docs/AggregateTranslations.md
@@ -40,7 +40,7 @@ The `aggregate-translations` CLI is supplied as a bin script, called `tt-aggrega
 ```js
 scripts: {
     // ...other scripts
-    "aggregate-translations": "tt-aggregate-translations -b ./ -d ./src/**/translations -d ./translations -l en,es -o ./aggregated-translations",
+    "aggregate-translations": "tt-aggregate-translations -b ./ -d ./src/**/translations -d ./translations -l=['en','es'] -o ./aggregated-translations",,
     "start:build": "npm run aggregate-translations && npm run start"
 }
 ```

--- a/docs/AggregateTranslations.md
+++ b/docs/AggregateTranslations.md
@@ -40,7 +40,7 @@ The `aggregate-translations` CLI is supplied as a bin script, called `tt-aggrega
 ```js
 scripts: {
     // ...other scripts
-    "aggregate-translations": "tt-aggregate-translations -b ./ -d ./src/**/translations -d ./translations -l ['en', 'es'] -o ./aggregated-translations",
+    "aggregate-translations": "tt-aggregate-translations -b ./ -d ./src/**/translations -d ./translations -l en,es -o ./aggregated-translations",
     "start:build": "npm run aggregate-translations && npm run start"
 }
 ```

--- a/docs/AggregateTranslations.md
+++ b/docs/AggregateTranslations.md
@@ -40,7 +40,7 @@ The `aggregate-translations` CLI is supplied as a bin script, called `tt-aggrega
 ```js
 scripts: {
     // ...other scripts
-    "aggregate-translations": "tt-aggregate-translations -b ./ -d ./src/**/translations -d ./translations -l=['en','es'] -o ./aggregated-translations",
+    "aggregate-translations": "tt-aggregate-translations -b ./ -d ./src/**/translations -d ./translations -l ['en','es'] -o ./aggregated-translations",
     "start:build": "npm run aggregate-translations && npm run start"
 }
 ```

--- a/docs/AggregateTranslations.md
+++ b/docs/AggregateTranslations.md
@@ -40,7 +40,7 @@ The `aggregate-translations` CLI is supplied as a bin script, called `tt-aggrega
 ```js
 scripts: {
     // ...other scripts
-    "aggregate-translations": "tt-aggregate-translations -b ./ -d ./src/**/translations -d ./translations -l=['en','es'] -o ./aggregated-translations",,
+    "aggregate-translations": "tt-aggregate-translations -b ./ -d ./src/**/translations -d ./translations -l=['en','es'] -o ./aggregated-translations",
     "start:build": "npm run aggregate-translations && npm run start"
 }
 ```

--- a/scripts/aggregate-translations/aggregate-translations-cli.js
+++ b/scripts/aggregate-translations/aggregate-translations-cli.js
@@ -15,7 +15,7 @@ const addCustomDirectory = (baseDirectory, searchPattern) => {
 // Parse locale list
 const localeList = list => (
   // eslint-disable-next-line no-useless-escape
-  list.replace(/[\[\]\s\']/g, '').split(',')
+  list.replace(/[\[\]\s]/g, '').split(',').map(String)
 );
 
 // Parse process arguments
@@ -23,7 +23,7 @@ commander
   .version(i18nPackageJson.version)
   .option('-b, --baseDir [baseDir]', 'The directory to start searching from and to prepend to the output directory', process.cwd())
   .option('-d, --directories [directories]', 'Regex pattern to glob search for translations', addCustomDirectory)
-  .option('-l, --locales <locales>', 'A comma-separated list of locale codes aggregate on and combine into a single, respective translation file ', localeList, supportedLocales)
+  .option('-l, --locales <locales>', 'The list of locale codes aggregate on and combine into a single, respective translation file ', localeList, supportedLocales)
   .option('-o, --outputDir [outputDir]', 'The output location of the generated configuration file', './aggregated-translations')
   .option('-c, --config [configPath]', 'The path to the terra i18n configuration file', undefined)
   .parse(process.argv);

--- a/scripts/aggregate-translations/aggregate-translations-cli.js
+++ b/scripts/aggregate-translations/aggregate-translations-cli.js
@@ -15,7 +15,7 @@ const addCustomDirectory = (baseDirectory, searchPattern) => {
 // Parse locale list
 const localeList = list => (
   // eslint-disable-next-line no-useless-escape
-  list.replace(/[\[\]\s]/g, '').split(',').map(String)
+  list.replace(/[\[\]\s\']/g, '').split(',')
 );
 
 // Parse process arguments
@@ -23,7 +23,7 @@ commander
   .version(i18nPackageJson.version)
   .option('-b, --baseDir [baseDir]', 'The directory to start searching from and to prepend to the output directory', process.cwd())
   .option('-d, --directories [directories]', 'Regex pattern to glob search for translations', addCustomDirectory)
-  .option('-l, --locales <locales>', 'The list of locale codes aggregate on and combine into a single, respective translation file ', localeList, supportedLocales)
+  .option('-l, --locales <locales>', 'A comma-separated list of locale codes aggregate on and combine into a single, respective translation file ', localeList, supportedLocales)
   .option('-o, --outputDir [outputDir]', 'The output location of the generated configuration file', './aggregated-translations')
   .option('-c, --config [configPath]', 'The path to the terra i18n configuration file', undefined)
   .parse(process.argv);


### PR DESCRIPTION
### Summary
I think there is some discrepancy in how Commander handles arguments across Windows and Macs. When using the aggregate-translations command, if you have a space between the locales,
```
tt-aggregate-translations -b ./ -d ./translations -l ['en', 'es'] -o ./aggregated-translations
```
...Commander (at least on Windows), won't group the argument together, which was causing an incorrect aggregated-translations folder to be generated. I've included a screenshot.

![with-space](https://user-images.githubusercontent.com/5365325/43914024-49444526-9bcc-11e8-99a1-4c4568d92f2d.PNG)


Even if I remove the space
`['en','es']`
...it doesn't quite parse the list correctly
![capture](https://user-images.githubusercontent.com/5365325/43913923-00d38ca2-9bcc-11e8-8217-72c4979ce53e.PNG)

So I added a small change to the Regex to strip the extra quotes. I also removed the .map(String), though maybe I'm missing an edge case since I'm assuming everything after the split will be a string.

But I think the more important change here is just to change the docs so that you take in a comma-separated list rather than some pseudo-array structure. I think the pseudo-array structure implies that you can use any valid JS-array syntax (with spaces included) and that it'd work, but it's not quite the case, at least on Windows. The regex change at least maintains backwards compatibility with the older syntax as long as you remove spaces.


### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
