### PR TITLE
Add parse list utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ----------
 ### Changed
 * Bumped node-sass dependency to v4.9.3. This version should work better on latest High Sierra OS on mac.
+* Fixed aggregated-translations locales and tt-wdio formFactors and locales flag to not include single quotes in output file names on Windows.
 
 4.9.0 - (August 14, 2018)
 ----------

--- a/scripts/aggregate-translations/aggregate-translations-cli.js
+++ b/scripts/aggregate-translations/aggregate-translations-cli.js
@@ -2,7 +2,7 @@ const path = require('path');
 const commander = require('commander');
 const i18nPackageJson = require('../../package.json');
 const supportedLocales = require('./i18nSupportedLocales');
-const parseList = require('../util/parse-list');
+const parseCLIList = require('../utils/parse-cli-list');
 
 const aggregateTranslations = require('./aggregate-translations');
 
@@ -18,7 +18,7 @@ commander
   .version(i18nPackageJson.version)
   .option('-b, --baseDir [baseDir]', 'The directory to start searching from and to prepend to the output directory', process.cwd())
   .option('-d, --directories [directories]', 'Regex pattern to glob search for translations', addCustomDirectory)
-  .option('-l, --locales <locales>', 'The list of locale codes aggregate on and combine into a single, respective translation file ', parseList, supportedLocales)
+  .option('-l, --locales <locales>', 'The list of locale codes aggregate on and combine into a single, respective translation file ', parseCLIList, supportedLocales)
   .option('-o, --outputDir [outputDir]', 'The output location of the generated configuration file', './aggregated-translations')
   .option('-c, --config [configPath]', 'The path to the terra i18n configuration file', undefined)
   .parse(process.argv);

--- a/scripts/aggregate-translations/aggregate-translations-cli.js
+++ b/scripts/aggregate-translations/aggregate-translations-cli.js
@@ -2,6 +2,7 @@ const path = require('path');
 const commander = require('commander');
 const i18nPackageJson = require('../../package.json');
 const supportedLocales = require('./i18nSupportedLocales');
+const parseList = require('../util/parse-list');
 
 const aggregateTranslations = require('./aggregate-translations');
 
@@ -12,18 +13,12 @@ const addCustomDirectory = (searchPattern) => {
   customSearchDirectories.push(customDir);
 };
 
-// Parse locale list
-const localeList = list => (
-  // eslint-disable-next-line no-useless-escape
-  list.replace(/[\[\]\s]/g, '').split(',').map(String)
-);
-
 // Parse process arguments
 commander
   .version(i18nPackageJson.version)
   .option('-b, --baseDir [baseDir]', 'The directory to start searching from and to prepend to the output directory', process.cwd())
   .option('-d, --directories [directories]', 'Regex pattern to glob search for translations', addCustomDirectory)
-  .option('-l, --locales <locales>', 'The list of locale codes aggregate on and combine into a single, respective translation file ', localeList, supportedLocales)
+  .option('-l, --locales <locales>', 'The list of locale codes aggregate on and combine into a single, respective translation file ', parseList, supportedLocales)
   .option('-o, --outputDir [outputDir]', 'The output location of the generated configuration file', './aggregated-translations')
   .option('-c, --config [configPath]', 'The path to the terra i18n configuration file', undefined)
   .parse(process.argv);

--- a/scripts/util/parse-list.js
+++ b/scripts/util/parse-list.js
@@ -1,5 +1,0 @@
-// eslint-disable-next-line no-useless-escape
-const parseList = list => list.replace(/[\[\'\'\]\s]/g, '').split(',').map(String);
-
-module.exports = parseList;
-

--- a/scripts/util/parse-list.js
+++ b/scripts/util/parse-list.js
@@ -1,0 +1,5 @@
+// eslint-disable-next-line no-useless-escape
+const parseList = list => list.replace(/[\[\'\'\]\s]/g, '').split(',').map(String);
+
+module.exports = parseList;
+

--- a/scripts/utils/parse-cli-list.js
+++ b/scripts/utils/parse-cli-list.js
@@ -1,0 +1,4 @@
+// eslint-disable-next-line no-useless-escape
+const parseCLIList = list => list.replace(/[\[\'\'\]\s]/g, '').split(',').map(String);
+
+module.exports = parseCLIList;

--- a/scripts/wdio/wdio-runner-cli.js
+++ b/scripts/wdio/wdio-runner-cli.js
@@ -4,18 +4,16 @@ const commander = require('commander');
 const getWdioConfigPath = require('./getWdioConfigPath');
 const cleanScreenshots = require('./clean-screenshots');
 const runner = require('./wdio-runner');
+const parseList = require('../util/parse-list');
 
 const packageJson = require('../../package.json');
-
-// eslint-disable-next-line no-useless-escape
-const listOptions = list => (list.replace(/[\[\]\s]/g, '').split(',').map(String));
 
 // Parse process arguments
 commander
   .version(packageJson.version)
   .option('--config <path>', 'The wdio config path for the tests', undefined)
-  .option('--formFactors <list>', 'The list of viewport sizes to test', listOptions, undefined)
-  .option('--locales <list>', 'The list of locales to test', listOptions, ['en'])
+  .option('--formFactors <list>', 'The list of viewport sizes to test', parseList, undefined)
+  .option('--locales <list>', 'The list of locales to test', parseList, ['en'])
   .option('--continueOnFail', 'Wheather or not to execute all test runs when a run fails', false)
   .option('--updateReference', 'Whether or not to remove reference screenshots during screenshot cleanup', false)
   .option('--host <number>', '[wdio option] The selenium server port', undefined)

--- a/scripts/wdio/wdio-runner-cli.js
+++ b/scripts/wdio/wdio-runner-cli.js
@@ -4,7 +4,7 @@ const commander = require('commander');
 const getWdioConfigPath = require('./getWdioConfigPath');
 const cleanScreenshots = require('./clean-screenshots');
 const runner = require('./wdio-runner');
-const parseList = require('../util/parse-list');
+const parseCLIList = require('../utils/parse-cli-list');
 
 const packageJson = require('../../package.json');
 
@@ -12,8 +12,8 @@ const packageJson = require('../../package.json');
 commander
   .version(packageJson.version)
   .option('--config <path>', 'The wdio config path for the tests', undefined)
-  .option('--formFactors <list>', 'The list of viewport sizes to test', parseList, undefined)
-  .option('--locales <list>', 'The list of locales to test', parseList, ['en'])
+  .option('--formFactors <list>', 'The list of viewport sizes to test', parseCLIList, undefined)
+  .option('--locales <list>', 'The list of locales to test', parseCLIList, ['en'])
   .option('--continueOnFail', 'Wheather or not to execute all test runs when a run fails', false)
   .option('--updateReference', 'Whether or not to remove reference screenshots during screenshot cleanup', false)
   .option('--host <number>', '[wdio option] The selenium server port', undefined)

--- a/tests/jest/parse-list.test.js
+++ b/tests/jest/parse-list.test.js
@@ -1,13 +1,13 @@
-import parseList from '../../scripts/util/parse-list';
+import parseCLIList from '../../scripts/utils/parse-cli-list';
 
-describe('Parse List', () => {
+describe('Parse CLI List', () => {
   it.each`
     input                | expectedLocales
     ${"['en']"}          | ${['en']}
     ${"['en','en-US']"}  | ${['en', 'en-US']}`(
   'parses $input to $expectedLocales',
   ({ input, expectedLocales }) => {
-    const parsedList = parseList(input);
+    const parsedList = parseCLIList(input);
     expect(parsedList).toEqual(expectedLocales);
   },
 );

--- a/tests/jest/parse-list.test.js
+++ b/tests/jest/parse-list.test.js
@@ -1,0 +1,14 @@
+import parseList from '../../scripts/util/parse-list';
+
+describe('Parse List', () => {
+  it.each`
+    input                | expectedLocales
+    ${"['en']"}          | ${['en']}
+    ${"['en','en-US']"}  | ${['en', 'en-US']}`(
+  'parses $input to $expectedLocales',
+  ({ input, expectedLocales }) => {
+    const parsedList = parseList(input);
+    expect(parsedList).toEqual(expectedLocales);
+  },
+);
+});


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

### Additional Details
On Windows machines, Commander includes single quotes in the input of lists. This causes filenames that include that single quote in the file name. See the below screenshot when running the aggregate-translations CLI.

![aggregated-translations](https://user-images.githubusercontent.com/5365325/44420348-42635c80-a543-11e8-91e5-8e8fd39a5952.PNG)

It also has this log
```
WARNING: 'en' is NOT a Terra supported locale. Creating an aggregate translation file for 'en', but be sure to include the appropriate translations messages for each te
rra component used in your application otherwise the translations will fail and the fallback will be displayed.
WARNING: 'es' is NOT a Terra supported locale. Creating an aggregate translation file for 'es', but be sure to include the appropriate translations messages for each te
rra component used in your application otherwise the translations will fail and the fallback will be displayed.
WARNING: 'en' is NOT a Terra supported locale. Creating a translation and intl loader for 'en', but be sure the lanaguage specified is supported by intl, otherwise no l
ocale-date will exist and the import will result in an error.
WARNING: 'es' is NOT a Terra supported locale. Creating a translation and intl loader for 'es', but be sure the lanaguage specified is supported by intl, otherwise no l
ocale-date will exist and the import will result in an error.
```

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
