### PR TITLE
Add hideInputCaret wdio test helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ Unreleased
 ----------
 ### Added
 * Added test helper to hide a blinking input caret in an element
-
-### Changed
 * The WDIO TerraService automatically hides carets in the page whenever a page is loaded or refreshed
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added test helper to hide a blinking input caret in an element
 
 5.2.0 - (July 9, 2019)
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Unreleased
 ### Added
 * Added test helper to hide a blinking input caret in an element
 
+### Changed
+* The WDIO TerraService automatically hides carets in the page whenever a page is loaded or refreshed
+
 5.2.0 - (July 9, 2019)
 ----------
 ### Added

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,6 +22,7 @@ Cerner Corporation
 - Lalitha Kalidindi[@lalitha94]
 - Pranav Agarwal [@pranav300]
 - Adam Parker [@amichaelparker]
+- Nathan Faltermeier [@Blackop778]
 
 [@emilyrohrbough]: https://github.com/emilyrohrbough
 [@brettjankord]: https://github.com/bjankord
@@ -45,3 +46,4 @@ Cerner Corporation
 [@lalitha94]: https://github.com/lalitha94
 [@pranav300]: https://github.com/pranav300
 [@amichaelparker]: https://github.com/amichaelparker
+[@Blackop778]: https://github.com/Blackop778

--- a/docs/Wdio_Utility.md
+++ b/docs/Wdio_Utility.md
@@ -20,7 +20,6 @@ To run the webdriver.io test running, the [webdriver.io configuration options](h
     - See [here](https://github.com/cerner/terra-toolkit/blob/master/docs/SeleniumDockerService.md) for configuration information.
 * `TerraService` - provides utilities for accessibility testing as well as gives global access to chai and a Terra object containg helpers to make testing easier. 
     - A global selector must be defined: add `terra: { selector: 'selector_name' }` to the configuration.
-    - To disable theme testing add `terra: { disableThemeTests: true }` to the configuration. This will skip the following functions during testing: `themeEachCustomProperty` and `themeCombinationOfCustomProperties`. 
     - To configure the acessibilty utility, add `axe: { options: {} }` to be passed to the axe instance that is inject on the test page. See [axe-core's axe.configure docs](https://www.deque.com/axe/axe-for-web/documentation/api-documentation/#api-name-axeconfigure) for possible configuraiton options.
 * `VisualRegressionService` - uses wdio-screenshot to capture screenshots and run visual regression testing.
     - See [here](https://github.com/zinserjan/wdio-visual-regression-service#configuration) for configuration information.
@@ -65,69 +64,46 @@ There are a few things to note about the webdriver.io configuration provided by 
 
 Then, to assist with testing, the TerraService provides the Terra global helper to make testing easier:
 
-- `Terra.viewports(name)` takes the viewport key name(s) and returns an array of { height, width } objects representing the respective terra viewport size(s).
+- `Terra.describeViewports` mocha `describe` block intended to replace the spec file's top level `describe` block. This method will run all tests within it's block at the given viewport(s). `Terra.describeViewports` blocks should not be nested and if tests need to run against different viewports then they should have their own top level `Terra.describeViewports` block. Only Terra defined viewports are accepted. This method accepts these arguments (in this order):
+    - String: The describe block name. Will automatically have viewport information included.
+    - String array: The viewport(s) to run the tests at. If the formFactor is defined that is the only viewport size that tests may be ran against.
+    - Function: The method containing the tests to run against each viewport.
+    - See [describeViewports-spec.js](https://github.com/cerner/terra-toolkit/blob/master/tests/wdio/describeViewports-spec.js) for example usage.
+- `Terra.viewports(name)` **Note - It is preferred to use Terra.describeViewports().** takes the viewport key name(s) and returns an array of { height, width } objects representing the respective terra viewport size(s).
     - Use this function to resize the browser or pass the viewport sizes to the accessibility and visual regression commands.
     - By default returns all viewports if not name key are provided.
-- `Terra.should.beAccessible()` mocha-chai convenience method that runs an axe test for the page. Takes the same arguments as the `axe()` utility.
-    - See [beAccessible-spec.js](https://github.com/cerner/terra-toolkit/blob/master/tests/wdio/beAccessible-spec.js) for examples.
-- `Terra.should.matchScreenshot()` **Note - It is preferred to use Terra.should.validateElement().  Terra.should.matchScreenshot() may eventually be deprecated** mocha-chai convenience method that takes a screenshot for the specified viewports and verifies the images are within the specified mis-match tolerance. Note: this method provides its own mocha it test case. The methods accepts these arguments (in this order):
-    - String (optional): the test case name. Default name is 'default'
-    - Object (optional): the test options. Options include selector, viewports, and misMatchTolerance:
-         - selector: the element selector to take a screenshot of. Defaults to the global terra.selector.
-         - viewports: the array of viewports dimensions to take a screenshot in. Defaults to the current viewport size.
-         - misMatchTolerance: number between 0 and 100 that defines the degree of mismatch to consider two images as identical, increasing this value will decrease test coverage. Defaults to the global visualRegression.compare.misMatchTolerance.
-    - See [matchScreenshot-spec.js](https://github.com/cerner/terra-toolkit/blob/master/tests/wdio/matchScreenshot-spec.js) for example usage.
-- `Terra.should.validateElement()` mocha-chai convenience method that takes a screenshot and verifies the images are within the specified mis-match tolerance and performs accessibility validation. Note: this method provides its own mocha it test case. Also, since viewports isn't accepted in this method, you need to [test in multiple viewports](#testing-multiple-viewports) This method accepts these arguments (in this order):
+- `Terra.it.validatesElement()` mocha-chai convenience method that takes a screenshot and verifies the images are within the specified mis-match tolerance and performs accessibility validation. Note: this method provides its own mocha it test case. Also, since viewports isn't accepted in this method, you need to [test in multiple viewports](https://github.com/cerner/terra-toolkit/blob/master/tests/wdio/describeViewports-spec.js). This method accepts these arguments (in this order):
     - String (optional): the test case name. Default name is 'default'
     - Object (optional): the test options. Options include selector, misMatchTolerance and axeRules:
          - selector: the element selector to take a screenshot of. Defaults to the global terra.selector.
          - misMatchTolerance: number between 0 and 100 that defines the degree of mismatch to consider two images as identical, increasing this value will decrease test coverage. Defaults to the global visualRegression.compare.misMatchTolerance.
          - axeRules: the axe rules to use as overrides if necessary.
     - See [validateElement-spec.js](https://github.com/cerner/terra-toolkit/blob/master/tests/wdio/validateElement-spec.js) for example usage.
-- `Terra.should.themeEachCustomProperty()` mocha-chai convenience method that runs a visual comparison test for each custom property given. Note: this method provides its own mocha it test case. The methods accepts these arguments (in this order):
-    - String (optional): the element selector to take a screenshot of. Defaults to the global terra.selector.
-    - Object: list of themeable-variable key-value pairs such that the key is the themeable-variable name and the value is the css value to check in the screenshot.
-  - `Terra.should.themeCombinationOfCustomProperties()` mocha-chai convenience method that runs a visual comparison test for a grouping of custom properties provided. Note: this method provides its own mocha it test case. The methods accepts these arguments (in this order):
-      - Object: the test options. Options include testName, selector and properties:
-           - testName (optional): the name associated to the test. Used to create unique screenshots. Defaults to `themed`.
-           - properties (required): object of themeable-variable key-value pairs such that the key is the themeable-variable name and the value is the css value to check in the screenshot.
-           - selector (optional): the element selector to take a screenshot of. Defaults to the global terra.selector.
+    - This helper can be used inside mocha `it` blocks by being called through `Terra.validates.element()`. This takes the same arguments.
+- `Terra.it.isAccessible()` mocha-chai convenience method that runs an axe test for the page.
+    - See [beAccessible-spec.js](https://github.com/cerner/terra-toolkit/blob/master/tests/wdio/beAccessible-spec.js) for examples.
+    - This helper can be used inside mocha `it` blocks by being called through `Terra.validates.accessibliity()`. This takes the same arguments.
+- `Terra.it.matchesScreenshot()` **Note - It is preferred to use Terra.it.validatesElement().  Terra.should.matchScreenshot() may eventually be deprecated** mocha-chai convenience method that takes a screenshot for the specified viewports and verifies the images are within the specified mis-match tolerance. Note: this method provides its own mocha it test case. The methods accepts these arguments (in this order):
+    - String (optional): the test case name. Default name is 'default'
+    - Object (optional): the test options. Options include selector, viewports, and misMatchTolerance:
+         - selector: the element selector to take a screenshot of. Defaults to the global terra.selector.
+         - viewports: the array of viewports dimensions to take a screenshot in. Defaults to the current viewport size.
+         - misMatchTolerance: number between 0 and 100 that defines the degree of mismatch to consider two images as identical, increasing this value will decrease test coverage. Defaults to the global visualRegression.compare.misMatchTolerance.
+    - See [matchScreenshot-spec.js](https://github.com/cerner/terra-toolkit/blob/master/tests/wdio/matchScreenshot-spec.js) for example usage.
+    - This helper can be used inside mocha `it` blocks by being called through `Terra.validates.screenshot()`. This takes the same arguments.
+- `Terra.hideInputCaret()` mocha-chai convenience method that sets the CSS caret color of an element to transparent. Normally this caret will blink when an editable text field is focused which can lead to inconsistent test failures. The method accepts this argument:
+    - String: the element selector to hide the input caret of. Will only apply to the first element if multiple are found.
 
 ```js
 // These globals are provide via the Terra Service
 /* global browser, describe, it, expect, viewport */
-describe('Basic Test', () => {
+Terra.describeViewports('Basic Test', ['huge'], () => {
   before(() => browser.url('/test.html'));
 
-  Terra.should.beAccessible();
-  Terra.should.matchScreenshot();
-  Terra.should.themeEachCustomProperty({
-    '--color': 'red',
-    '--font-size': '20px',
-  });
+  Terra.it.validatesElement();
 
   it('custom test', () => {
     expect('something').to.equal('something');
-  });
-});
-```
-
-### Testing multiple viewports.
-Sometimes its necessary to rerun the test steps in each viewport. Some build systems support running viewports in parallel and control the viewport via the FORM_FACTOR environment variable. For build systems that don't support parallelization, `Terra.viewports` can be used to wrap the `describe` block. Example:
-
-```js
-Terra.viewports('tiny', 'small', 'large').forEach((viewport) => {
-  describe(`Resize Example - ${viewport.name}`, () => {
-    before(() => {
-      browser.setViewportSize(viewport);
-      browser.url('/test.html');
-    });
-
-    it(`correctly resized to ${viewport.name}`, () => {
-      const size = browser.getViewportSize();
-      expect(size.height).to.equal(viewport.height);
-      expect(size.width).to.equal(viewport.width);
-    });
   });
 });
 ```

--- a/docs/Wdio_Utility.md
+++ b/docs/Wdio_Utility.md
@@ -65,6 +65,8 @@ There are a few things to note about the webdriver.io configuration provided by 
 
 Then, to assist with testing, the TerraService provides the Terra global helper to make testing easier:
 
+### Test Setup Helpers
+
 - `Terra.describeViewports` mocha `describe` block intended to replace the spec file's top level `describe` block. This method will run all tests within it's block at the given viewport(s). `Terra.describeViewports` blocks should not be nested and if tests need to run against different viewports then they should have their own top level `Terra.describeViewports` block. Only Terra defined viewports are accepted. This method accepts these arguments (in this order):
     - String: The describe block name. Will automatically have viewport information included.
     - String array: The viewport(s) to run the tests at. If the formFactor is defined that is the only viewport size that tests may be ran against.
@@ -73,27 +75,34 @@ Then, to assist with testing, the TerraService provides the Terra global helper 
 - `Terra.viewports(name)` **Note - It is preferred to use Terra.describeViewports().** takes the viewport key name(s) and returns an array of { height, width } objects representing the respective terra viewport size(s).
     - Use this function to resize the browser or pass the viewport sizes to the accessibility and visual regression commands.
     - By default returns all viewports if not name key are provided.
+- `Terra.hideInputCaret()` mocha-chai convenience method that sets the CSS caret color of an element to transparent. Normally this caret will blink when an editable text field is focused which can lead to inconsistent test failures. This must be placed in a Mocha `before`, `beforeEach`, or `it` block or it will not be ran. The method accepts this argument:
+    - String: the CSS element selector to hide the input caret of. Will only apply to the first element if multiple are found.
+    - See [hideInputCaret-spec.js](https://github.com/cerner/terra-toolkit/blob/master/tests/wdio/hideInputCaret-spec.js) for examples.
+
+### Test Assertion Helpers
+
 - `Terra.it.validatesElement()` mocha-chai convenience method that takes a screenshot and verifies the images are within the specified mis-match tolerance and performs accessibility validation. Note: this method provides its own mocha it test case. Also, since viewports isn't accepted in this method, you need to [test in multiple viewports](https://github.com/cerner/terra-toolkit/blob/master/tests/wdio/describeViewports-spec.js). This method accepts these arguments (in this order):
     - String (optional): the test case name. Default name is 'default'
     - Object (optional): the test options. Options include selector, misMatchTolerance and axeRules:
-         - selector: the element selector to take a screenshot of. Defaults to the global terra.selector.
-         - misMatchTolerance: number between 0 and 100 that defines the degree of mismatch to consider two images as identical, increasing this value will decrease test coverage. Defaults to the global visualRegression.compare.misMatchTolerance.
-         - axeRules: the axe rules to use as overrides if necessary.
+         - selector: the element selector to take a screenshot of. Defaults to the global `terra.selector`. Accessibility testing ignores this option and always tests the whole document.
+         - misMatchTolerance: number between 0 and 100 that defines the degree of mismatch to consider two images as identical, increasing this value will decrease test coverage. Defaults to the global `visualRegression.compare.misMatchTolerance`.
+         - axeRules: the [axe rules](https://github.com/dequelabs/axe-core/blob/master/doc/rule-descriptions.md) to use as overrides if necessary.
     - See [validateElement-spec.js](https://github.com/cerner/terra-toolkit/blob/master/tests/wdio/validateElement-spec.js) for example usage.
     - This helper can be used inside mocha `it` blocks by being called through `Terra.validates.element()`. This takes the same arguments.
 - `Terra.it.isAccessible()` mocha-chai convenience method that runs an axe test for the page.
+    - Object (optional): the test options. Options include rules and viewports:
+         - rules: the [axe rules](https://github.com/dequelabs/axe-core/blob/master/doc/rule-descriptions.md) to use as overrides if necessary.
+         - viewports: the array of viewports dimensions to test accessibility in. Defaults to the current viewport size. **Note - This will significantly slow down tests and it is prefered to instead use a top-level `Terra.describeViewports` block**
     - See [beAccessible-spec.js](https://github.com/cerner/terra-toolkit/blob/master/tests/wdio/beAccessible-spec.js) for examples.
     - This helper can be used inside mocha `it` blocks by being called through `Terra.validates.accessibliity()`. This takes the same arguments.
 - `Terra.it.matchesScreenshot()` **Note - It is preferred to use Terra.it.validatesElement().  Terra.should.matchScreenshot() may eventually be deprecated** mocha-chai convenience method that takes a screenshot for the specified viewports and verifies the images are within the specified mis-match tolerance. Note: this method provides its own mocha it test case. The methods accepts these arguments (in this order):
     - String (optional): the test case name. Default name is 'default'
     - Object (optional): the test options. Options include selector, viewports, and misMatchTolerance:
          - selector: the element selector to take a screenshot of. Defaults to the global terra.selector.
-         - viewports: the array of viewports dimensions to take a screenshot in. Defaults to the current viewport size.
+         - viewports: the array of viewports dimensions to take a screenshot in. Defaults to the current viewport size. **Note - This will significantly slow down tests and can cause screenshot inconsistencies with some responsive UI. It is prefered to instead use a top-level `Terra.describeViewports` block**
          - misMatchTolerance: number between 0 and 100 that defines the degree of mismatch to consider two images as identical, increasing this value will decrease test coverage. Defaults to the global visualRegression.compare.misMatchTolerance.
     - See [matchScreenshot-spec.js](https://github.com/cerner/terra-toolkit/blob/master/tests/wdio/matchScreenshot-spec.js) for example usage.
     - This helper can be used inside mocha `it` blocks by being called through `Terra.validates.screenshot()`. This takes the same arguments.
-- `Terra.hideInputCaret()` mocha-chai convenience method that sets the CSS caret color of an element to transparent. Normally this caret will blink when an editable text field is focused which can lead to inconsistent test failures. The method accepts this argument:
-    - String: the element selector to hide the input caret of. Will only apply to the first element if multiple are found.
 
 ```js
 // These globals are provide via the Terra Service

--- a/docs/Wdio_Utility.md
+++ b/docs/Wdio_Utility.md
@@ -61,7 +61,7 @@ There are a few things to note about the webdriver.io configuration provided by 
 
 - Test files should use `*-spec.js` naming format. The default spec search paths are `./tests/wdio/**/*-spec.js` and `./packages/*/tests/wdio/**/*-spec.js`.
 - Use `/test_url_path` to direct test urls. This is appended to the `baseUrl` provided in the config.
-- The TerraService automatically sets the `caret-color` CSS property to `transparent` at the root level, although this can be overridden by CSS further down the tree. If it is overridden you can change it back to `transparent` with `Terra.hideInputCaret()` (scroll down for documentation).
+- The TerraService automatically sets the `caret-color` CSS property to `transparent` at the root level whenever a page is loaded or refreshed, although this can be overridden by CSS further down the tree. If it is overridden you can change it back to `transparent` with `Terra.hideInputCaret()` (scroll down for documentation).
 
 Then, to assist with testing, the TerraService provides the Terra global helper to make testing easier:
 

--- a/docs/Wdio_Utility.md
+++ b/docs/Wdio_Utility.md
@@ -61,6 +61,7 @@ There are a few things to note about the webdriver.io configuration provided by 
 
 - Test files should use `*-spec.js` naming format. The default spec search paths are `./tests/wdio/**/*-spec.js` and `./packages/*/tests/wdio/**/*-spec.js`.
 - Use `/test_url_path` to direct test urls. This is appended to the `baseUrl` provided in the config.
+- The TerraService automatically sets the `caret-color` CSS property to `transparent` at the root level, although this can be overridden by CSS further down the tree. If it is overridden you can change it back to `transparent` with `Terra.hideInputCaret()` (scroll down for documentation).
 
 Then, to assist with testing, the TerraService provides the Terra global helper to make testing easier:
 

--- a/src/wdio/services/TerraCommands/hide-input-caret.js
+++ b/src/wdio/services/TerraCommands/hide-input-caret.js
@@ -7,7 +7,7 @@ import Logger from '../../../../scripts/utils/logger';
  */
 const hideInputCaret = (selector) => {
   try {
-    global.browser.execute(`document.querySelector("${selector.replace('"', '\\"')}").style.caretColor = "transparent";`);
+    global.browser.execute(`document.querySelector("${selector.replace(/"/g, '\\"')}").style.caretColor = "transparent";`);
   } catch (error) {
     if (!global.browser.isExisting(selector)) {
       throw Logger.error(`No element could be found with the selector '${selector}'.`);

--- a/src/wdio/services/TerraCommands/hide-input-caret.js
+++ b/src/wdio/services/TerraCommands/hide-input-caret.js
@@ -1,5 +1,5 @@
 /**
- * Hides the blinking input caret that appears in editable text areas and can cause inconsistent test failues.
+ * Hides the blinking input caret that appears within editable text areas to prevent inconsistent test failures.
  *
  * @param {string} selector The selector for the element to hide the caret of
  */

--- a/src/wdio/services/TerraCommands/hide-input-caret.js
+++ b/src/wdio/services/TerraCommands/hide-input-caret.js
@@ -7,7 +7,7 @@ import Logger from '../../../../scripts/utils/logger';
  */
 const hideInputCaret = (selector) => {
   try {
-    global.browser.execute(`document.querySelector("${selector}").style.caretColor = "transparent";`);
+    global.browser.execute(`document.querySelector("${selector.replace('"', '\\"')}").style.caretColor = "transparent";`);
   } catch (error) {
     if (!global.browser.isExisting(selector)) {
       throw Logger.error(`No element could be found with the selector '${selector}'.`);

--- a/src/wdio/services/TerraCommands/hide-input-caret.js
+++ b/src/wdio/services/TerraCommands/hide-input-caret.js
@@ -1,13 +1,20 @@
+import Logger from '../../../../scripts/utils/logger';
+
 /**
  * Hides the blinking input caret that appears within editable text areas to prevent inconsistent test failures.
  *
  * @param {string} selector The selector for the element to hide the caret of
  */
 const hideInputCaret = (selector) => {
-  if (!global.browser.isExisting(selector)) {
-    throw new Error(`No element could be found with the selector '${selector}'.`);
+  try {
+    global.browser.execute(`document.querySelector("${selector}").style.caretColor = "transparent";`);
+  } catch (error) {
+    if (!global.browser.isExisting(selector)) {
+      throw Logger.error(`No element could be found with the selector '${selector}'.`);
+    } else {
+      throw new Error(error);
+    }
   }
-  global.browser.execute(`document.querySelector("${selector}").style.caretColor = "transparent";`);
 };
 
 export default hideInputCaret;

--- a/src/wdio/services/TerraCommands/hide-input-caret.js
+++ b/src/wdio/services/TerraCommands/hide-input-caret.js
@@ -1,0 +1,13 @@
+/**
+ * Hides the blinking input caret that appears in editable text areas and can cause inconsistent test failues.
+ *
+ * @param {string} selector The selector for the element to hide the caret of
+ */
+const hideInputCaret = (selector) => {
+  if (!global.browser.isExisting(selector)) {
+    throw new Error(`No element could be found with the selector '${selector}'.`);
+  }
+  global.browser.execute(`document.querySelector("${selector}").style.caretColor = "transparent";`);
+};
+
+export default hideInputCaret;

--- a/src/wdio/services/TerraService.js
+++ b/src/wdio/services/TerraService.js
@@ -77,9 +77,10 @@ export default class TerraService {
   // eslint-disable-next-line class-methods-use-this
   afterCommand(commandName, args, result, error) {
     if ((commandName === 'refresh' || commandName === 'url') && !error) {
-      hideInputCaret('body');
-
       try {
+        // This is only meant as a convenience so failure is not particularly concerning
+        hideInputCaret('body');
+
         if (global.browser.isExisting('[data-terra-dev-site-loading]')) {
           global.browser.waitUntil(() => (
             global.browser.isExisting('[data-terra-dev-site-content]')

--- a/src/wdio/services/TerraService.js
+++ b/src/wdio/services/TerraService.js
@@ -73,6 +73,8 @@ export default class TerraService {
   // eslint-disable-next-line class-methods-use-this
   afterCommand(commandName) {
     if (commandName === 'refresh' || (commandName === 'url')) {
+      hideInputCaret('body');
+
       if (global.browser.isExisting('[data-terra-dev-site-loading]')) {
         try {
           global.browser.waitUntil(() => (

--- a/src/wdio/services/TerraService.js
+++ b/src/wdio/services/TerraService.js
@@ -42,7 +42,7 @@ export default class TerraService {
       /* `describeViewports` provides a custom Mocha `describe` block for looping test viewports. */
       describeViewports: viewportHelpers.describeViewports,
 
-      /* `hideInputCaret` hides the blinking input caret that appears in editable text areas. */
+      /* `hideInputCaret` hides the blinking input caret that appears in inputs or editable text areas. */
       hideInputCaret,
 
       /* `validates` provides access to the chai assertions to use in Mocha `it` blocks. */
@@ -69,7 +69,11 @@ export default class TerraService {
     viewportHelpers.setViewport(global.browser.options.formFactor);
   }
 
-  // To more passively support code splitting in terra dev site, wait for data to load before progressing with the test.
+  /*
+   * To more passively support code splitting in terra dev site, wait for data to load before progressing with the test.
+   *
+   * Automatically hides input carets on the page (unless something explicitly sets a caret-color) when the page is loaded or refreshed.
+   */
   // eslint-disable-next-line class-methods-use-this
   afterCommand(commandName) {
     if (commandName === 'refresh' || (commandName === 'url')) {

--- a/src/wdio/services/TerraService.js
+++ b/src/wdio/services/TerraService.js
@@ -5,6 +5,7 @@ import accessibility from './TerraCommands/accessibility';
 import visualRegression from './TerraCommands/visual-regression';
 import validateElement from './TerraCommands/validate-element';
 import viewportHelpers from './TerraCommands/viewport-helpers';
+import hideInputCaret from './TerraCommands/hide-input-caret';
 import Logger from '../../../scripts/utils/logger';
 
 /**
@@ -40,6 +41,9 @@ export default class TerraService {
 
       /* `describeViewports` provides a custom Mocha `describe` block for looping test viewports. */
       describeViewports: viewportHelpers.describeViewports,
+
+      /* `hideInputCaret` hides the blinking input caret that appears in editable text areas. */
+      hideInputCaret,
 
       /* `validates` provides access to the chai assertions to use in Mocha `it` blocks. */
       validates: {

--- a/tests/fixtures/input.html
+++ b/tests/fixtures/input.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="<%= htmlWebpackPlugin.options.lang %>" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Text Input Test</title>
+  </head>
+  <body>
+      <input id="inputID">This is an input</input>
+  </body>
+</html>

--- a/tests/fixtures/input.html
+++ b/tests/fixtures/input.html
@@ -5,8 +5,14 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Text Input Test</title>
+    <style>
+      input {
+        caret-color: black;
+      }
+    </style>
   </head>
   <body>
       <input id="inputID">This is an input</input>
+      <textarea id="textareaID">This is a textarea</textarea>
   </body>
 </html>

--- a/tests/fixtures/input.html
+++ b/tests/fixtures/input.html
@@ -5,11 +5,6 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Text Input Test</title>
-    <style>
-      input {
-        caret-color: black;
-      }
-    </style>
   </head>
   <body>
       <input id="inputID">This is an input</input>

--- a/tests/test.config.func.js
+++ b/tests/test.config.func.js
@@ -61,6 +61,12 @@ module.exports = (env = {}) => {
         inject: false,
         filename: './404.html',
       }),
+      new HtmlWebpackPlugin({
+        lang: defaultLocale,
+        template: path.join(__dirname, 'fixtures', 'input.html'),
+        chunks: ['index'],
+        filename: './input.html',
+      }),
     ],
     output: {
       path: path.join(process.cwd(), 'build'),

--- a/tests/wdio/hideInputCaret-spec.js
+++ b/tests/wdio/hideInputCaret-spec.js
@@ -1,13 +1,20 @@
 describe('hideInputCaret', () => {
   before(() => {
     browser.url('/input.html');
+    // The input explicitly has the caret-color set to black
     Terra.hideInputCaret('#inputID');
   });
 
-  it('validates the caretColor is transparent', () => {
+  it('validates the input\'s caret-color is transparent', () => {
     const element = browser.element('#inputID');
     // wdio parses colors with rgb2hex so it becomes a rgba value
     // http://v4.webdriver.io/api/property/getCssProperty.html
+    expect(element.getCssProperty('caretColor').value).to.equal('rgba(0,0,0,0)');
+  });
+
+  it('validates the textarea\'s caret-color is transparent', () => {
+    const element = browser.element('#textareaID');
+    // Terra service automatically sets caretColor at root level to transparent
     expect(element.getCssProperty('caretColor').value).to.equal('rgba(0,0,0,0)');
   });
 });

--- a/tests/wdio/hideInputCaret-spec.js
+++ b/tests/wdio/hideInputCaret-spec.js
@@ -14,7 +14,13 @@ describe('hideInputCaret', () => {
 
   it('validates the textarea\'s caret-color is transparent', () => {
     const element = browser.element('#textareaID');
-    // Terra service automatically sets caretColor at root level to transparent
+    // Terra service automatically sets caretColor on the body to transparent which gets inherited
+    expect(element.getCssProperty('caretColor').value).to.equal('rgba(0,0,0,0)');
+  });
+
+  it('validates the body\'s caret-color is transparent', () => {
+    const element = browser.element('#textareaID');
+    // Terra service automatically sets caretColor on the body to transparent
     expect(element.getCssProperty('caretColor').value).to.equal('rgba(0,0,0,0)');
   });
 

--- a/tests/wdio/hideInputCaret-spec.js
+++ b/tests/wdio/hideInputCaret-spec.js
@@ -1,0 +1,13 @@
+describe('hideInputCaret', () => {
+  before(() => {
+    browser.url('/input.html');
+    Terra.hideInputCaret('#inputIDd');
+  });
+
+  it('validates the caretColor is transparent', () => {
+    const element = browser.element('#inputID');
+    // wdio parses colors with rgb2hex so it becomes a rgba value
+    // http://v4.webdriver.io/api/property/getCssProperty.html
+    expect(element.getCssProperty('caretColor').value).to.equal('rgba(0,0,0,0)');
+  });
+});

--- a/tests/wdio/hideInputCaret-spec.js
+++ b/tests/wdio/hideInputCaret-spec.js
@@ -17,4 +17,8 @@ describe('hideInputCaret', () => {
     // Terra service automatically sets caretColor at root level to transparent
     expect(element.getCssProperty('caretColor').value).to.equal('rgba(0,0,0,0)');
   });
+
+  it('hides the input caret on a non-existent element', () => {
+    expect(Terra.hideInputCaret.bind(this, '#NotAnElement')).to.throw('No element could be found');
+  });
 });

--- a/tests/wdio/hideInputCaret-spec.js
+++ b/tests/wdio/hideInputCaret-spec.js
@@ -1,30 +1,43 @@
 describe('hideInputCaret', () => {
   before(() => {
     browser.url('/input.html');
-    // The input explicitly has the caret-color set to black
-    Terra.hideInputCaret('#inputID');
   });
 
-  it('validates the input\'s caret-color is transparent', () => {
-    const element = browser.element('#inputID');
+  it('validates the body\'s caret-color is transparent by default', () => {
+    const element = browser.element('#textareaID');
+
     // wdio parses colors with rgb2hex so it becomes a rgba value
     // http://v4.webdriver.io/api/property/getCssProperty.html
     expect(element.getCssProperty('caretColor').value).to.equal('rgba(0,0,0,0)');
   });
 
-  it('validates the textarea\'s caret-color is transparent', () => {
+  it('validates the textarea\'s caret-color is inherited as transparent', () => {
     const element = browser.element('#textareaID');
-    // Terra service automatically sets caretColor on the body to transparent which gets inherited
+
     expect(element.getCssProperty('caretColor').value).to.equal('rgba(0,0,0,0)');
   });
 
-  it('validates the body\'s caret-color is transparent', () => {
-    const element = browser.element('#textareaID');
-    // Terra service automatically sets caretColor on the body to transparent
+  it('validates the input\'s caret-color is inherited as transparent', () => {
+    const element = browser.element('#inputID');
+
     expect(element.getCssProperty('caretColor').value).to.equal('rgba(0,0,0,0)');
   });
 
-  it('hides the input caret on a non-existent element', () => {
+  it('sets the input\'s caret-color to orange', () => {
+    browser.execute('document.querySelector("#inputID").style.caretColor = "rgb(255, 165, 0)"');
+    const element = browser.element('#inputID');
+
+    expect(element.getCssProperty('caretColor').value).to.equal('rgb(255,165,0)');
+  });
+
+  it('sets the input\'s caret-color back to transparent', () => {
+    Terra.hideInputCaret('#inputID');
+    const element = browser.element('#inputID');
+
+    expect(element.getCssProperty('caretColor').value).to.equal('rgba(0,0,0,0)');
+  });
+
+  it('throws an error for a non-existent element', () => {
     expect(Terra.hideInputCaret.bind(this, '#NotAnElement')).to.throw('No element could be found');
   });
 });

--- a/tests/wdio/hideInputCaret-spec.js
+++ b/tests/wdio/hideInputCaret-spec.js
@@ -1,7 +1,7 @@
 describe('hideInputCaret', () => {
   before(() => {
     browser.url('/input.html');
-    Terra.hideInputCaret('#inputIDd');
+    Terra.hideInputCaret('#inputID');
   });
 
   it('validates the caretColor is transparent', () => {

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -34,6 +34,7 @@ const config = {
     unopinionated: [
       'tests/wdio/i18n-spec.js',
       'tests/wdio/validateElement-spec.js',
+      'tests/wdio/hideInputCaret-spec.js',
     ],
     static: [
       'tests/wdio/axe-spec.js',


### PR DESCRIPTION
### Summary
Adds `Terra.hideInputCaret` to help write consistent tests. The `TerraService` automatically sets `caret-color` to `transparent` when pages are loaded/refreshed.

The `isExisting` check changes the error resulting from an invalid selector from
```
unknown error: Cannot read property 'style' of null
running chrome
Error: An unknown server-side error occurred while processing the command.
    at execute("document.querySelector("#inputIDd").style.caretColor = "transparent";") - index.js:312:3
```
to
```
No element could be found with the selector '#inputIDd'.
running chrome
Error: No element could be found with the selector '#inputIDd'.
    at Object.hideInputCaret (terra-toolkit/lib/wdio/services/TerraCommands/hide-input-caret.js:17:11)
    at Context.before (terra-toolkit/tests/wdio/hideInputCaret-spec.js:4:11)
    at new Promise (<anonymous>)
    at new F (terra-toolkit/node_modules/babel-runtime/node_modules/core-js/library/modules/_export.js:36:28)
```
making missing selectors significantly easier to debug for anyone writing tests.

Also ended up updating some outdated documentation on the `Terra` WDIO service.

### Validation PR
cerner/terra-core#2537

### Additional Details
Closes #302 
