### PR TITLE
Don't search for en locale if the en-us is in the options locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Unreleased
 ### Changed
 * Switch back to using webpack-dev-server for tt-serve due to webpack deprecating webpack-serve in favor of webpack-dev-server.
 
+* Prevent en from being injected into aggregate-translations when en-US locale is passed
 
 4.13.0 - (October 8, 2018)
 ----------

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,6 +13,7 @@ Cerner Corporation
 - Noah Benham [@noahbenham]
 - Ben Boersma [@BenBoersma]
 - Daniel Vu [@dv297]
+- Cory McDonald [@corymcdonald]
 
 [@emilyrohrbough]: https://github.com/emilyrohrbough
 [@brettjankord]: https://github.com/bjankord
@@ -27,3 +28,4 @@ Cerner Corporation
 [@noahbenham]: https://github.com/noahbenham
 [@BenBoersma]: https://github.com/BenBoersma
 [@dvv297]: https://github.com/dv297
+[@corymcdonald]: https://github.com/corymcdonald

--- a/scripts/aggregate-translations/aggregate-translations.js
+++ b/scripts/aggregate-translations/aggregate-translations.js
@@ -43,7 +43,7 @@ const defaults = (options = {}) => {
     outputDir: options.outputDir || './aggregated-translations',
   };
 
-  if (!defaultConfig.locales.includes('en')) {
+  if (!defaultConfig.locales.includes('en') || !defaultConfig.locales.includes('en-US')) {
     defaultConfig.locales.push('en');
   }
 


### PR DESCRIPTION
### Summary
I get the following errors when I run webpack compile from std err

```sh
There was an error reading your translations file /Users/cory/repos/hi_console/app/javascript/bundles/translations/en.json.
 Exception Message: ENOENT: no such file or directory, open '/Users/cory/repos/hi_console/app/javascript/bundles/translations/en.json' 

There was an error reading your translations file /Users/cory/repos/hi_console/node_modules/@healtheintent/console-ui/translations/en.json.
 Exception Message: ENOENT: no such file or directory, open '/Users/cory/repos/hi_console/node_modules/@healtheintent/console-ui/translations/en.json' 

There was an error reading your translations file /Users/cory/repos/hi_console/node_modules/tenant-console-ui/translations/en.json.
 Exception Message: ENOENT: no such file or directory, open '/Users/cory/repos/hi_console/node_modules/tenant-console-ui/translations/en.json' 

There was an error reading your translations file /Users/cory/repos/hi_console/node_modules/terra-i18n/tests/jest/fixtures/translations/en-US.json.
 Exception Message: ENOENT: no such file or directory, open '/Users/cory/repos/hi_console/node_modules/terra-i18n/tests/jest/fixtures/translations/en-US.json' 
```

3/4 of the messages are there because the default options checks to see if there is an en locale in the options and will inject en if it's not present. 

--

@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
