### PR TITLE
Add Webpack Mode in Serve-Static Logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Chanded
+* Give more info on webpack mode in serve-static startup
 
 4.15.0 - (October 23, 2018)
 ----------

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "release:minor": "node scripts/release/release.js minor",
     "release:patch": "node scripts/release/release.js patch",
     "start": "node scripts/serve/serve-cli.js --config ./tests/test.config",
+    "start-static": "node scripts/serve/serve-static-cli.js --config ./tests/test.config",
     "test": "npm run jest && npm run nightwatch && npm run nightwatch:port-provided && npm run wdio",
     "wdio": "npm run wdio-webpack-obj && npm run wdio-webpack-func && npm run tt-wdio-webpack-obj && npm run tt-wdio-webpack-func && npm run tt-wdio-unopinionated",
     "wdio-webpack-obj": "wdio --suite opinionated",

--- a/scripts/serve/serve-static.js
+++ b/scripts/serve/serve-static.js
@@ -14,7 +14,6 @@ const compile = (webpackConfig, disk) => (
     if (!disk) {
       compiler.outputFileSystem = new MemoryFS();
     }
-    console.log(webpackConfig.mode);
     console.log('[Terra-Toolkit:serve-static] Starting Webpack compilation');
     compiler.run((err, stats) => {
       if (err || stats.hasErrors()) {

--- a/scripts/serve/serve-static.js
+++ b/scripts/serve/serve-static.js
@@ -14,16 +14,17 @@ const compile = (webpackConfig, disk) => (
     if (!disk) {
       compiler.outputFileSystem = new MemoryFS();
     }
-    console.log('[Terra-Toolkit:serve-static] Webpack compilation started');
+    console.log(webpackConfig.mode);
+    console.log('[Terra-Toolkit:serve-static] Starting Webpack compilation');
     compiler.run((err, stats) => {
       if (err || stats.hasErrors()) {
-        console.log('[Terra-Toolkit:serve-static] Webpack compiled unsuccessfully');
+        console.log(`[Terra-Toolkit:serve-static] Webpack failed to compile in ${webpackConfig.mode} mode`);
         reject(err || new Error(stats.toJson().errors));
       } else {
         if (stats.hasWarnings()) {
           console.warn(stats.toJson().warnings);
         }
-        console.log('[Terra-Toolkit:serve-static] Webpack compiled successfully');
+        console.log(`[Terra-Toolkit:serve-static] Webpack compiled successfully in ${webpackConfig.mode} mode`);
         resolve([webpackConfig.output.path, compiler.outputFileSystem]);
       }
     });


### PR DESCRIPTION
### Summary
Add which webpack mode in used for serve-static logs so consumers know what mode webpack packed assets in. Maybe this will help take away the mystery that wdio tests run in production mode??