### PR TITLE
Update default publicPath to be Empty String

### DIFF
--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -17,7 +17,7 @@ const webpackConfig = (options, env, argv) => {
   let filename = production ? '[name]-[chunkhash]' : '[name]';
   filename = argv['output-filename'] || filename;
   const outputPath = argv['output-path'] || path.join(rootPath, 'build');
-  const publicPath = argv['output-public-path'] || '/';
+  const publicPath = argv['output-public-path'] || '';
 
   const devConfig = {
     mode: 'development',

--- a/tests/jest/webpack.config.test.js
+++ b/tests/jest/webpack.config.test.js
@@ -115,7 +115,7 @@ describe('webpack config', () => {
     it('add the output config', () => {
       expect(config).toHaveProperty('output');
       expect(config.output).toHaveProperty('path', outputPath);
-      expect(config.output).toHaveProperty('publicPath', '/');
+      expect(config.output).toHaveProperty('publicPath', '');
     });
 
     it('disabled stats on children', () => {


### PR DESCRIPTION
### Summary
I was mistaken that the default publicPath value was `/`, but it is actually `''`. Both tt-serve and tt-serve-static work as expected, however this error was seen with github-deployments.

References: 
https://webpack.js.org/configuration/output/#output-publicpath