### PR TITLE
Added an environment variable to support WebdriverIO's bail option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Changelog
 Unreleased
 ----------
 
+### Added
+* Added an environment variable to support WebdriverIO's bail option.
+
 ### Changed
 * Updated devtool sourceMap from cheap-source-map to eval-source-map
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Unreleased
 ----------
 
 ### Added
-* Added an environment variable to support WebdriverIO's bail option.
+* Added an environment variable `WDIO_BAIL` to support WebdriverIO's bail option.
 
 ### Changed
 * Updated devtool sourceMap from cheap-source-map to eval-source-map

--- a/config/wdio/wdio.conf.js
+++ b/config/wdio/wdio.conf.js
@@ -11,7 +11,7 @@ const ip = process.env.WDIO_EXTERNAL_HOST || localIP.address();
 const externalPort = process.env.WDIO_EXTERNAL_PORT || 8080;
 const internalPort = process.env.WDIO_INTERNAL_PORT || 8080;
 const ci = process.env.TRAVIS || process.env.CI;
-const bail = process.env.BAIL || ci;
+const bail = process.env.WDIO_BAIL || ci;
 const locale = process.env.LOCALE;
 const formFactor = process.env.FORM_FACTOR;
 

--- a/config/wdio/wdio.conf.js
+++ b/config/wdio/wdio.conf.js
@@ -11,6 +11,7 @@ const ip = process.env.WDIO_EXTERNAL_HOST || localIP.address();
 const externalPort = process.env.WDIO_EXTERNAL_PORT || 8080;
 const internalPort = process.env.WDIO_INTERNAL_PORT || 8080;
 const ci = process.env.TRAVIS || process.env.CI;
+const bail = process.env.BAIL || ci;
 const locale = process.env.LOCALE;
 const formFactor = process.env.FORM_FACTOR;
 
@@ -32,7 +33,7 @@ const config = {
   sync: true,
   logLevel: 'silent',
   coloredLogs: true,
-  bail: ci ? 1 : 0,
+  bail: bail ? 1 : 0,
   screenshotPath: path.join('.', 'errorScreenshots'),
   waitforTimeout: 3000,
   connectionRetryTimeout: 90000,
@@ -65,7 +66,7 @@ const config = {
   mochaOpts: {
     ui: 'bdd',
     timeout: 20000,
-    bail: ci,
+    bail,
   },
 };
 

--- a/docs/Wdio_Utility.md
+++ b/docs/Wdio_Utility.md
@@ -50,11 +50,12 @@ exports.config = config;
 
 ### Environment Variables
 
-In order to support tests running inside of a container and hitting an external selenium grid, 3 environment variables are provided:
+* In order to support tests running inside of a container and hitting an external selenium grid, 3 environment variables are provided:
 
-* `WDIO_INTERNAL_PORT` - This specifies the port for the ServeStaticService. This is the port that the server being tested against will actually run on.
-* `WDIO_EXTERNAL_PORT` - This specifies the external port that is mapped on the container to the WDIO_INTERNAL_PORT.
-* `WDIO_EXTERNAL_HOST` - This specifies the externally accessible name for the host on which the container is running.
+  * `WDIO_INTERNAL_PORT` - This specifies the port for the ServeStaticService. This is the port that the server being tested against will actually run on.
+  * `WDIO_EXTERNAL_PORT` - This specifies the external port that is mapped on the container to the WDIO_INTERNAL_PORT.
+  * `WDIO_EXTERNAL_HOST` - This specifies the externally accessible name for the host on which the container is running.
+* In order to stop test runner as soon as a single test has failed, explicitly set the environment variable `WDIO_BAIL` to true. Please note that if it is not set, then the test runner does not bail and all the tests are run.
 
 ## Writing Tests
 


### PR DESCRIPTION
### Summary
Added support for consumers to choose to stop the execution of the WDIO tests as early as 1 failure in the test run.

Resolves #267.

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
