### PR TITLE
Issue 274 make themed default test name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Unreleased
 ----------
 ### Added 
-* Added default testName in themeCombinationOfCustomProperties
+* Added default testName `themed` for `themeCombinationOfCustomProperties` helper.
 
 4.27.0 - (April 16, 2019)
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added 
+* Added default testName in themeCombinationOfCustomProperties
 
 4.27.0 - (April 16, 2019)
 ----------

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,6 +20,7 @@ Cerner Corporation
 - Justin Wisniewski [@JustinWisniewski]
 - Naveen Kumar Ramamurthy [@nramamurth]
 - Lalitha Kalidindi[@lalitha94]
+- Pranav Agarwal [@pranav300]
 
 [@emilyrohrbough]: https://github.com/emilyrohrbough
 [@brettjankord]: https://github.com/bjankord
@@ -41,3 +42,4 @@ Cerner Corporation
 [@JustinWisniewski]: https://github.com/JustinWisniewski
 [@nramamurth]: https://github.com/nramamurth
 [@lalitha94]: https://github.com/lalitha94
+[@pranav300]: https://github.com/pranav300

--- a/docs/Wdio_Utility.md
+++ b/docs/Wdio_Utility.md
@@ -91,7 +91,7 @@ Then, to assist with testing, the TerraService provides the Terra global helper 
     - Object: list of themeable-variable key-value pairs such that the key is the themeable-variable name and the value is the css value to check in the screenshot.
   - `Terra.should.themeCombinationOfCustomProperties()` mocha-chai convenience method that runs a visual comparison test for a grouping of custom properties provided. Note: this method provides its own mocha it test case. The methods accepts these arguments (in this order):
       - Object: the test options. Options include testName, selector and properties:
-           - testName (optional): the name associated to the test. Used to create unique screenshots. Defaults to the `themed`.
+           - testName (optional): the name associated to the test. Used to create unique screenshots. Defaults to `themed`.
            - properties (required): object of themeable-variable key-value pairs such that the key is the themeable-variable name and the value is the css value to check in the screenshot.
            - selector (optional): the element selector to take a screenshot of. Defaults to the global terra.selector.
 

--- a/docs/Wdio_Utility.md
+++ b/docs/Wdio_Utility.md
@@ -91,7 +91,7 @@ Then, to assist with testing, the TerraService provides the Terra global helper 
     - Object: list of themeable-variable key-value pairs such that the key is the themeable-variable name and the value is the css value to check in the screenshot.
   - `Terra.should.themeCombinationOfCustomProperties()` mocha-chai convenience method that runs a visual comparison test for a grouping of custom properties provided. Note: this method provides its own mocha it test case. The methods accepts these arguments (in this order):
       - Object: the test options. Options include testName, selector and properties:
-           - testName (required): the name associated to the test. Used to create unique screenshots.
+           - testName (optional): the name associated to the test. Used to create unique screenshots. Defaults to the `themed`.
            - properties (required): object of themeable-variable key-value pairs such that the key is the themeable-variable name and the value is the css value to check in the screenshot.
            - selector (optional): the element selector to take a screenshot of. Defaults to the global terra.selector.
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "wdio-webpack-func": "TT_TEST_WDIO_FUNCTION=true wdio --suite opinionated",
     "tt-wdio-webpack-obj": "node scripts/wdio/wdio-runner-cli.js --suite opinionated",
     "tt-wdio-webpack-func": "TT_TEST_WDIO_FUNCTION=true node scripts/wdio/wdio-runner-cli.js --suite opinionated",
-    "tt-wdio-unopinionated": "npm run pack; node scripts/wdio/wdio-runner-cli.js --formFactors=['tiny','huge'] --locales=['en','fr'] --suite unopinionated; rm -rf ./build"
+    "tt-wdio-unopinionated": "npm run pack && node scripts/wdio/wdio-runner-cli.js --formFactors=['tiny','huge'] --locales=['en','fr'] --suite unopinionated && rm -rf ./build"
   },
   "dependencies": {
     "async": "^2.5.0",

--- a/src/wdio/services/TerraCommands/visual-regression.js
+++ b/src/wdio/services/TerraCommands/visual-regression.js
@@ -76,7 +76,8 @@ const themeCombinationOfCustomProperties = (...args) => {
   const styleProperties = args[0].properties ? args[0].properties : [];
 
   if (!args[0].testName) {
-    args[0].testName=themed;
+    throw Logger.error(`A test name for themeCombinationOfCustomProperties test is not provided.
+A testName property should be set in the options object passed to the themeCombinationOfCustomProperties to uniquely identify it.`);
   }
 
   global.it(`[${args[0].testName}]`, () => {

--- a/src/wdio/services/TerraCommands/visual-regression.js
+++ b/src/wdio/services/TerraCommands/visual-regression.js
@@ -70,14 +70,10 @@ const themeCombinationOfCustomProperties = (...args) => {
     return;
   }
 
-  const selector = args[0].selector ? args[0].selector : global.browser.options.terra.selector;
-  const styleProperties = args[0].properties ? args[0].properties : [];
-  let testName;
-  if (!args[0].testName) {
-    testName = 'themed';
-  } else {
-    testName = args[0][testName];
-  }
+  const options = args[0];
+  const selector = options.selector || global.browser.options.terra.selector;
+  const styleProperties = options.properties || [];
+  const testName = options.testName || 'themed';
 
   global.it(`[${testName}]`, () => {
     Object.entries(styleProperties).forEach(([key, value]) => {

--- a/src/wdio/services/TerraCommands/visual-regression.js
+++ b/src/wdio/services/TerraCommands/visual-regression.js
@@ -1,5 +1,3 @@
-import Logger from '../../../../scripts/utils/logger';
-
 /**
 * Helper method to determine the screenshot tag name, the element selector, the viewport(s)
 * in which to take the screenshots, as well as the capture screenshot options to be passed
@@ -74,12 +72,14 @@ const themeCombinationOfCustomProperties = (...args) => {
 
   const selector = args[0].selector ? args[0].selector : global.browser.options.terra.selector;
   const styleProperties = args[0].properties ? args[0].properties : [];
-
+  let testName;
   if (!args[0].testName) {
-    args[0].testName = 'themed';
+    testName = 'themed';
+  } else {
+    testName = args[0][testName];
   }
 
-  global.it(`[${args[0].testName}]`, () => {
+  global.it(`[${testName}]`, () => {
     Object.entries(styleProperties).forEach(([key, value]) => {
       global.browser.execute(`document.documentElement.style.setProperty('${key}', '${value}')`);
     });

--- a/src/wdio/services/TerraCommands/visual-regression.js
+++ b/src/wdio/services/TerraCommands/visual-regression.js
@@ -76,8 +76,7 @@ const themeCombinationOfCustomProperties = (...args) => {
   const styleProperties = args[0].properties ? args[0].properties : [];
 
   if (!args[0].testName) {
-    throw Logger.error(`A test name for themeCombinationOfCustomProperties test is not provided.
-A testName property should be set in the options object passed to the themeCombinationOfCustomProperties to uniquely identify it.`);
+    args[0].testName = 'themed';
   }
 
   global.it(`[${args[0].testName}]`, () => {

--- a/src/wdio/services/TerraCommands/visual-regression.js
+++ b/src/wdio/services/TerraCommands/visual-regression.js
@@ -76,8 +76,7 @@ const themeCombinationOfCustomProperties = (...args) => {
   const styleProperties = args[0].properties ? args[0].properties : [];
 
   if (!args[0].testName) {
-    throw Logger.error(`A test name for themeCombinationOfCustomProperties test is not provided.
-A testName property should be set in the options object passed to the themeCombinationOfCustomProperties to uniquely identify it.`);
+    args[0].testName=themed;
   }
 
   global.it(`[${args[0].testName}]`, () => {

--- a/tests/wdio/theme-spec.js
+++ b/tests/wdio/theme-spec.js
@@ -20,6 +20,7 @@ describe('themeCombinationOfCustomProperties', () => {
   beforeEach(() => browser.url('/theme.html'));
 
   Terra.should.themeCombinationOfCustomProperties({
+    testName: 'themed',
     properties: {
       '--color': 'blue',
       '--font-size': '50px',

--- a/tests/wdio/theme-spec.js
+++ b/tests/wdio/theme-spec.js
@@ -20,7 +20,6 @@ describe('themeCombinationOfCustomProperties', () => {
   beforeEach(() => browser.url('/theme.html'));
 
   Terra.should.themeCombinationOfCustomProperties({
-    testName: 'themed',
     properties: {
       '--color': 'blue',
       '--font-size': '50px',


### PR DESCRIPTION
### Summary
Made `themed` as default testName for the helper 'themeCombinationOfCustomProperties`. Resolves #274 
