### PR TITLE
 Update test suite determination logic

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -26,4 +26,5 @@ Cerner Corporation
 [@alex-bezek]: https://github.com/alex-bezek
 [@noahbenham]: https://github.com/noahbenham
 [@BenBoersma]: https://github.com/BenBoersma
-[@dvv297]: https://github.com/dv297
+[@dv297]: https://github.com/dv297
+[@tb021781]: https://github.com/tb021781

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,7 +13,7 @@ Cerner Corporation
 - Noah Benham [@noahbenham]
 - Ben Boersma [@BenBoersma]
 - Daniel Vu [@dv297]
-- Tyler Biethman [@tb021781]
+- Tyler Biethman [@tbiethman]
 
 [@emilyrohrbough]: https://github.com/emilyrohrbough
 [@brettjankord]: https://github.com/bjankord
@@ -28,4 +28,4 @@ Cerner Corporation
 [@noahbenham]: https://github.com/noahbenham
 [@BenBoersma]: https://github.com/BenBoersma
 [@dv297]: https://github.com/dv297
-[@tb021781]: https://github.com/tb021781
+[@tbiethman]: https://github.com/tbiethman

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,6 +13,7 @@ Cerner Corporation
 - Noah Benham [@noahbenham]
 - Ben Boersma [@BenBoersma]
 - Daniel Vu [@dv297]
+- Tyler Biethman [@tb021781]
 
 [@emilyrohrbough]: https://github.com/emilyrohrbough
 [@brettjankord]: https://github.com/bjankord

--- a/config/wdio/wdio.conf.js
+++ b/config/wdio/wdio.conf.js
@@ -79,14 +79,14 @@ if (hasPackages) {
 
   const numberOfPackagesWithTests = packageLocationsWithTests.length;
   if (numberOfPackagesWithTests > 0) {
-    const numberOfSuites = 4;
+    const numberOfSuites = Math.min(numberOfPackagesWithTests, 4);
     config.suites = {};
     [...Array(numberOfSuites)].forEach((_, index) => {
       config.suites[`suite${index + 1}`] = [];
     });
-    const itemsPerSuite = Math.ceil(numberOfPackagesWithTests / numberOfSuites);
+
     packageLocationsWithTests.forEach((packageLocation, index) => {
-      const currentSuite = `suite${Math.floor(index / itemsPerSuite) + 1}`;
+      const currentSuite = `suite${index % numberOfSuites + 1}`;
       config.suites[currentSuite] = config.suites[currentSuite].concat(packageLocation);
     });
   }

--- a/config/wdio/wdio.conf.js
+++ b/config/wdio/wdio.conf.js
@@ -86,7 +86,7 @@ if (hasPackages) {
     });
 
     packageLocationsWithTests.forEach((packageLocation, index) => {
-      const currentSuite = `suite${index % numberOfSuites + 1}`;
+      const currentSuite = `suite${(index % numberOfSuites) + 1}`;
       config.suites[currentSuite] = config.suites[currentSuite].concat(packageLocation);
     });
   }


### PR DESCRIPTION
### Summary
The existing logic has a couple holes that cause builds to fail (e.g. having 9 packages causes suite4 to always be empty). The new expression should always ensure every suite has at least one test set. 

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
