### PR TITLE
Remove unused-disable-directives

### DIFF
--- a/scripts/wdio/wdio-runner.js
+++ b/scripts/wdio/wdio-runner.js
@@ -26,7 +26,6 @@ async function wdioRunner(options) {
       await new Launcher(configPath, testSetup)
         .run()
         .then(
-          // eslint-disable-next-line no-loop-func
           (code) => {
             if (code === 1 && !continueOnFail) {
               // eslint-disable-next-line no-console

--- a/tests/nightwatch/MoreTests/nested-test-suite-spec.js
+++ b/tests/nightwatch/MoreTests/nested-test-suite-spec.js
@@ -13,7 +13,6 @@ module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous
 
     browser.windowSize('width', (result) => {
       if (result.value.width !== testWidth) {
-      // eslint-disable-next-line no-console
         throw new Error(`The test breakpoint width is: ${testWidth} and the browser width is ${result.value.width}`);
       }
     });

--- a/tests/nightwatch/responsive-test-suite-spec.js
+++ b/tests/nightwatch/responsive-test-suite-spec.js
@@ -13,7 +13,6 @@ module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous
 
     browser.windowSize('width', (result) => {
       if (result.value.width !== testWidth) {
-      // eslint-disable-next-line no-console
         throw new Error(`The test breakpoint width is: ${testWidth} and the browser width is ${result.value.width}`);
       }
     });

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 const path = require('path');
 const fs = require('fs');
 const wdioConf = require('./config/wdio/wdio.conf');


### PR DESCRIPTION
### Summary
When running `npm run lint -- --report-unused-disable-directives` all unused directives are reported.