### PR TITLE
Lock down webpack version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ----------
 ### Changed
 * Updated linter and linter plugins
+* Locked webpack version to 4.19.0
 
 4.11.1 - (August 29, 2018)
 ----------

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "uglifyjs-webpack-plugin": "^1.2.4",
     "wdio-visual-regression-service": "^0.9.0",
     "webdriverio": "^4.9.8",
-    "webpack": "^4.4.1",
+    "webpack": "4.19.0",
     "webpack-cli": "^2.0.13",
     "webpack-merge": "^4.1.2",
     "webpack-serve": "^1.0.2"


### PR DESCRIPTION
### Summary
Lock down webpack version to prevent errors in webpack-cli while releasing.

@cerner/terra

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
