### PR TITLE
Fix server file path extension

### DIFF
--- a/scripts/serve/serve-static.js
+++ b/scripts/serve/serve-static.js
@@ -93,7 +93,7 @@ const virtualApp = (site, index, locale, fs, verbose) => {
         return;
       }
 
-      const fileExt = path.extname(filename);
+      const fileExt = path.extname(filename).replace(/(\?).*/, '');
       res.setHeader('content-type', mime.contentType(fileExt));
 
       if (fileExt === '.html') {


### PR DESCRIPTION
### Summary
The serve-static script was incorrect the header content type which can result in incorrect loading on the page.

What happened was the serve-static server would remove any hashing following a file extension when it determined the file path. However, when serve-static would parse the extension name, it would return the non-cleaned up extension. This resulted in ab invalid content type returned by mime which was then set as the header content type. 

##### Before:
![screen shot 2018-10-03 at 2 01 28 pm](https://user-images.githubusercontent.com/14099737/46433617-f2b5aa80-c716-11e8-9c46-0fd32c44148e.png)


##### After:
![screen shot 2018-10-03 at 2 03 12 pm](https://user-images.githubusercontent.com/14099737/46433628-f77a5e80-c716-11e8-8856-ecc70d0722fd.png)

I have been working with @nramamurth on this issue. Thank you for exposing this issue. Can you verify this has been resolved for you?