### PR TITLE
Aftercommand error handling again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Unreleased
 * Upgraded mini extract text plugin
 * Ignore css order warnings from mini extract text plugin
 * Upgraded terra-node to node 10
+* Improve afterCommand error handling
 
 5.2.0 - (July 9, 2019)
 ----------

--- a/src/wdio/services/TerraService.js
+++ b/src/wdio/services/TerraService.js
@@ -68,7 +68,7 @@ export default class TerraService {
   // To more passively support code splitting in terra dev site, wait for data to load before progressing with the test.
   // eslint-disable-next-line class-methods-use-this
   afterCommand(commandName, args, result, error) {
-    if ((commandName === 'refresh' || commandName === 'url')) {
+    if ((commandName === 'refresh' || commandName === 'url') && result && !error) {
       console.log('afterCommand result', result);
       console.log('afterCommand error', error);
       // try {

--- a/src/wdio/services/TerraService.js
+++ b/src/wdio/services/TerraService.js
@@ -69,8 +69,6 @@ export default class TerraService {
   // eslint-disable-next-line class-methods-use-this
   afterCommand(commandName, args, result, error) {
     if ((commandName === 'refresh' || commandName === 'url') && !error) {
-      console.log('afterCommand result', result);
-      console.log('afterCommand error', error);
       try {
         if (global.browser.isExisting('[data-terra-dev-site-loading]')) {
           global.browser.waitUntil(() => (

--- a/src/wdio/services/TerraService.js
+++ b/src/wdio/services/TerraService.js
@@ -67,20 +67,20 @@ export default class TerraService {
 
   // To more passively support code splitting in terra dev site, wait for data to load before progressing with the test.
   // eslint-disable-next-line class-methods-use-this
-  afterCommand(commandName, args, result, error) {
-    if ((commandName === 'refresh' || commandName === 'url') && result && !error) {
-      console.log('afterCommand result', result);
-      console.log('afterCommand error', error);
-      // try {
-        if (global.browser.isExisting('[data-terra-dev-site-loading]')) {
-          global.browser.waitUntil(() => (
-            global.browser.isExisting('[data-terra-dev-site-content]')
-          ), global.browser.options.waitforTimeout + 2000, '', 100);
-        }
-      // } catch (err) {
-      //   // intentionally blank
-      //   // if this fails we don't want to warn because the user can't fix the issue
-      // }
-    }
-  }
+  // afterCommand(commandName, args, result, error) {
+  //   if ((commandName === 'refresh' || commandName === 'url') && result && !error) {
+  //     console.log('afterCommand result', result);
+  //     console.log('afterCommand error', error);
+  //     // try {
+  //       if (global.browser.isExisting('[data-terra-dev-site-loading]')) {
+  //         global.browser.waitUntil(() => (
+  //           global.browser.isExisting('[data-terra-dev-site-content]')
+  //         ), global.browser.options.waitforTimeout + 2000, '', 100);
+  //       }
+  //     // } catch (err) {
+  //     //   // intentionally blank
+  //     //   // if this fails we don't want to warn because the user can't fix the issue
+  //     // }
+  //   }
+  // }
 }

--- a/src/wdio/services/TerraService.js
+++ b/src/wdio/services/TerraService.js
@@ -68,17 +68,19 @@ export default class TerraService {
   // To more passively support code splitting in terra dev site, wait for data to load before progressing with the test.
   // eslint-disable-next-line class-methods-use-this
   afterCommand(commandName, args, result, error) {
-    if ((commandName === 'refresh' || commandName === 'url') && result === 0 && !error) {
-      try {
+    if ((commandName === 'refresh' || commandName === 'url')) {
+      console.log('afterCommand result', result);
+      console.log('afterCommand error', error);
+      // try {
         if (global.browser.isExisting('[data-terra-dev-site-loading]')) {
           global.browser.waitUntil(() => (
             global.browser.isExisting('[data-terra-dev-site-content]')
           ), global.browser.options.waitforTimeout + 2000, '', 100);
         }
-      } catch (err) {
-        // intentionally blank
-        // if this fails we don't want to warn because the user can't fix the issue
-      }
+      // } catch (err) {
+      //   // intentionally blank
+      //   // if this fails we don't want to warn because the user can't fix the issue
+      // }
     }
   }
 }

--- a/src/wdio/services/TerraService.js
+++ b/src/wdio/services/TerraService.js
@@ -67,20 +67,20 @@ export default class TerraService {
 
   // To more passively support code splitting in terra dev site, wait for data to load before progressing with the test.
   // eslint-disable-next-line class-methods-use-this
-  // afterCommand(commandName, args, result, error) {
-  //   if ((commandName === 'refresh' || commandName === 'url') && result && !error) {
-  //     console.log('afterCommand result', result);
-  //     console.log('afterCommand error', error);
-  //     // try {
-  //       if (global.browser.isExisting('[data-terra-dev-site-loading]')) {
-  //         global.browser.waitUntil(() => (
-  //           global.browser.isExisting('[data-terra-dev-site-content]')
-  //         ), global.browser.options.waitforTimeout + 2000, '', 100);
-  //       }
-  //     // } catch (err) {
-  //     //   // intentionally blank
-  //     //   // if this fails we don't want to warn because the user can't fix the issue
-  //     // }
-  //   }
-  // }
+  afterCommand(commandName, args, result, error) {
+    if ((commandName === 'refresh' || commandName === 'url') && !error) {
+      console.log('afterCommand result', result);
+      console.log('afterCommand error', error);
+      try {
+        if (global.browser.isExisting('[data-terra-dev-site-loading]')) {
+          global.browser.waitUntil(() => (
+            global.browser.isExisting('[data-terra-dev-site-content]')
+          ), global.browser.options.waitforTimeout + 2000, '', 100);
+        }
+      } catch (err) {
+        // intentionally blank
+        // if this fails we don't want to warn because the user can't fix the issue
+      }
+    }
+  }
 }

--- a/src/wdio/services/TerraService.js
+++ b/src/wdio/services/TerraService.js
@@ -67,17 +67,17 @@ export default class TerraService {
 
   // To more passively support code splitting in terra dev site, wait for data to load before progressing with the test.
   // eslint-disable-next-line class-methods-use-this
-  afterCommand(commandName) {
-    if (commandName === 'refresh' || (commandName === 'url')) {
-      if (global.browser.isExisting('[data-terra-dev-site-loading]')) {
-        try {
+  afterCommand(commandName, args, result, error) {
+    if ((commandName === 'refresh' || commandName === 'url') && result === 0 && !error) {
+      try {
+        if (global.browser.isExisting('[data-terra-dev-site-loading]')) {
           global.browser.waitUntil(() => (
             global.browser.isExisting('[data-terra-dev-site-content]')
           ), global.browser.options.waitforTimeout + 2000, '', 100);
-        } catch (error) {
-          // intentionally blank
-          // if this fails we don't want to warn because the user can't fix the issue
         }
+      } catch (err) {
+        // intentionally blank
+        // if this fails we don't want to warn because the user can't fix the issue
       }
     }
   }


### PR DESCRIPTION
### Summary
Trying this again. In the previous fix i was using the results param. The wido spec claims that results will either be a zero or 1 depending on success or failure. This is incorrect and it's an object. Now we rely only on the presence of the error object.

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
