### PR TITLE
Adding Duplicate Package Checker Plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Unreleased
 
 ### Added
 * Added format option to aggregate-translations to output modern syntax
+* Added the Duplicate Package Checker Plugin to the default webpack config. The duplicate package checker plugin will warn if duplicate packages (different versions) are included in your webpack bundle.
 
 4.22.0 - (January 2, 2019)
 ----------

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -8,8 +8,8 @@ const CleanPlugin = require('clean-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const browserslist = require('browserslist-config-terra');
 const merge = require('webpack-merge');
+const DuplicatePackageCheckerPlugin = require('duplicate-package-checker-webpack-plugin');
 const aggregateTranslations = require('../../scripts/aggregate-translations/aggregate-translations');
-const DuplicatePackageCheckerPlugin = require("duplicate-package-checker-webpack-plugin");
 
 const webpackConfig = (options, env, argv) => {
   const { rootPath, resolveModules } = options;

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -9,6 +9,7 @@ const TerserPlugin = require('terser-webpack-plugin');
 const browserslist = require('browserslist-config-terra');
 const merge = require('webpack-merge');
 const aggregateTranslations = require('../../scripts/aggregate-translations/aggregate-translations');
+const DuplicatePackageCheckerPlugin = require("duplicate-package-checker-webpack-plugin");
 
 const webpackConfig = (options, env, argv) => {
   const { rootPath, resolveModules } = options;
@@ -82,6 +83,9 @@ const webpackConfig = (options, env, argv) => {
         plugins: [
           PostCSSCustomProperties({ preserve: true }),
         ],
+      }),
+      new DuplicatePackageCheckerPlugin({
+        showHelp: false,
       }),
     ],
     resolve: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3535,6 +3535,18 @@
         "stream-shift": "^1.0.0"
       }
     },
+    "duplicate-package-checker-webpack-plugin": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/duplicate-package-checker-webpack-plugin/-/duplicate-package-checker-webpack-plugin-3.0.0.tgz",
+      "integrity": "sha512-aO50/qPC7X2ChjRFniRiscxBLT/K01bALqfcDaf8Ih5OqQ1N4iT/Abx9Ofu3/ms446vHTm46FACIuJUmgUQcDQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.3.0",
+        "find-root": "^1.0.0",
+        "lodash": "^4.17.4",
+        "semver": "^5.4.1"
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -4621,6 +4633,12 @@
         "pkg-dir": "^2.0.0"
       }
     },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "dev": true
+    },
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -4856,13 +4874,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4875,18 +4891,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4989,8 +5002,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5000,7 +5012,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5013,20 +5024,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5043,7 +5051,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5116,8 +5123,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5127,7 +5133,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5233,7 +5238,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "babel-preset-env": "^1.7.0",
     "babel-runtime": "^6.26.0",
     "danger": "^3.7.14",
+    "duplicate-package-checker-webpack-plugin": "^3.0.0",
     "eslint": "^5.12.0",
     "eslint-config-terra": "^2.2.0",
     "html-webpack-plugin": "^3.1.0",

--- a/tests/jest/webpack.config.test.js
+++ b/tests/jest/webpack.config.test.js
@@ -63,7 +63,7 @@ describe('webpack config', () => {
 
     it('adds the plugins', () => {
       expect(config).toHaveProperty('plugins');
-      expect(config.plugins).toHaveLength(2);
+      expect(config.plugins).toHaveLength(3);
 
       expect(MiniCssExtractPlugin).toBeCalled();
 
@@ -155,7 +155,7 @@ describe('webpack config', () => {
 
     it('adds the CleanPlugin', () => {
       expect(config).toHaveProperty('plugins');
-      expect(config.plugins).toHaveLength(3);
+      expect(config.plugins).toHaveLength(4);
 
       expect(MiniCssExtractPlugin).toBeCalled();
       expect(PostCSSAssetsPlugin).toBeCalled();


### PR DESCRIPTION
### Summary
Added the Duplicate Package Checker Plugin to the default webpack config. The duplicate package checker plugin will warn if duplicate packages (different versions) are included in your webpack bundle.

https://www.npmjs.com/package/duplicate-package-checker-webpack-plugin

### Additional Details
This is passive.

@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
