### PR TITLE
Limit Connection Retry to 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Update the `connectionRetryCount` to 1 in the default wdio configuraiton
 
 4.22.0 - (January 2, 2019)
 ----------

--- a/config/wdio/wdio.conf.js
+++ b/config/wdio/wdio.conf.js
@@ -36,7 +36,7 @@ const config = {
   screenshotPath: path.join('.', 'errorScreenshots'),
   waitforTimeout: 3000,
   connectionRetryTimeout: 90000,
-  connectionRetryCount: 3,
+  connectionRetryCount: 1,
   services: ['visual-regression', AxeService, TerraService, SeleniumDockerService, ServeStaticService],
 
   visualRegression: visualRegressionConfig,


### PR DESCRIPTION
### Summary
Webdriver.io bug is how connection tries have been implemented. The connection will retry immediately instead of after the specified timeout, which overloads the selenium request queue. We haven't felt this issue with our standalone-selenium grid that is setup via the DockerSelenium Service, regardless this should bel limited for consumers, until webdriver.io fixes the issue.

More details on the issue is described on the issue logged with webdriver.io: https://github.com/webdriverio/webdriverio/issues/3037