### PR TITLE
Remove Lerna Dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Lerna dependency
 
 4.12.0 - (September 25, 2018)
 ----------

--- a/config/wdio/wdio.conf.js
+++ b/config/wdio/wdio.conf.js
@@ -2,8 +2,6 @@ const localIP = require('ip');
 const glob = require('glob');
 
 const path = require('path');
-const PackageUtilities = require('lerna/lib/PackageUtilities');
-const Repository = require('lerna/lib/Repository');
 const {
   Axe: AxeService, SeleniumDocker: SeleniumDockerService, ServeStaticService, Terra: TerraService,
 } = require('../../lib/wdio/services/index');
@@ -16,12 +14,13 @@ const ci = process.env.TRAVIS || process.env.CI;
 const locale = process.env.LOCALE;
 const formFactor = process.env.FORM_FACTOR;
 
+const hasPackages = glob.sync((path.join(process.cwd(), 'packages'))).length > 0;
+
 const config = {
-  specs: [
-    path.join('test', 'wdio', '**', '*-spec.js'),
-    path.join('tests', 'wdio', '**', '*-spec.js'),
-    path.join('packages', '*', 'test', 'wdio', '**', '*-spec.js'),
-    path.join('packages', '*', 'tests', 'wdio', '**', '*-spec.js'),
+  specs: hasPackages ? [
+    path.join('packages', '*', 'test*', 'wdio', '**', '*-spec.js'),
+  ] : [
+    path.join('test*', 'wdio', '**', '*-spec.js'),
   ],
   maxInstances: 1,
   capabilities: [
@@ -75,23 +74,22 @@ if (ci) {
 
 // This code only executes for monorepos.  It will create a set of suites that can then be executed
 // independently and/or in parallel via 'wdio --suite suite1' for example
-const isRepoTest = !process.cwd().includes('packages');
-if (isRepoTest) {
-  const packageLocationsWithTests = PackageUtilities.getPackages(new Repository(path.resolve('.')))
-    // eslint-disable-next-line no-underscore-dangle
-    .map(pkg => path.join(pkg._location, 'tests', 'wdio', '**', '*-spec.js'))
-    .filter(packageLocation => glob.sync(packageLocation).length > 0);
+if (hasPackages) {
+  const packageLocationsWithTests = glob.sync((path.join(process.cwd(), 'packages', '*', 'test*', 'wdio', '**', '*-spec.js')));
 
-  const numberOfSuites = 4;
-  config.suites = {};
-  [...Array(numberOfSuites)].forEach((_, index) => {
-    config.suites[`suite${index + 1}`] = [];
-  });
-  const itemsPerSuite = Math.ceil(packageLocationsWithTests.length / numberOfSuites);
-  packageLocationsWithTests.forEach((packageLocation, index) => {
-    const currentSuite = `suite${Math.floor(index / itemsPerSuite) + 1}`;
-    config.suites[currentSuite] = config.suites[currentSuite].concat(packageLocation);
-  });
+  const numberOfPackagesWithTests = packageLocationsWithTests.length;
+  if (numberOfPackagesWithTests > 0) {
+    const numberOfSuites = 4;
+    config.suites = {};
+    [...Array(numberOfSuites)].forEach((_, index) => {
+      config.suites[`suite${index + 1}`] = [];
+    });
+    const itemsPerSuite = Math.ceil(numberOfPackagesWithTests / numberOfSuites);
+    packageLocationsWithTests.forEach((packageLocation, index) => {
+      const currentSuite = `suite${Math.floor(index / itemsPerSuite) + 1}`;
+      config.suites[currentSuite] = config.suites[currentSuite].concat(packageLocation);
+    });
+  }
 }
 
 exports.config = config;

--- a/docs/TerraToolkitUpgradeGuide-v5.0.0.md
+++ b/docs/TerraToolkitUpgradeGuide-v5.0.0.md
@@ -1,7 +1,0 @@
-# Terra Toolkit Upgrade Guide v5.0.0
-This document will provide information on upgrading from terra-toolkit 4.x to 5.0.0.
-
-### Dependencies Updates
-The following dependencies were removed from Terra toolkit:
-
-- lerna

--- a/docs/TerraToolkitUpgradeGuide-v5.0.0.md
+++ b/docs/TerraToolkitUpgradeGuide-v5.0.0.md
@@ -1,0 +1,7 @@
+# Terra Toolkit Upgrade Guide v5.0.0
+This document will provide information on upgrading from terra-toolkit 4.x to 5.0.0.
+
+### Dependencies Updates
+The following dependencies were removed from Terra toolkit:
+
+- lerna

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "fs-extra": "^6.0.1",
     "glob": "^7.1.1",
     "ip": "^1.1.5",
-    "lerna": "^2.8.0",
     "load-json-file": "^5.0.0",
     "lodash.startcase": "^4.4.0",
     "memory-fs": "^0.4.1",


### PR DESCRIPTION
### Summary
Use glob instead for creating suites for mono-repo testing / Travis builds 