### PR TITLE
Fix AggregateTranslations doc link to default search patterns

### DIFF
--- a/docs/AggregateTranslations.md
+++ b/docs/AggregateTranslations.md
@@ -9,7 +9,7 @@ Once all of the translation files are created for the specified locales, the scr
 
 ### Order of Operations
 
-* Start with [default search patterns](https://github.com/cerner/terra-toolkit/blob/master/scripts/aggregate-translations/aggregate-translations.js#L10-L15)
+* Start with [default search patterns](https://github.com/cerner/terra-toolkit/blob/master/scripts/aggregate-translations/defaultSearchPatterns.js)
 * Add any `custom directories` to the list of `default search patterns` to get an intermediate list of `directories to search`
 * Filter out any directories provided in the `exclude` option from the intermediate list of `directories to search`
 


### PR DESCRIPTION
### Summary
Default search patterns were moved into their own file with #215 but the doc wasn't updated.

### Additional Details
N/A

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
