### PR TITLE
[terra-toolkit] Remove defaults from Aggregate Translations CLI options.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Unreleased
 * Added a new method `validateElement` to both do a screenshot comparison and test accessibility
 * Log information on what selenium version is being used for the test run.
 
+### Fixed
+* Fixed the issue with Aggregate Translations CLI default options overriding the configuration file options.
+
 4.25.0 - (March 5, 2019)
 ----------
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Unreleased
 
 ### Fixed
 * Fixed the issue with Aggregate Translations CLI default options overriding the configuration file options.
-* Fixed an issue with the 'exclude' option in Aggregate Translations setup function.
+* Fixed an issue with the 'exclude' option in Aggregate Translations setup function. [#264](https://github.com/cerner/terra-toolkit/issues/264)
 
 4.25.0 - (March 5, 2019)
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Unreleased
 
 ### Fixed
 * Fixed the issue with Aggregate Translations CLI default options overriding the configuration file options.
+* Fixed an issue with the 'exclude' option in Aggregate Translations setup function.
 
 4.25.0 - (March 5, 2019)
 ----------

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -18,6 +18,7 @@ Cerner Corporation
 - Jaime Mackey [@jmsv6d]
 - Cody Price [@dev-cprice]
 - Justin Wisniewski [@JustinWisniewski]
+- Naveen Kumar Ramamurthy [@nramamurth]
 
 [@emilyrohrbough]: https://github.com/emilyrohrbough
 [@brettjankord]: https://github.com/bjankord
@@ -37,3 +38,4 @@ Cerner Corporation
 [@jmsv6d]: https://github.com/jmsv6d
 [@dev-cprice]: https://github.com/dev-cprice
 [@JustinWisniewski]: https://github.com/JustinWisniewski
+[@nramamurth]: https://github.com/nramamurth

--- a/docs/AggregateTranslations.md
+++ b/docs/AggregateTranslations.md
@@ -11,14 +11,14 @@ Once all of the translation files are created for the specified locales, the scr
 
 * Start with [default search patterns](https://github.com/cerner/terra-toolkit/blob/master/scripts/aggregate-translations/defaultSearchPatterns.js)
 * Add any `custom directories` to the list of `default search patterns` to get an intermediate list of `directories to search`
-* Filter out any directories provided in the `exclude` option from the intermediate list of `directories to search`
+* Filter out any directories provided in the `excludes` option from the intermediate list of `directories to search`
 
 ### `aggregate-translations` Options
 | Option | CLI Option | Type | Description | Default |
 |-|-|-|-|-|
 | baseDir | -b, --baseDir | Path | Directory to search from and to prepend to the output directory. | current working directory |
 | directories | -d, --directories | Array of Strings | Translation directory regex pattern(s) to glob, in addition to the default search patterns. | [ ] |
-| exclude | -e, --exclude | Array of Strings | Translation directory regex pattern(s) to glob exclude from the search patterns. | [ ] |
+| excludes | -e, --excludes | Array of Strings | Translation directory regex pattern(s) to glob exclude from the search patterns. | [ ] |
 | outputFileSystem | N/A | File System Module | The filesystem to use to write the translation and loader files. Note: The file system provide must support `mkdirp`. | [fs-extra](https://www.npmjs.com/package/fs-extra) |
 | locales  | -l, --locales | Array of Strings | The list of locale codes to aggregate. **Note: 'en' is always added if not specified.** | [terra-supported locales](https://github.com/cerner/terra-core/blob/master/packages/terra-i18n/src/i18nSupportedLocales.js) |
 | outputDir | -o, --ouputDir | String | Output directory for the translation and loader files | ./aggregated-translations |
@@ -34,7 +34,7 @@ const aggregateTranslations = require('terra-toolkit/scripts/aggregate-translati
 const aggregateOptions = {
     baseDir: __dirname,
     directories: ['./src/**/translations', './translations'],
-    exclude: ['./node_modules/packageToExclude'],
+    excludes: ['./node_modules/packageToExclude'],
     locales: ['en', 'en-US'],
     outputDir: './aggregated-translations',
     format: 'es6',
@@ -63,7 +63,7 @@ Add a terra-i18n config file like:
 const aggregateOptions = {
     baseDir: __dirname,
     directories: ['./src/**/translations', './translations'],
-    exclude: ['./node_modules/packageToExclude'],
+    excludes: ['./node_modules/packageToExclude'],
     locales: ['en', 'en-US'],
     outputDir: './aggregated-translations',
 };

--- a/scripts/aggregate-translations/aggregate-translations-cli.js
+++ b/scripts/aggregate-translations/aggregate-translations-cli.js
@@ -5,22 +5,33 @@ const parseCLIList = require('../utils/parse-cli-list');
 
 const aggregateTranslations = require('./aggregate-translations');
 
+// Adds custom search directory paths
+const customSearchDirectories = [];
+const addCustomDirectory = (searchPattern) => {
+  customSearchDirectories.push(searchPattern);
+};
+
+const customExcludeDirectories = [];
+const addCustomExclude = (searchPattern) => {
+  customExcludeDirectories.push(searchPattern);
+};
+
 // Parse process arguments
 commander
   .version(i18nPackageJson.version)
   .option('-b, --baseDir [baseDir]', `The directory to start searching from and to prepend to the output directory. Default: ${process.cwd()}`)
-  .option('-d, --directories [directories]', 'Regex pattern to glob search for translations. Default: []', parseCLIList)
+  .option('-d, --directories [directories]', 'Regex pattern to glob search for translations. Default: []', addCustomDirectory)
   .option('-l, --locales [locales]', `The list of locale codes aggregate on and combine into a single, respective translation file. Default: ${supportedLocales}`, parseCLIList)
   .option('-o, --outputDir [outputDir]', 'The output location of the generated configuration file. Default: ./aggregated-translations')
   .option('-c, --config [configPath]', 'The path to the terra i18n configuration file.')
-  .option('-e, --exclude [exclude]', 'Regex pattern to glob filter out directories. Default: []', parseCLIList)
+  .option('-e, --exclude [exclude]', 'Regex pattern to glob filter out directories. Default: []', addCustomExclude)
   .option('-f, --format [format]', 'Format to output the aggregated translations to. Options are [es5, es6]. Default: es5')
   .parse(process.argv);
 
 const aggregationOption = {
   baseDirectory: commander.baseDir,
-  directories: commander.directories,
-  exclude: commander.exclude,
+  directories: customSearchDirectories,
+  exclude: customExcludeDirectories,
   locales: commander.locales,
   outputDir: commander.outputDir,
   configPath: commander.config,

--- a/scripts/aggregate-translations/aggregate-translations-cli.js
+++ b/scripts/aggregate-translations/aggregate-translations-cli.js
@@ -1,5 +1,6 @@
 const commander = require('commander');
 const i18nPackageJson = require('../../package.json');
+const supportedLocales = require('./i18nSupportedLocales');
 const parseCLIList = require('../utils/parse-cli-list');
 
 const aggregateTranslations = require('./aggregate-translations');
@@ -7,13 +8,13 @@ const aggregateTranslations = require('./aggregate-translations');
 // Parse process arguments
 commander
   .version(i18nPackageJson.version)
-  .option('-b, --baseDir [baseDir]', 'The directory to start searching from and to prepend to the output directory')
-  .option('-d, --directories [directories]', 'Regex pattern to glob search for translations', parseCLIList)
-  .option('-l, --locales [locales]', 'The list of locale codes aggregate on and combine into a single, respective translation file ', parseCLIList)
-  .option('-o, --outputDir [outputDir]', 'The output location of the generated configuration file')
-  .option('-c, --config [configPath]', 'The path to the terra i18n configuration file')
-  .option('-e, --exclude [exclude]', 'Regex pattern to glob filter out directories', parseCLIList)
-  .option('-f, --format [format]', 'Format to output the aggregated translations to. Options are [es5, es6]', 'es5')
+  .option('-b, --baseDir [baseDir]', `The directory to start searching from and to prepend to the output directory. Default: ${process.cwd()}`)
+  .option('-d, --directories [directories]', 'Regex pattern to glob search for translations. Default: []', parseCLIList)
+  .option('-l, --locales [locales]', `The list of locale codes aggregate on and combine into a single, respective translation file. Default: ${supportedLocales}`, parseCLIList)
+  .option('-o, --outputDir [outputDir]', 'The output location of the generated configuration file. Default: ./aggregated-translations')
+  .option('-c, --config [configPath]', 'The path to the terra i18n configuration file.')
+  .option('-e, --exclude [exclude]', 'Regex pattern to glob filter out directories. Default: []', parseCLIList)
+  .option('-f, --format [format]', 'Format to output the aggregated translations to. Options are [es5, es6]. Default: es5')
   .parse(process.argv);
 
 const aggregationOption = {

--- a/scripts/aggregate-translations/aggregate-translations-cli.js
+++ b/scripts/aggregate-translations/aggregate-translations-cli.js
@@ -1,37 +1,25 @@
 const commander = require('commander');
 const i18nPackageJson = require('../../package.json');
-const supportedLocales = require('./i18nSupportedLocales');
 const parseCLIList = require('../utils/parse-cli-list');
 
 const aggregateTranslations = require('./aggregate-translations');
 
-// Adds custom search directory paths
-const customSearchDirectories = [];
-const addCustomDirectory = (searchPattern) => {
-  customSearchDirectories.push(searchPattern);
-};
-
-const customExcludeDirectories = [];
-const addCustomExclude = (searchPattern) => {
-  customExcludeDirectories.push(searchPattern);
-};
-
 // Parse process arguments
 commander
   .version(i18nPackageJson.version)
-  .option('-b, --baseDir [baseDir]', 'The directory to start searching from and to prepend to the output directory', process.cwd())
-  .option('-d, --directories [directories]', 'Regex pattern to glob search for translations', addCustomDirectory)
-  .option('-l, --locales [locales]', 'The list of locale codes aggregate on and combine into a single, respective translation file ', parseCLIList, supportedLocales)
-  .option('-o, --outputDir [outputDir]', 'The output location of the generated configuration file', './aggregated-translations')
-  .option('-c, --config [configPath]', 'The path to the terra i18n configuration file', undefined)
-  .option('-e, --exclude [exclude]', 'Regex pattern to glob filter out directories', addCustomExclude)
+  .option('-b, --baseDir [baseDir]', 'The directory to start searching from and to prepend to the output directory')
+  .option('-d, --directories [directories]', 'Regex pattern to glob search for translations', parseCLIList)
+  .option('-l, --locales [locales]', 'The list of locale codes aggregate on and combine into a single, respective translation file ', parseCLIList)
+  .option('-o, --outputDir [outputDir]', 'The output location of the generated configuration file')
+  .option('-c, --config [configPath]', 'The path to the terra i18n configuration file')
+  .option('-e, --exclude [exclude]', 'Regex pattern to glob filter out directories', parseCLIList)
   .option('-f, --format [format]', 'Format to output the aggregated translations to. Options are [es5, es6]', 'es5')
   .parse(process.argv);
 
 const aggregationOption = {
   baseDirectory: commander.baseDir,
-  directories: customSearchDirectories,
-  exclude: customExcludeDirectories,
+  directories: commander.directories,
+  exclude: commander.exclude,
   locales: commander.locales,
   outputDir: commander.outputDir,
   configPath: commander.config,

--- a/scripts/aggregate-translations/aggregate-translations-cli.js
+++ b/scripts/aggregate-translations/aggregate-translations-cli.js
@@ -24,14 +24,14 @@ commander
   .option('-l, --locales [locales]', `The list of locale codes aggregate on and combine into a single, respective translation file. Default: ${supportedLocales}`, parseCLIList)
   .option('-o, --outputDir [outputDir]', 'The output location of the generated configuration file. Default: ./aggregated-translations')
   .option('-c, --config [configPath]', 'The path to the terra i18n configuration file.')
-  .option('-e, --exclude [exclude]', 'Regex pattern to glob filter out directories. Default: []', addCustomExclude)
+  .option('-e, --excludes [excludes]', 'Regex pattern to glob filter out directories. Default: []', addCustomExclude)
   .option('-f, --format [format]', 'Format to output the aggregated translations to. Options are [es5, es6]. Default: es5')
   .parse(process.argv);
 
 const aggregationOption = {
   baseDirectory: commander.baseDir,
   directories: customSearchDirectories,
-  exclude: customExcludeDirectories,
+  excludes: customExcludeDirectories,
   locales: commander.locales,
   outputDir: commander.outputDir,
   configPath: commander.config,

--- a/scripts/aggregate-translations/aggregate-translations.js
+++ b/scripts/aggregate-translations/aggregate-translations.js
@@ -36,7 +36,7 @@ const defaults = (options = {}) => {
     locales: options.locales || config.locales || supportedLocales,
     outputDir: options.outputDir || './aggregated-translations',
     excludes: options.excludes || config.excludes || [],
-    format: options.format,
+    format: options.format || 'es5',
   };
 
   if (!defaultConfig.locales.includes('en')) {


### PR DESCRIPTION
### Summary
Fixes #257. 
Fixes #264.

### Additional Details
1. The CLI options take precedence over the options mentioned in the configuration file (if one exists) if the consumer runs the CLI script. 
2. If the consumers specify a subset of CLI options, then the script
2.1. looks for the remaining options in the configuration file if one exists.
2.2. uses the default options if the configuration file does not exist.


https://github.com/cerner/terra-toolkit/blob/1015c35decebafad4135c231dd9a2bafdb6f2d8d/scripts/aggregate-translations/aggregate-translations.js#L32-L41

