### PR TITLE
Added - Configuration option to disable theme functions in wdio tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Added configuration option (disableThemeTests) to disable theme functions in wdio tests
 
 4.18.0 - (November 19, 2018)
 ----------

--- a/docs/Wdio_Utility.md
+++ b/docs/Wdio_Utility.md
@@ -22,6 +22,7 @@ To run the webdriver.io test running, the [webdriver.io configuration options](h
     - See [here](https://github.com/cerner/terra-toolkit/blob/master/docs/AxeService.md) for configuration information.
 * `TerraService` - provides global access to chai, custom chai assertions and a Terra helper to make testing easier.
     - To provide a custom global selector, add `terra: { selector: 'selector_name' }` to the configuration.
+    - To disable theme testing add `terra: { disableThemeTests: true }` to the configuration. This will skip the following functions during testing: `themeEachCustomProperty` and `themeCombinationOfCustomProperties`. 
 * `VisualRegressionService` - uses wdio-screenshot to capture screenshots and run visual regression testing.
     - See [here](https://github.com/zinserjan/wdio-visual-regression-service#configuration) for configuration information.
 * `ServeStaticService` - to start a server and returns a promise when the webpack compiler is completed.

--- a/src/wdio/services/TerraCommands/visual-regression.js
+++ b/src/wdio/services/TerraCommands/visual-regression.js
@@ -43,6 +43,10 @@ const determineScreenshotOptions = (...args) => {
 * @property {Array} args - An object containing the CSS custom properties to assert.
 */
 const themeEachCustomProperty = (...args) => {
+  if (global.browser.options.terra.disableThemeTests) {
+    return;
+  }
+
   // If more than 1 argument, selector is first
   const selector = args.length > 1 ? args[0] : global.browser.options.terra.selector;
   // Style properties are always last.
@@ -62,6 +66,10 @@ const themeEachCustomProperty = (...args) => {
 * @property {Array} args - An object containing the options for themeCombinationOfCustomProperties and  CSS custom properties to assert.
 */
 const themeCombinationOfCustomProperties = (...args) => {
+  if (global.browser.options.terra.disableThemeTests) {
+    return;
+  }
+
   const selector = args[0].selector ? args[0].selector : global.browser.options.terra.selector;
   const styleProperties = args[0].properties ? args[0].properties : [];
 


### PR DESCRIPTION
### Summary
Added a disableThemeTests configuration option to disable theme functions in wdio tests.

Resolves #210 

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
