### PR TITLE
Add local and network address display to tt-serve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 Unreleased
 ----------
 ### Added
+* Add local and network address display to tt-serve
 * Add exclude directories option to aggregateTranslations script and cli
 
 4.20.0 - (December 6, 2018)

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "babel-polyfill": "^6.23.0",
     "browserslist-config-terra": "^1.0.0",
     "chai": "^4.1.2",
+    "chalk": "^2.4.1",
     "clean-webpack-plugin": "^0.1.17",
     "clone": "^2.1.1",
     "commander": "^2.9.0",

--- a/scripts/serve/serve.js
+++ b/scripts/serve/serve.js
@@ -44,7 +44,7 @@ const server = (options) => {
 
   // start that server.
   devServer.listen(port, host, () => {
-    const localAddress = `http://${host}:${port}`;
+    const localAddress = `http://${host}:${port}/`;
     const networkAddress = `http://${ip.address()}:${port}/`;
     displayServer(localAddress, networkAddress);
   });

--- a/scripts/serve/serve.js
+++ b/scripts/serve/serve.js
@@ -1,6 +1,15 @@
 /* eslint-disable no-console */
 const WebpackDevServer = require('webpack-dev-server');
 const webpack = require('webpack');
+const ip = require('ip');
+const chalk = require('chalk');
+const { version: ttVersion } = require('../../package.json');
+
+const displayServer = (localAddress, networkAddress) => {
+  console.log(chalk.greenBright(`Terra-Toolkit ${chalk.bold(ttVersion)} started`));
+  console.log(`* Local:            ${chalk.cyan(localAddress)}`);
+  console.log(`* On your network:  ${chalk.cyan(networkAddress)}\n`);
+};
 
 // Create a webpack dev server instance.
 const server = (options) => {
@@ -35,8 +44,9 @@ const server = (options) => {
 
   // start that server.
   devServer.listen(port, host, () => {
-    // profit
-    console.log(`Starting server on http://${host}:${port}`);
+    const localAddress = `http://${host}:${port}`;
+    const networkAddress = `http://${ip.address()}:${port}/`;
+    displayServer(localAddress, networkAddress);
   });
 };
 


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->
Inspired by [Storybook.js](https://storybook.js.org/). Add network address display when using `tt-serve`

### Additional Details

#### Storybook Example

![image](https://user-images.githubusercontent.com/34115417/49969195-97a9ec00-feed-11e8-868b-248bd1dac872.png)

#### Terra-Toolkit Example

<img width="962" alt="screen shot 2018-12-13 at 3 44 26 pm" src="https://user-images.githubusercontent.com/34115417/49969375-00916400-feee-11e8-99f1-e9a564ab7f92.png">

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
