### PR TITLE
Be semantically Correct According to Commander Docs

### DIFF
--- a/scripts/aggregate-translations/aggregate-translations-cli.js
+++ b/scripts/aggregate-translations/aggregate-translations-cli.js
@@ -18,7 +18,7 @@ commander
   .version(i18nPackageJson.version)
   .option('-b, --baseDir [baseDir]', 'The directory to start searching from and to prepend to the output directory', process.cwd())
   .option('-d, --directories [directories]', 'Regex pattern to glob search for translations', addCustomDirectory)
-  .option('-l, --locales <locales>', 'The list of locale codes aggregate on and combine into a single, respective translation file ', parseCLIList, supportedLocales)
+  .option('-l, --locales [locales]', 'The list of locale codes aggregate on and combine into a single, respective translation file ', parseCLIList, supportedLocales)
   .option('-o, --outputDir [outputDir]', 'The output location of the generated configuration file', './aggregated-translations')
   .option('-c, --config [configPath]', 'The path to the terra i18n configuration file', undefined)
   .parse(process.argv);

--- a/scripts/serve/serve-cli.js
+++ b/scripts/serve/serve-cli.js
@@ -7,9 +7,9 @@ const loadWebpackConfig = require('./loadWebpackConfig');
 // Parse process arguments
 commander
   .version(packageJson.version)
-  .option('--config <path>', 'The webpack config to serve.', undefined)
-  .option('--host <s>', 'Sets the host that the server will listen on. eg. \'10.10.10.1\'', '0.0.0.0')
-  .option('--port <n>', 'The port the server should listen on.', Number(parseInt), 8080)
+  .option('--config [path]', 'The webpack config to serve.', undefined)
+  .option('--host [string]', 'Sets the host that the server will listen on. eg. \'10.10.10.1\'', '0.0.0.0')
+  .option('--port [number]', 'The port the server should listen on.', Number(parseInt), 8080)
   .option('-p, --production', 'Passes the -p flag to the webpack config')
   .parse(process.argv);
 

--- a/scripts/serve/serve-static-cli.js
+++ b/scripts/serve/serve-static-cli.js
@@ -8,11 +8,11 @@ const loadWebpackConfig = require('./loadWebpackConfig');
 // Parse process arguments
 commander
   .version(packageJson.version)
-  .option('--config <path>', 'The webpack config to serve. Alias for <config>.', undefined)
-  .option('--port <n>', 'The port the app should listen on', parseInt)
-  .option('--host <s>', 'Sets the host that the server will listen on. eg. \'10.10.10.1\'', '0.0.0.0')
+  .option('--config [path]', 'The webpack config to serve. Alias for <config>.', undefined)
+  .option('--port [number]', 'The port the app should listen on', parseInt)
+  .option('--host [string]', 'Sets the host that the server will listen on. eg. \'10.10.10.1\'', '0.0.0.0')
   .option('-p, --production', 'Passes the -p flag to the webpack config, if available.')
-  .option('--site <path>', 'The relative path to the static site. This takes precidence over webpack config if both are passed.', undefined)
+  .option('--site [path]', 'The relative path to the static site. This takes precidence over webpack config if both are passed.', undefined)
   .option('--disk', 'The webpack assets will be written to disk instead of a virtual file system.')
   .parse(process.argv);
 

--- a/scripts/wdio/clean-screenshots-cli.js
+++ b/scripts/wdio/clean-screenshots-cli.js
@@ -8,7 +8,7 @@ const packageJson = require('../../package.json');
 // Parse process arguments
 commander
   .version(packageJson.version)
-  .option('--config <path>', 'The wdio config path for the tests', undefined)
+  .option('--config [path]', 'The wdio config path for the tests', undefined)
   .option('--removeReference', 'Whether or not to remove the reference screenshots', false)
   .parse(process.argv);
 

--- a/scripts/wdio/wdio-runner-cli.js
+++ b/scripts/wdio/wdio-runner-cli.js
@@ -11,16 +11,16 @@ const packageJson = require('../../package.json');
 // Parse process arguments
 commander
   .version(packageJson.version)
-  .option('--config <path>', 'The wdio config path for the tests', undefined)
-  .option('--formFactors <list>', 'The list of viewport sizes to test', parseCLIList, undefined)
-  .option('--locales <list>', 'The list of locales to test', parseCLIList, ['en'])
+  .option('--config [path]', 'The wdio config path for the tests', undefined)
+  .option('--formFactors [list]', 'The list of viewport sizes to test', parseCLIList, undefined)
+  .option('--locales [list]', 'The list of locales to test', parseCLIList, ['en'])
   .option('--continueOnFail', 'Wheather or not to execute all test runs when a run fails', false)
   .option('--updateReference', 'Whether or not to remove reference screenshots during screenshot cleanup', false)
-  .option('--host <number>', '[wdio option] The selenium server port', undefined)
-  .option('--port <string>', '[wdio option] The selenium server host address', undefined)
-  .option('--baseUrl <path>', '[wdio option] The base URL', undefined)
-  .option('--suite <path>', '[wdio option] The suite to run', undefined)
-  .option('--spec <path>', '[wdio option] The spec file to run', undefined)
+  .option('--host [number]', '[wdio option] The selenium server port', undefined)
+  .option('--port [string]', '[wdio option] The selenium server host address', undefined)
+  .option('--baseUrl [path]', '[wdio option] The base URL', undefined)
+  .option('--suite [path]', '[wdio option] The suite to run', undefined)
+  .option('--spec [path]', '[wdio option] The spec file to run', undefined)
   .parse(process.argv);
 
 const {


### PR DESCRIPTION
### Summary
According to the commander module's documentation, `[...]` indicates options arguments, while `<...>` indicates required arguments when running  `--help`. Figured we should be correct.