### PR TITLE
Add Site Wdio Configuration Key

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@ lib
 node_modules
 build
 reports
+**/coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@ Changelog
 
 Unreleased
 ----------
-### Chanded
+### Added
+* Added `site` wdio configuration option such that a relative path to a static site can used in the ServeStatic service. This options can be utilized to speed up tt-wdio runs by removing duplicated webpack compilation.
+
+### Changed
 * Give more info on webpack mode in serve-static startup
 
 4.15.0 - (October 23, 2018)

--- a/README.md
+++ b/README.md
@@ -8,11 +8,10 @@
   Terra Toolkit
 </h1>
 
-[![Cerner OSS](https://img.shields.io/badge/Cerner-OSS-blue.svg?style=flat)](http://engineering.cerner.com/2014/01/cerner-and-open-source/)
-[![NPM version](http://img.shields.io/npm/v/terra-toolkit.svg)](https://www.npmjs.org/package/terra-toolkit)
-[![Build Status](https://travis-ci.org/cerner/terra-toolkit.svg?branch=master)](https://travis-ci.org/cerner/terra-toolkit)
-[![Dependencies status](https://david-dm.org/cerner/terra-toolkit/status.svg)](https://david-dm.org/cerner/terra-toolkit)
-[![devDependencies status](https://david-dm.org/cerner/terra-toolkit/dev-status.svg)](https://david-dm.org/cerner/terra-toolkit?type=dev)
+[![Cerner OSS](https://badgen.net/badge/Cerner/OSS/blue)](http://engineering.cerner.com/2014/01/cerner-and-open-source/)
+[![License](https://badgen.net/github/license/cerner/terra-toolkit)](https://github.com/cerner/terra-toolkit/blob/master/LICENSE)
+[![Build Status](https://badgen.net/travis/cerner/terra-toolkit)](https://travis-ci.org/cerner/terra-toolkit)
+[![devDependencies status](https://badgen.net/david/dev/cerner/terra-toolkit)](https://david-dm.org/cerner/terra-toolkit?type=dev)
 
 Terra Toolkit is a utility module used to facilitate independent development of Terra projects. This toolkit provides build scripts, configurations, and Webdriver Services needed to serve assets, compile webpack, and run webdriver.io tests to streamline development of npm packages. [terra-core][@terra-core], [terra-clinical][@terra-clinical], and [terra-framework][@terra-framework] are a few examples repos which are utilizing the utilities offered in this package, while [terra-dev-site][@terra-dev-site] is a repo that extends the configurations offered by toolkit.
 

--- a/docs/ServeStaticService.md
+++ b/docs/ServeStaticService.md
@@ -6,6 +6,7 @@ Serve-static Service is provided as a convenience to start an express server and
 | Name  | Required | Default Value | Description |
 | ------------- | ------------- | ------------- | ------------- |
 | **webpackConfig**  | true | `undefined` | The webpack configuration used to start the express server. |
+| **site**  | false | `undefined` | The relative path to the static site used to start the express server. This takes precidence over webpack config if both are passed. |
 | **serveStatic**  | false | `{ index: 'index.html', port: '8080' }` | The serveStatic configuration to be passed to the service. The only options are index and port. |
 
 ```js

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
       "integrity": "sha512-TnuzjE880qbknEFAVqEr3VeOcE0yXo0kJEW+EK8TASpzMbykKCydei6WUmDSV3bq7aI+llkMrBYes1kIjpU7fA==",
       "dev": true,
       "requires": {
-        "before-after-hook": "1.1.0",
+        "before-after-hook": "1.2.0",
         "btoa-lite": "1.0.0",
         "debug": "3.2.6",
         "http-proxy-agent": "2.1.0",
@@ -331,13 +331,10 @@
       }
     },
     "acorn-jsx": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-4.1.1.tgz",
-      "integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
-      "dev": true,
-      "requires": {
-        "acorn": "5.7.3"
-      }
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.0.tgz",
+      "integrity": "sha512-XkB50fn0MURDyww9+UYL3c1yLbOBz0ZFvrdYlGB8l+Ije1oSC75qAqrzSPjYQbdnQUzhlUGNKuesryAv0gxZOg==",
+      "dev": true
     },
     "acorn-walk": {
       "version": "6.1.0",
@@ -701,7 +698,7 @@
       "integrity": "sha512-PLWJN3Xo/rycNkx+mp8iBDMTm3FeWe4VmYaZDSqL5QQB9sLsQkG5k8n+LNDFnhh9kdq2K+egL/icpctOmDHwig==",
       "requires": {
         "browserslist": "3.2.8",
-        "caniuse-lite": "1.0.30000898",
+        "caniuse-lite": "1.0.30000903",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "6.0.23",
@@ -1885,9 +1882,9 @@
       }
     },
     "before-after-hook": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.1.0.tgz",
-      "integrity": "sha512-VOMDtYPwLbIncTxNoSzRyvaMxtXmLWLUqr8k5AfC1BzLk34HvBXaQX8snOwQZ4c0aX8aSERqtJSiI9/m2u5kuA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.2.0.tgz",
+      "integrity": "sha512-wI3QtdLppHNkmM1VgRVLCrlWCKk/YexlPicYbXPs4eYdd1InrUCTFsx5bX1iUQzzMsoRXXPpM1r+p7JEJJydag==",
       "dev": true
     },
     "big.js": {
@@ -2125,8 +2122,8 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
       "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
       "requires": {
-        "caniuse-lite": "1.0.30000898",
-        "electron-to-chromium": "1.3.80"
+        "caniuse-lite": "1.0.30000903",
+        "electron-to-chromium": "1.3.82"
       }
     },
     "browserslist-config-terra": {
@@ -2370,7 +2367,7 @@
       "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000898",
+        "caniuse-db": "1.0.30000903",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       },
@@ -2380,21 +2377,21 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "1.0.30000898",
-            "electron-to-chromium": "1.3.80"
+            "caniuse-db": "1.0.30000903",
+            "electron-to-chromium": "1.3.82"
           }
         }
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000898",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000898.tgz",
-      "integrity": "sha512-i8WfgaYakyxHs5kmITs/XHjrdm7QsuuFmI5cE43I0pJ0NIJpe52t2Rz6mliG8yyu1NMXjNceC7udWdiQuA5hUA=="
+      "version": "1.0.30000903",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000903.tgz",
+      "integrity": "sha512-x3npiIhv0zDc5qAj+r4rByMETsz2XkukPFsVWzwyY5r5h63XoO8msj9D65BqeNt1aBn17fsBnDDP78yFM/OAqA=="
     },
     "caniuse-lite": {
-      "version": "1.0.30000898",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000898.tgz",
-      "integrity": "sha512-ytlTZqO4hYe4rNAJhMynUAIUI33jsP2Bb1two/9OVC39wZjPZ8exIO0eCLw5mqAtegOGiGF0kkTWTn3B02L+mw=="
+      "version": "1.0.30000903",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000903.tgz",
+      "integrity": "sha512-T1XVJEpGCoaq7MDw7/6hCdYUukmSaS+1l/OQJkLtw7Cr2+/+d67tNGKEbyiqf7Ck8x6EhNFUxjYFXXka0N/w5g=="
     },
     "capture-exit": {
       "version": "1.2.0",
@@ -3060,14 +3057,14 @@
       "integrity": "sha512-wovHgjAx8ZIMGSL8pTys7edA1ClmzxHeY6n/d97gg5odgsxEgKjULPR0viqyC+FWMCL9sfqoC/QCUBo62tLvPg==",
       "requires": {
         "babel-code-frame": "6.26.0",
-        "css-selector-tokenizer": "0.7.0",
+        "css-selector-tokenizer": "0.7.1",
         "cssnano": "3.10.0",
         "icss-utils": "2.1.0",
         "loader-utils": "1.1.0",
         "lodash.camelcase": "4.3.0",
         "object-assign": "4.1.1",
         "postcss": "5.2.18",
-        "postcss-modules-extract-imports": "1.2.0",
+        "postcss-modules-extract-imports": "1.2.1",
         "postcss-modules-local-by-default": "1.2.0",
         "postcss-modules-scope": "1.1.0",
         "postcss-modules-values": "1.3.0",
@@ -3151,12 +3148,12 @@
       }
     },
     "css-selector-tokenizer": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
-      "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.1.tgz",
+      "integrity": "sha512-xYL0AMZJ4gFzJQsHUKa5jiWWi2vH77WVNg7JYRyewwj6oPh4yb/y6Y9ZCw9dsj/9UauMhtuxR+ogQd//EdEVNA==",
       "requires": {
         "cssesc": "0.1.0",
-        "fastparse": "1.1.1",
+        "fastparse": "1.1.2",
         "regexpu-core": "1.0.0"
       }
     },
@@ -3226,7 +3223,7 @@
           "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
           "requires": {
             "browserslist": "1.7.7",
-            "caniuse-db": "1.0.30000898",
+            "caniuse-db": "1.0.30000903",
             "normalize-range": "0.1.2",
             "num2fraction": "1.2.2",
             "postcss": "5.2.18",
@@ -3238,8 +3235,8 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "1.0.30000898",
-            "electron-to-chromium": "1.3.80"
+            "caniuse-db": "1.0.30000903",
+            "electron-to-chromium": "1.3.82"
           }
         },
         "chalk": {
@@ -3438,9 +3435,9 @@
       "dev": true
     },
     "data-urls": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.1.tgz",
-      "integrity": "sha512-0HdcMZzK6ubMUnsMmQmG0AcLQPvbvb47R0+7CCZQCYgcd8OUWG91CG7sM6GoXgjz+WLl4ArFzHtBMy/QqSF4eg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+      "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
       "dev": true,
       "requires": {
         "abab": "2.0.0",
@@ -3935,9 +3932,9 @@
       "integrity": "sha512-GJCAeDBKfREgkBtgrYSf9hQy9kTb3helv0zGdzqhM7iAkW8FA/ZF97VQDbwFiwIT8MQLLOe5VlPZOEvZAqtUAQ=="
     },
     "electron-to-chromium": {
-      "version": "1.3.80",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.80.tgz",
-      "integrity": "sha512-WClidEWEUNx7OfwXehB0qaxCuetjbKjev2SmXWgybWPLKAThBiMTF/2Pd8GSUDtoGOavxVzdkKwfFAPRSWlkLw=="
+      "version": "1.3.82",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.82.tgz",
+      "integrity": "sha512-NI4nB2IWGcU4JVT1AE8kBb/dFor4zjLHMLsOROPahppeHrR0FG5uslxMmkp/thO1MvPjM2xhlKoY29/I60s0ew=="
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -3999,9 +3996,9 @@
       "dev": true
     },
     "envinfo": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-5.10.0.tgz",
-      "integrity": "sha512-rXbzXWvnQxy+TcqZlARbWVQwgGVVouVJgFZhLVN5htjLxl1thstrP2ZGi0pXC309AbK7gVOPU+ulz/tmpCI7iw=="
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-5.11.0.tgz",
+      "integrity": "sha512-NnWUQbKHZSG5rJSUn18+K6l1gh8jG67xQR1gt9v1rcHf2MEOPKAMzk37Ii/Va9MHWJ/RlLCzPFU/TXvlQydp6Q=="
     },
     "errno": {
       "version": "0.1.7",
@@ -4106,9 +4103,9 @@
       }
     },
     "eslint": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.7.0.tgz",
-      "integrity": "sha512-zYCeFQahsxffGl87U2aJ7DPyH8CbWgxBC213Y8+TCanhUTf2gEvfq3EKpHmEcozTLyPmGe9LZdMAwC/CpJBM5A==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.8.0.tgz",
+      "integrity": "sha512-Zok6Bru3y2JprqTNm14mgQ15YQu/SMDkWdnmHfFg770DIUlmMFd/gqqzCHekxzjHZJxXv3tmTpH0C1icaYJsRQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.0.0",
@@ -4120,7 +4117,7 @@
         "eslint-scope": "4.0.0",
         "eslint-utils": "1.3.1",
         "eslint-visitor-keys": "1.0.0",
-        "espree": "4.0.0",
+        "espree": "4.1.0",
         "esquery": "1.0.1",
         "esutils": "2.0.2",
         "file-entry-cache": "2.0.0",
@@ -4388,20 +4385,20 @@
       "dev": true,
       "requires": {
         "@babel/runtime": "7.1.2",
-        "browserslist": "4.3.2",
-        "caniuse-db": "1.0.30000898",
+        "browserslist": "4.3.4",
+        "caniuse-db": "1.0.30000903",
         "mdn-browser-compat-data": "0.0.53"
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.2.tgz",
-          "integrity": "sha512-wgZJWlYcDvsjRtf8socmAHf1nXq88KrQLB/gMYHGPUc2bzPWsgltSXwPWYHx4Sw0G9E/XGNW5wJDaWlpHRMpjA==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.4.tgz",
+          "integrity": "sha512-u5iz+ijIMUlmV8blX82VGFrB9ecnUg5qEt55CMZ/YJEhha+d8qpBfOFuutJ6F/VKRXjZoD33b6uvarpPxcl3RA==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "1.0.30000898",
-            "electron-to-chromium": "1.3.80",
-            "node-releases": "1.0.0-alpha.14"
+            "caniuse-lite": "1.0.30000903",
+            "electron-to-chromium": "1.3.82",
+            "node-releases": "1.0.2"
           }
         }
       }
@@ -4550,13 +4547,22 @@
       "dev": true
     },
     "espree": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-4.0.0.tgz",
-      "integrity": "sha512-kapdTCt1bjmspxStVKX6huolXVV5ZfyZguY1lcfhVVZstce3bqxH9mcLzNn3/mlgW6wQ732+0fuG9v7h0ZQoKg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
+      "integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
       "dev": true,
       "requires": {
-        "acorn": "5.7.3",
-        "acorn-jsx": "4.1.1"
+        "acorn": "6.0.2",
+        "acorn-jsx": "5.0.0",
+        "eslint-visitor-keys": "1.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.2.tgz",
+          "integrity": "sha512-GXmKIvbrN3TV7aVqAzVFaMW8F8wzVX7voEBRO3bDA64+EX37YSayggRJP5Xig6HYHBkWKpFg9W5gg6orklubhg==",
+          "dev": true
+        }
       }
     },
     "esprima": {
@@ -4629,7 +4635,7 @@
       "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
       "dev": true,
       "requires": {
-        "merge": "1.2.0"
+        "merge": "1.2.1"
       }
     },
     "execa": {
@@ -4721,7 +4727,7 @@
           "requires": {
             "is-number": "2.1.0",
             "isobject": "2.1.0",
-            "randomatic": "3.1.0",
+            "randomatic": "3.1.1",
             "repeat-element": "1.1.3",
             "repeat-string": "1.6.1"
           }
@@ -4949,9 +4955,9 @@
       "dev": true
     },
     "fastparse": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
-      "integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
+      "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ=="
     },
     "faye-websocket": {
       "version": "0.10.0",
@@ -4972,7 +4978,7 @@
     },
     "fibers": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/fibers/-/fibers-2.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/fibers/-/fibers-2.0.2.tgz",
       "integrity": "sha512-HfVRxhYG7C8Jl9FqtrlElMR2z/8YiLQVDKf67MLY25Ic+ILx3ecmklfT1v3u+7P5/4vEFjuxaAFXhr2/Afwk5g==",
       "optional": true
     },
@@ -5166,9 +5172,9 @@
       "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I="
     },
     "flow-parser": {
-      "version": "0.83.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.83.0.tgz",
-      "integrity": "sha512-L+8CQhekf9FJOr1cqH3G6bvBfCVt8uvKzZq25nwOymJeQChU4P8g6Iwb2rOytan//6dd3ptUL8BzLXS+DvzpTg=="
+      "version": "0.85.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.85.0.tgz",
+      "integrity": "sha512-oMmkfBX/ku7j9KCiog0tP7e0hFou5cZM/RywCOluioz10ZC9b0dFjxrkVscUHgKcQfz2i39EtnUKkm9M8Qo+Fg=="
     },
     "flush-write-stream": {
       "version": "1.0.3",
@@ -5699,6 +5705,14 @@
           "bundled": true,
           "optional": true
         },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -5706,14 +5720,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {
@@ -6294,7 +6300,7 @@
         },
         "fast-deep-equal": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
           "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
         },
         "json-schema-traverse": {
@@ -6403,7 +6409,8 @@
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "optional": true
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -6468,15 +6475,15 @@
       "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
     },
     "html-minifier": {
-      "version": "3.5.20",
-      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.20.tgz",
-      "integrity": "sha512-ZmgNLaTp54+HFKkONyLFEfs5dd/ZOtlquKaTnqIWFmx3Av5zG6ZPcV2d0o9XM2fXOTxxIf6eDcwzFFotke/5zA==",
+      "version": "3.5.21",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz",
+      "integrity": "sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==",
       "dev": true,
       "requires": {
         "camel-case": "3.0.0",
         "clean-css": "4.2.1",
         "commander": "2.17.1",
-        "he": "1.1.1",
+        "he": "1.2.0",
         "param-case": "2.1.1",
         "relateurl": "0.2.7",
         "uglify-js": "3.4.9"
@@ -6486,6 +6493,12 @@
           "version": "2.17.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
           "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+          "dev": true
+        },
+        "he": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+          "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
           "dev": true
         },
         "uglify-js": {
@@ -6506,7 +6519,7 @@
       "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
       "dev": true,
       "requires": {
-        "html-minifier": "3.5.20",
+        "html-minifier": "3.5.21",
         "loader-utils": "0.2.17",
         "lodash": "4.17.11",
         "pretty-error": "2.1.1",
@@ -6651,7 +6664,7 @@
       "requires": {
         "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
-        "sshpk": "1.15.1"
+        "sshpk": "1.15.2"
       }
     },
     "https-browserify": {
@@ -8524,7 +8537,7 @@
         "babel-register": "6.26.0",
         "babylon": "7.0.0-beta.47",
         "colors": "1.1.2",
-        "flow-parser": "0.83.0",
+        "flow-parser": "0.85.0",
         "lodash": "4.17.11",
         "micromatch": "2.3.11",
         "neo-async": "2.6.0",
@@ -8629,7 +8642,7 @@
         "array-equal": "1.0.0",
         "cssom": "0.3.4",
         "cssstyle": "1.1.1",
-        "data-urls": "1.0.1",
+        "data-urls": "1.1.0",
         "domexception": "1.0.1",
         "escodegen": "1.11.0",
         "html-encoding-sniffer": "1.0.2",
@@ -9726,9 +9739,9 @@
       }
     },
     "merge": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
       "dev": true
     },
     "merge-descriptors": {
@@ -10349,9 +10362,9 @@
       }
     },
     "node-releases": {
-      "version": "1.0.0-alpha.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.0-alpha.14.tgz",
-      "integrity": "sha512-G8nnF9cP9QPP/jUmYWw/uUUhumHmkm+X/EarCugYFjYm2uXRMFeOD6CVT3RLdoyCvDUNy51nirGfUItKWs/S1g==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.2.tgz",
+      "integrity": "sha512-zP8Asfg13lG9KDAW85rylSxXBYvaSdtjMIYKHUk8c1fM8drmFwRqbSYKYD+UlNVPUvrceSvgLUKHMOWR5jPWQg==",
       "dev": true,
       "requires": {
         "semver": "5.6.0"
@@ -12048,8 +12061,8 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "1.0.30000898",
-            "electron-to-chromium": "1.3.80"
+            "caniuse-db": "1.0.30000903",
+            "electron-to-chromium": "1.3.82"
           }
         },
         "chalk": {
@@ -12369,9 +12382,9 @@
       }
     },
     "postcss-modules-extract-imports": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.0.tgz",
-      "integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.1.tgz",
+      "integrity": "sha512-6jt9XZwUhwmRUhb/CkyJY020PYaPJsCyt3UjbaWo6XEbH/94Hmv6MP7fG2C5NDU/BcHzyGYxNtHvM+LTf9HrYw==",
       "requires": {
         "postcss": "6.0.23"
       }
@@ -12381,7 +12394,7 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
       "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
       "requires": {
-        "css-selector-tokenizer": "0.7.0",
+        "css-selector-tokenizer": "0.7.1",
         "postcss": "6.0.23"
       }
     },
@@ -12390,7 +12403,7 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
       "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
       "requires": {
-        "css-selector-tokenizer": "0.7.0",
+        "css-selector-tokenizer": "0.7.1",
         "postcss": "6.0.23"
       }
     },
@@ -13273,9 +13286,9 @@
       }
     },
     "randomatic": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
-      "integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+      "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
       "requires": {
         "is-number": "4.0.0",
         "kind-of": "6.0.2",
@@ -13566,7 +13579,7 @@
     },
     "regjsgen": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
       "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
     },
     "regjsparser": {
@@ -13854,7 +13867,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "0.1.15"
@@ -14385,7 +14398,7 @@
       "integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
       "requires": {
         "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.1"
+        "spdx-license-ids": "3.0.2"
       }
     },
     "spdx-exceptions": {
@@ -14399,13 +14412,13 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "requires": {
         "spdx-exceptions": "2.2.0",
-        "spdx-license-ids": "3.0.1"
+        "spdx-license-ids": "3.0.2"
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz",
-      "integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
+      "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg=="
     },
     "spdy": {
       "version": "3.4.7",
@@ -14448,9 +14461,9 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.1.tgz",
-      "integrity": "sha512-mSdgNUaidk+dRU5MhYtN9zebdzF2iG0cNPWy8HG+W8y+fT1JnSkh0fzzpjOa0L7P8i1Rscz38t0h4gPcKz43xA==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
+      "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
       "requires": {
         "asn1": "0.2.4",
         "assert-plus": "1.0.0",
@@ -14567,6 +14580,14 @@
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -14609,14 +14630,6 @@
         "strip-ansi": "3.0.1"
       }
     },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "requires": {
-        "safe-buffer": "5.1.2"
-      }
-    },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -14651,7 +14664,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-indent": {
@@ -15705,9 +15718,9 @@
       }
     },
     "webdriverio": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-4.13.2.tgz",
-      "integrity": "sha512-FiUcNaW21DEDgazzGJ1nN4ByWP2OZyY31Xy6+DENPgIvK03VHfuKlV6eBdurumGmpMnS0571SRO/13ajPavKJQ==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-4.14.0.tgz",
+      "integrity": "sha512-642Iqp9en2hvuVINkTfQvWoQCaLb6zJyLHgQFUFLx7s+8l8GnrHzMjkv5DbecZHwnBkhybpphbTW7k0B2ARH5A==",
       "requires": {
         "archiver": "2.1.1",
         "babel-runtime": "6.26.0",
@@ -15877,7 +15890,7 @@
             "babel-register": "6.26.0",
             "babylon": "6.18.0",
             "colors": "1.1.2",
-            "flow-parser": "0.83.0",
+            "flow-parser": "0.85.0",
             "lodash": "4.17.11",
             "micromatch": "2.3.11",
             "node-dir": "0.1.8",
@@ -15938,7 +15951,7 @@
         "cross-spawn": "6.0.5",
         "diff": "3.5.0",
         "enhanced-resolve": "4.1.0",
-        "envinfo": "5.10.0",
+        "envinfo": "5.11.0",
         "glob-all": "3.1.0",
         "global-modules": "1.0.0",
         "got": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "lint": "eslint --ext .js,.jsx .",
     "nightwatch": "nightwatch",
     "nightwatch:port-provided": "nightwatch -c tests/test.nightwatch.conf.js",
+    "pack": "webpack --config tests/test.config.js",
     "prepare": "npm run compile",
     "prepublishOnly": "npm test",
     "pretest": "npm run lint",
@@ -62,7 +63,7 @@
     "wdio-webpack-func": "TT_TEST_WDIO_FUNCTION=true wdio --suite opinionated",
     "tt-wdio-webpack-obj": "node scripts/wdio/wdio-runner-cli.js --suite opinionated",
     "tt-wdio-webpack-func": "TT_TEST_WDIO_FUNCTION=true node scripts/wdio/wdio-runner-cli.js --suite opinionated",
-    "tt-wdio-unopinionated": "node scripts/wdio/wdio-runner-cli.js --formFactors=['tiny','huge'] --locales=['en','fr'] --suite unopinionated"
+    "tt-wdio-unopinionated": "npm run pack; node scripts/wdio/wdio-runner-cli.js --formFactors=['tiny','huge'] --locales=['en','fr'] --suite unopinionated; rm -rf ./build"
   },
   "dependencies": {
     "async": "^2.5.0",

--- a/scripts/serve/serve-static.js
+++ b/scripts/serve/serve-static.js
@@ -39,7 +39,8 @@ const generateSite = (site, config, disk, production) => {
     if (fse.existsSync(sitePath) && fse.lstatSync(sitePath).isDirectory()) {
       return Promise.resolve([sitePath, disk]);
     }
-    console.log(`[Terra-Toolkit:serve-static] Could not serve static site from ${sitePath}. Attempting to use webpack configuration.`);
+
+    return Promise.reject(new Error(`[Terra-Toolkit:serve-static] Could not serve static site from ${sitePath}.`));
   }
 
   if (config) {
@@ -54,9 +55,7 @@ const generateSite = (site, config, disk, production) => {
       webpackConfig.output = Object.assign({}, webpackConfig.output, { path: '/dist' });
     }
 
-    // allow compile() to determine the output file system to ensure compilation since webpack-dev-server is opinioned on the fs methods required
-    const outputFileSystem = site ? undefined : disk;
-    return compile(webpackConfig, outputFileSystem);
+    return compile(webpackConfig, disk);
   }
 
   return Promise.reject(new Error('[Terra-Toolkit:serve-static] No webpack configuration provided.'));

--- a/scripts/serve/serve-static.js
+++ b/scripts/serve/serve-static.js
@@ -34,7 +34,7 @@ const compile = (webpackConfig, disk) => (
 const generateSite = (site, config, disk, production) => {
   if (site) {
     const sitePath = path.join(process.cwd(), site);
-    return Promise.resolve([sitePath, undefined]);
+    return Promise.resolve([sitePath, disk]);
   }
 
   if (config) {

--- a/scripts/serve/serve-static.js
+++ b/scripts/serve/serve-static.js
@@ -37,7 +37,8 @@ const generateSite = (site, config, disk, production) => {
     const sitePath = path.join(process.cwd(), site);
 
     if (fse.existsSync(sitePath) && fse.lstatSync(sitePath).isDirectory()) {
-      return Promise.resolve([sitePath, disk]);
+      const fileSystem = disk ? fse : undefined;
+      return Promise.resolve([sitePath, fileSystem]);
     }
 
     return Promise.reject(new Error(`[Terra-Toolkit:serve-static] Could not serve static site from ${sitePath}.`));
@@ -76,7 +77,6 @@ const setSiteLocale = (fileContent, locale) => {
 
   return content.replace(/<html/, `<html ${langLocale}`);
 };
-
 
 // Setup an app server that reads from a filesystem.
 const virtualApp = (site, index, locale, fs, verbose) => {

--- a/scripts/serve/serve-static.js
+++ b/scripts/serve/serve-static.js
@@ -54,6 +54,7 @@ const generateSite = (site, config, disk, production) => {
       webpackConfig.output = Object.assign({}, webpackConfig.output, { path: '/dist' });
     }
 
+    // all compile to determine the output file system to ensure compilation since webpack-dev-server is opinioned on the fs methods required
     const outputFileSystem = site ? undefined : disk;
     return compile(webpackConfig, outputFileSystem);
   }

--- a/scripts/serve/serve-static.js
+++ b/scripts/serve/serve-static.js
@@ -54,7 +54,7 @@ const generateSite = (site, config, disk, production) => {
       webpackConfig.output = Object.assign({}, webpackConfig.output, { path: '/dist' });
     }
 
-    // all compile to determine the output file system to ensure compilation since webpack-dev-server is opinioned on the fs methods required
+    // allow compile() to determine the output file system to ensure compilation since webpack-dev-server is opinioned on the fs methods required
     const outputFileSystem = site ? undefined : disk;
     return compile(webpackConfig, outputFileSystem);
   }

--- a/scripts/serve/serve.js
+++ b/scripts/serve/serve.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 const WebpackDevServer = require('webpack-dev-server');
-const Webpack = require('webpack');
+const webpack = require('webpack');
 
 // Create a webpack dev server instance.
 const server = (options) => {
@@ -29,7 +29,7 @@ const server = (options) => {
   }
 
   // get a compiler
-  const compiler = Webpack(config);
+  const compiler = webpack(config);
   // get a server
   const devServer = new WebpackDevServer(compiler, devServerOptions);
 

--- a/scripts/wdio/README.md
+++ b/scripts/wdio/README.md
@@ -1,7 +1,7 @@
 # Terra Toolkit Wdio Helpers
 
 ## Wdio Runner
-Terra Toolkit offers its own wdio test runner which runs wdio test runs for specified locales and form factors. This allows for locale test runs that can match parallelized container test runs by synchronously running the wdio for each test run variation. This runner is a replacement for webdriver's bin script `wdio` by directly calling Webdriver's test launcher module for each test variation. Before running this script, it is recommended you pack the static site and add the relative path to the `site` key in the wdio configuration. This would only be desired for locally testing with this script.
+Terra Toolkit offers its own wdio test runner which runs wdio test runs for specified locales and form factors. This allows for locale test runs that can match parallelized container test runs by synchronously running the wdio for each test run variation. This runner is a replacement for webdriver's bin script `wdio` by directly calling Webdriver's test launcher module for each test variation. Before running this script, it is recommended you pack the static site in proeudtion mode and add the relative path to the `site` key in the wdio configuration. This would only be desired for locally testing with this script.
 
 Terra's wdio test runner is available via the `tt-wdio` cli or the `wdio-runner` javascript function.
 
@@ -25,7 +25,8 @@ If no config is supplied to `tt-wdio`, `tt-wdio` will first search for `wdio.con
 In your package.json
 ```JSON
 {
-  "test:wdio": "tt-wdio --config ./wdio.conf.js --locales ['en','es']"
+  "pack": "NODE_ENV=production webpack --config ./webpack.config.js -p",
+  "test:wdio-locally": "npm run pack; tt-wdio --config ./wdio.conf.js --locales ['en','es']; rm -rf ./build"
 }
 ```
 

--- a/scripts/wdio/README.md
+++ b/scripts/wdio/README.md
@@ -1,7 +1,7 @@
 # Terra Toolkit Wdio Helpers
 
 ## Wdio Runner
-Terra Toolkit offers its own wdio test runner which runs wdio test runs for specified locales and form factors. This allows for locale test runs that can match parallelized container test runs by synchronously running the wdio for each test run variation. This runner is a replacement for webdriver's bin script `wdio` by directly calling Webdriver's test launcher module for each test variation.
+Terra Toolkit offers its own wdio test runner which runs wdio test runs for specified locales and form factors. This allows for locale test runs that can match parallelized container test runs by synchronously running the wdio for each test run variation. This runner is a replacement for webdriver's bin script `wdio` by directly calling Webdriver's test launcher module for each test variation. Before running this script, it is recommended you pack the static site and add the relative path to the `site` key in the wdio configuration. This would only be desired for locally testing with this script.
 
 Terra's wdio test runner is available via the `tt-wdio` cli or the `wdio-runner` javascript function.
 

--- a/scripts/wdio/README.md
+++ b/scripts/wdio/README.md
@@ -5,7 +5,7 @@ Terra Toolkit offers its own wdio test runner which runs wdio test runs for spec
 
 Terra's wdio test runner is available via the `tt-wdio` cli or the `wdio-runner` javascript function.
 
-Before running this script, it is recommended you pack the static site in proeudtion mode and add the relative path to the `site` key in the wdio configuration. This would only be desired for locally testing with this script.
+Before running this script, it is recommended you pack the static site in production mode and add the relative path to the `site` key in the wdio configuration. This would only be desired for locally testing with this script.
 
 #### API
 | Name  | Default Value | Description |

--- a/scripts/wdio/README.md
+++ b/scripts/wdio/README.md
@@ -1,9 +1,11 @@
 # Terra Toolkit Wdio Helpers
 
 ## Wdio Runner
-Terra Toolkit offers its own wdio test runner which runs wdio test runs for specified locales and form factors. This allows for locale test runs that can match parallelized container test runs by synchronously running the wdio for each test run variation. This runner is a replacement for webdriver's bin script `wdio` by directly calling Webdriver's test launcher module for each test variation. Before running this script, it is recommended you pack the static site in proeudtion mode and add the relative path to the `site` key in the wdio configuration. This would only be desired for locally testing with this script.
+Terra Toolkit offers its own wdio test runner which runs wdio test runs for specified locales and form factors. This allows for locale test runs that can match parallelized container test runs by synchronously running the wdio for each test run variation. This runner is a replacement for webdriver's bin script `wdio` by directly calling Webdriver's test launcher module for each test variation.
 
 Terra's wdio test runner is available via the `tt-wdio` cli or the `wdio-runner` javascript function.
+
+Before running this script, it is recommended you pack the static site in proeudtion mode and add the relative path to the `site` key in the wdio configuration. This would only be desired for locally testing with this script.
 
 #### API
 | Name  | Default Value | Description |

--- a/scripts/wdio/clean-screenshots.js
+++ b/scripts/wdio/clean-screenshots.js
@@ -40,7 +40,7 @@ const cleanSnapshots = (options) => {
   });
 
   // eslint-disable-next-line no-console
-  console.log('> [Terra-Tookit:wdio-runner] Cleaned screenshot directories');
+  console.log('> [Terra-Tookit:wdio-clean-screenshots] Cleaned screenshot directories');
   if (wdioConfig.logLevel !== 'silent' && removedDirs.length > 0) {
     // eslint-disable-next-line no-console
     console.log(removedDirs);

--- a/src/wdio/services/ServeStaticService.js
+++ b/src/wdio/services/ServeStaticService.js
@@ -1,4 +1,3 @@
-import fse from 'fs-extra';
 import serveStatic from '../../../scripts/serve/serve-static';
 import SERVICE_DEFAULTS from '../../../config/wdio/services.default-config';
 
@@ -27,7 +26,7 @@ export default class ServeStaticService {
     }
 
     const serveOptions = {
-      ...site && { site, disk: fse },
+      ...site && { site, disk: true },
       config: webpackConfig,
       port,
       index,

--- a/tests/test.config.js
+++ b/tests/test.config.js
@@ -47,5 +47,8 @@ module.exports = {
       filename: './i18n.html',
     }),
   ],
+  output: {
+    path: path.join(process.cwd(), 'build'),
+  },
   mode: 'production',
 };

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -1,7 +1,12 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
+const path = require('path');
+const fs = require('fs');
 const wdioConf = require('./config/wdio/wdio.conf');
 const webpackConfigObject = require('./tests/test.config.js');
 const webpackConfigFunction = require('./tests/test.config.func.js');
+
+const site = path.join('./build');
+const siteExists = fs.existsSync(site) && fs.lstatSync(site).isDirectory();
 
 const webpackConfig = process.env.TT_TEST_WDIO_FUNCTION ? webpackConfigFunction : webpackConfigObject;
 
@@ -35,6 +40,8 @@ const config = {
       'tests/wdio/theme-spec.js',
     ],
   },
+  // Static site for ServeStaticService
+  ...siteExists && { site },
 
   // Configuration for ServeStaticService
   webpackConfig,


### PR DESCRIPTION
### Summary
Closes https://github.com/cerner/terra-toolkit/issues/145

Enhanced the serve-static service to accept a relative file path to serve static site assets via a `site` key. Named it site to align with serve-static's existing terminology.

If the site path is invalid, it will attempt to fall back to compiles the webpack config provided. 
