### PR TITLE
Ctrl-c wdio end process issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Fixed
+* Stop gracefully when using Ctrl-C to kill the wdio-runner
 
 5.1.0 - (June 25, 2019)
 ----------

--- a/scripts/wdio/wdio-runner.js
+++ b/scripts/wdio/wdio-runner.js
@@ -3,6 +3,8 @@ const Logger = require('../utils/logger');
 
 const context = '[Terra-Tookit:wdio-runner]';
 
+process.on('SIGINT', () => process.exit(0));
+
 async function wdioRunner(options) {
   const {
     configPath, locales, formFactors, gridUrl, browsers, continueOnFail, ...testSetup

--- a/scripts/wdio/wdio-runner.js
+++ b/scripts/wdio/wdio-runner.js
@@ -36,7 +36,6 @@ async function wdioRunner(options) {
       let exitProcess = false;
       process.on('SIGINT', () => {
         exitProcess = true;
-        return exitProcess;
       });
 
       const form = factors[factor];
@@ -52,6 +51,8 @@ async function wdioRunner(options) {
         .run()
         .then(
           (code) => {
+            // If we receive a test failure, exit with a status of 1.  exitProcess is a special case
+            // where the user hit Ctrl-C and will be handled in the else block.
             if (code === 1 && !continueOnFail && !exitProcess) {
               Logger.error(`Running tests for: ${envValues} failed.`, { context });
               process.exit(1);

--- a/scripts/wdio/wdio-runner.js
+++ b/scripts/wdio/wdio-runner.js
@@ -3,8 +3,6 @@ const Logger = require('../utils/logger');
 
 const context = '[Terra-Tookit:wdio-runner]';
 
-process.on('SIGINT', () => process.exit(0));
-
 async function wdioRunner(options) {
   const {
     configPath, locales, formFactors, gridUrl, browsers, continueOnFail, ...testSetup
@@ -21,11 +19,17 @@ async function wdioRunner(options) {
     process.env.BROWSERS = browsers;
   }
 
-  for (let localeI = 0; localeI < testlocales.length; localeI += 1) {
+  let factor = 0;
+  let localeI = 0;
+  process.on('SIGINT', () => {
+    factor = factors.length;
+    localeI = testlocales.length;
+  });
+  for (localeI = 0; localeI < testlocales.length; localeI += 1) {
     const locale = testlocales[localeI];
     process.env.LOCALE = locale;
 
-    for (let factor = 0; factor < factors.length; factor += 1) {
+    for (factor = 0; factor < factors.length; factor += 1) {
       let envValues = `LOCALE=${locale} `;
 
       const form = factors[factor];


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->
This will gracefully exit the wdio runner when a ctrl-c happens.  Fixes #197 