### PR TITLE
Fix Serve CLI Port Arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Fixed
+* Cast serve-cli port value to be a number to prevent NaN from being passed as the port value for the server. 
 
 4.15.0 - (October 23, 2018)
 ----------

--- a/scripts/serve/serve-cli.js
+++ b/scripts/serve/serve-cli.js
@@ -9,7 +9,7 @@ commander
   .version(packageJson.version)
   .option('--config <path>', 'The webpack config to serve.', undefined)
   .option('--host <s>', 'Sets the host that the server will listen on. eg. \'10.10.10.1\'', '0.0.0.0')
-  .option('--port <n>', 'The port the server should listen on.', parseInt, 8080)
+  .option('--port <n>', 'The port the server should listen on.', Number(parseInt), 8080)
   .option('-p, --production', 'Passes the -p flag to the webpack config')
   .parse(process.argv);
 


### PR DESCRIPTION
### Summary
When using the serve-cli, the port gets passed as string but the commandar module assumes the passed cli port value should be a number due to the default being 8080. This caused NaN to be passed for the port value, thus the server would fail to start. 

### Test
Pull branch & run `npm run start -- --port 9090`