### PR TITLE
Look for all translations in all the places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Add exclude directories option to aggregateTranslations script and cli
 
 4.20.0 - (December 6, 2018)
 ----------

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,6 +16,7 @@ Cerner Corporation
 - Tyler Biethman [@tbiethman]
 - Stephen Esser [@StephenEsser]
 - Jaime Mackey [@jmsv6d]
+- Cody Price [@dev-cprice]
 
 [@emilyrohrbough]: https://github.com/emilyrohrbough
 [@brettjankord]: https://github.com/bjankord
@@ -33,3 +34,4 @@ Cerner Corporation
 [@tbiethman]: https://github.com/tbiethman
 [@StephenEsser]: https://github.com/StephenEsser
 [@jmsv6d]: https://github.com/jmsv6d
+[@dev-cprice]: https://github.com/dev-cprice

--- a/docs/AggregateTranslations.md
+++ b/docs/AggregateTranslations.md
@@ -12,6 +12,7 @@ Once all of the translation files are created for the specified locales, the scr
 |-|-|-|-|-|
 | baseDir | -b, --baseDir | Path | Directory to search from and to prepend to the output directory. | current working directory |
 | directories | -d, --directories | Array of Strings | Translation directory regex pattern(s) to glob, in addition to the default search patterns. | [ ] |
+| exclude | -e, --exclude | Array of Strings | Translation directory regex pattern(s) to glob exclude from the search patterns. | [ ] |
 | outputFileSystem | N/A | File System Module | The filesystem to use to write the translation and loader files. Note: The file system provide must support `mkdirp`. | [fs-extra](https://www.npmjs.com/package/fs-extra) |
 | locales  | -l, --locales | Array of Strings | The list of locale codes to aggregate. **Note: 'en' is always added if not specified.** | [terra-supported locales](https://github.com/cerner/terra-core/blob/master/packages/terra-i18n/src/i18nSupportedLocales.js) |
 | outputDir | -o, --ouputDir | String | Output directory for the translation and loader files | ./aggregated-translations |
@@ -26,6 +27,7 @@ const aggregateTranslations = require('terra-toolkit/scripts/aggregate-translati
 const aggregateOptions = {
     baseDir: __dirname,
     directories: ['./src/**/translations', './translations'],
+    exclude: ['./node_modules/packageToExclude'],
     locales: ['en', 'en-US'],
     outputDir: './aggregated-translations',
 };
@@ -40,7 +42,7 @@ The `aggregate-translations` CLI is supplied as a bin script, called `tt-aggrega
 ```js
 scripts: {
     // ...other scripts
-    "aggregate-translations": "tt-aggregate-translations -b ./ -d ./src/**/translations -d ./translations -l ['en','es'] -o ./aggregated-translations",
+    "aggregate-translations": "tt-aggregate-translations -b ./ -d ./src/**/translations -d ./translations -l ['en','es'] -e ./node_modules/packageToExclude -o ./aggregated-translations",
     "start:build": "npm run aggregate-translations && npm run start"
 }
 ```
@@ -53,6 +55,7 @@ Add a terra-i18n config file like:
 const aggregateOptions = {
     baseDir: __dirname,
     directories: ['./src/**/translations', './translations'],
+    exclude: ['./node_modules/packageToExclude'],
     locales: ['en', 'en-US'],
     outputDir: './aggregated-translations',
 };

--- a/docs/AggregateTranslations.md
+++ b/docs/AggregateTranslations.md
@@ -7,6 +7,12 @@ for each specified locale, the message-translation pairs from each translation j
 
 Once all of the translation files are created for the specified locales, the script will create an intl loader and translation loader that is specific to the specified locales. This is utilized by the by terra-i18n's `I18nLoader` to load on-demand locale information.
 
+### Order of Operations
+
+* Start with [default search patterns](https://github.com/cerner/terra-toolkit/blob/master/scripts/aggregate-translations/aggregate-translations.js#L10-L15)
+* Add any `custom directories` to the list of `default search patterns` to get an intermediate list of `directories to search`
+* Filter out any directories provided in the `exclude` option from the intermediate list of `directories to search`
+
 ### `aggregate-translations` Options
 | Option | CLI Option | Type | Description | Default |
 |-|-|-|-|-|

--- a/scripts/aggregate-translations/aggregate-translations-cli.js
+++ b/scripts/aggregate-translations/aggregate-translations-cli.js
@@ -6,11 +6,17 @@ const parseCLIList = require('../utils/parse-cli-list');
 
 const aggregateTranslations = require('./aggregate-translations');
 
+const convertDirectoryPath = directoryPath => directoryPath.split('/').join(path.sep);
+
 // Adds custom search directory paths
 const customSearchDirectories = [];
 const addCustomDirectory = (searchPattern) => {
-  const customDir = searchPattern.split('/').join(path.sep);
-  customSearchDirectories.push(customDir);
+  customSearchDirectories.push(convertDirectoryPath(searchPattern));
+};
+
+const customExcludeDirectories = [];
+const addCustomExclude = (searchPattern) => {
+  customExcludeDirectories.push(convertDirectoryPath(searchPattern));
 };
 
 // Parse process arguments
@@ -21,11 +27,13 @@ commander
   .option('-l, --locales [locales]', 'The list of locale codes aggregate on and combine into a single, respective translation file ', parseCLIList, supportedLocales)
   .option('-o, --outputDir [outputDir]', 'The output location of the generated configuration file', './aggregated-translations')
   .option('-c, --config [configPath]', 'The path to the terra i18n configuration file', undefined)
+  .option('-e, --exclude [exclude]', 'Regex pattern to glob filter out directories', addCustomExclude)
   .parse(process.argv);
 
 const aggregationOption = {
   baseDirectory: commander.baseDir,
   directories: customSearchDirectories,
+  exclude: customExcludeDirectories,
   locales: commander.locales,
   outputDir: commander.outputDir,
   configPath: commander.config,

--- a/scripts/aggregate-translations/aggregate-translations-cli.js
+++ b/scripts/aggregate-translations/aggregate-translations-cli.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const commander = require('commander');
 const i18nPackageJson = require('../../package.json');
 const supportedLocales = require('./i18nSupportedLocales');
@@ -6,17 +5,15 @@ const parseCLIList = require('../utils/parse-cli-list');
 
 const aggregateTranslations = require('./aggregate-translations');
 
-const convertDirectoryPath = directoryPath => directoryPath.split('/').join(path.sep);
-
 // Adds custom search directory paths
 const customSearchDirectories = [];
 const addCustomDirectory = (searchPattern) => {
-  customSearchDirectories.push(convertDirectoryPath(searchPattern));
+  customSearchDirectories.push(searchPattern);
 };
 
 const customExcludeDirectories = [];
 const addCustomExclude = (searchPattern) => {
-  customExcludeDirectories.push(convertDirectoryPath(searchPattern));
+  customExcludeDirectories.push(searchPattern);
 };
 
 // Parse process arguments

--- a/scripts/aggregate-translations/aggregate-translations.js
+++ b/scripts/aggregate-translations/aggregate-translations.js
@@ -8,10 +8,7 @@ const writeAggregatedTranslations = require('./write-aggregated-translations');
 const writeI18nLoaders = require('./write-i18n-loaders');
 
 const defaultSearchPatterns = baseDirectory => ([
-  path.resolve(baseDirectory, 'translations'), // root level translations
-  path.resolve(baseDirectory, 'node_modules', 'terra-*', 'translations'), // root level dependency translations
-  path.resolve(baseDirectory, 'packages', 'terra-*', 'translations'), // package level translations
-  path.resolve(baseDirectory, 'packages', 'terra-*', 'node_modules', 'terra-*', 'translations'), // package level dependency translations
+  path.resolve(baseDirectory, '**', 'translations'),
 ]);
 
 const customDirectories = (baseDirectory, directories) => (directories.map(dir => path.resolve(baseDirectory, dir)));

--- a/scripts/aggregate-translations/aggregate-translations.js
+++ b/scripts/aggregate-translations/aggregate-translations.js
@@ -53,7 +53,7 @@ const defaults = (options = {}) => {
 
 const excludeThesePaths = (paths) => {
   const pathsSet = new Set(paths);
-  return (path => !pathsSet.has(path));
+  return (p => !pathsSet.has(p));
 };
 
 const aggregatedTranslations = (options) => {
@@ -68,10 +68,7 @@ const aggregatedTranslations = (options) => {
     ...resolve(directories),
   ].filter(excludeThesePaths(resolve(excludes)));
 
-  let translationDirectories = [];
-  searchPaths.forEach((searchPath) => {
-    translationDirectories = translationDirectories.concat(glob.sync(searchPath));
-  });
+  const translationDirectories = searchPaths.map(searchPath => glob.sync(searchPath));
 
   // Aggregate translation messages for each of the translations directories
   const aggregatedMessages = aggregateMessages(translationDirectories, locales);

--- a/tests/jest/aggregate-translations.test.js
+++ b/tests/jest/aggregate-translations.test.js
@@ -52,10 +52,12 @@ describe('aggregate-translations', () => {
   it('aggregates on the default search patterns and custom directory patterns while excluding the custom excludes directory patterns', () => {
     aggregateTranslations({ directories: ['./test/*/pattern', './foo/*/bar', './baz/*/buzz'], excludes: ['./foo/*/bar'] });
 
+    const expected = (pathParts = []) => [expect.stringContaining(pathParts.join(path.sep))];
+
     expect(globSpy).toHaveBeenCalledTimes(6);
-    expect(searchedDirectories).toEqual(expect.arrayContaining([`${process.cwd()}${path.sep}test${path.sep}*${path.sep}pattern`]));
-    expect(searchedDirectories).toEqual(expect.arrayContaining([`${process.cwd()}${path.sep}baz${path.sep}*${path.sep}buzz`]));
-    expect(searchedDirectories).toEqual(expect.not.arrayContaining([`${process.cwd()}${path.sep}foo${path.sep}*${path.sep}bar`]));
+    expect(searchedDirectories).toEqual(expect.arrayContaining(expected(['test', '*', 'pattern'])));
+    expect(searchedDirectories).toEqual(expect.arrayContaining(expected(['baz', '*', 'buzz'])));
+    expect(searchedDirectories).toEqual(expect.not.arrayContaining(expected(['foo', '*', 'bar'])));
   });
 
   it('uses the custom base directory', () => {

--- a/tests/jest/aggregate-translations.test.js
+++ b/tests/jest/aggregate-translations.test.js
@@ -9,9 +9,9 @@ const aggregateTranslations = require('../../scripts/aggregate-translations/aggr
 global.console = { warn: jest.fn() };
 const defaultSearchPatterns = baseDirectory => ([
   `${baseDirectory}${path.sep}translations`,
-  `${baseDirectory}${path.sep}node_modules${path.sep}terra-*${path.sep}translations`,
+  `${baseDirectory}${path.sep}node_modules${path.sep}**${path.sep}translations`,
   `${baseDirectory}${path.sep}packages${path.sep}terra-*${path.sep}translations`,
-  `${baseDirectory}${path.sep}packages${path.sep}terra-*${path.sep}node_modules${path.sep}terra-*${path.sep}translations`,
+  `${baseDirectory}${path.sep}packages${path.sep}**${path.sep}node_modules${path.sep}**${path.sep}translations`,
 ]);
 
 const nestedOutputDir = './translations/folder';
@@ -47,6 +47,15 @@ describe('aggregate-translations', () => {
 
     expect(globSpy).toHaveBeenCalledTimes(5);
     expect(searchedDirectories).toEqual(expect.arrayContaining([`${process.cwd()}${path.sep}test${path.sep}*${path.sep}pattern`]));
+  });
+
+  it('aggregates on the default search patterns and custom directory patterns while excluding the custom excludes directory patterns', () => {
+    aggregateTranslations({ directories: ['./test/*/pattern', './foo/*/bar', './baz/*/buzz'], excludes: ['./foo/*/bar'] });
+
+    expect(globSpy).toHaveBeenCalledTimes(6);
+    expect(searchedDirectories).toEqual(expect.arrayContaining([`${process.cwd()}${path.sep}test${path.sep}*${path.sep}pattern`]));
+    expect(searchedDirectories).toEqual(expect.arrayContaining([`${process.cwd()}${path.sep}baz${path.sep}*${path.sep}buzz`]));
+    expect(searchedDirectories).toEqual(expect.not.arrayContaining([`${process.cwd()}${path.sep}foo${path.sep}*${path.sep}bar`]));
   });
 
   it('uses the custom base directory', () => {


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

Fixes #206 

I noticed that translations for consuming apps weren't being loaded properly: only the `terra-*` translations were loading. We noticed that the toolkit doesn't look in all places for translations. The webpack config being used which calls `aggregateTranslations` relies on the default directory matchers, which have been enhanced in this PR. 

This matters for apps that consume other packages which follow the same pattern of placing custom translations under the `package-name/translations/` directory. 

E.g.: Public App A consumes Private App B which has custom translations. 
```
public_app_A
L translations (picked up properly)
  L en.json
  L ...
L node_modules
  L private_app_B
    L translations (not picked up)
      L en.json
      L ...
  L terra-*
    L translations (picked up properly)
      L en.json
      L ...
```

This aggregate-translations script, as it stands, won't pick up anything in node_modules/ except for terra translations. I believe that this is a common enough occurrence that multiple consumers will be affected and the aggregate-translations script should be used with as little config as possible to ease the barrier of developing apps.

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
