### PR TITLE
Pin version of axe-core at 3.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "async": "^2.5.0",
     "autoprefixer": "^8.5.2",
-    "axe-core": "^3.0.2",
+    "axe-core": "3.0.3",
     "babel-loader": "^7.1.2",
     "babel-polyfill": "^6.23.0",
     "browserslist-config-terra": "^1.0.0",


### PR DESCRIPTION
### Summary
Pins the version of axe-core to 3.0.3. The 3.1.0 release of axe-core introduces an npm resolution issue that needs to be resolved in the axe-core package. More info here: https://github.com/dequelabs/axe-core/issues/1104
