### PR TITLE
Fix false warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Fixed
+* Issue with false warnings on aggregating translations with blank strings.
 
 4.24.0 - (March 5, 2019)
 ----------

--- a/scripts/aggregate-translations/write-aggregated-translations.js
+++ b/scripts/aggregate-translations/write-aggregated-translations.js
@@ -20,7 +20,7 @@ const writeAggregatedTranslations = (aggregatedMessages, locales, fileSystem, ou
         const baseLocaleMessages = aggregatedMessages[baseLocale];
         if (baseLocaleMessages) {
           Object.keys(baseLocaleMessages).forEach((key) => {
-            if (!messages[key]) {
+            if (messages[key] === undefined) {
               Logger.warn(`${locale} translation missing for ${key}, ${baseLocale} translation string will be used instead.`);
             }
           });


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->
We are falsely warning if the string we are dealing with is "".  We only want to warn if the string is undefined.