### PR TITLE
Revert "Lock-in webpack range"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,6 @@ Changelog
 * Fallback theme generation strategy for theme aggregation.
 * Theme visual regression support.
 
-### Changed
-* Updated webpack range from "webpack": "^4.30.0" to "webpack": ">=4.30.0 <4.40.0" to avoid consuming buggy behavior in webpack 4.40.0
-
 5.6.2 - (September 6, 2019)
 ----------
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Changelog
 * Fallback theme generation strategy for theme aggregation.
 * Theme visual regression support.
 
-### Changed	
+### Changed
 * Updated webpack range from "webpack": "^4.30.0" to "webpack": ">=4.30.0 <4.40.0" to avoid consuming buggy behavior in webpack 4.40.0
 
 5.6.2 - (September 6, 2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 Changelog
 =========
+### Changed	
+* Revert change to webpack range from "webpack": "^4.30.0" to "webpack": ">=4.30.0 <4.40.0"
 
 5.7.1 - (September 12, 2019)
 ----------
@@ -12,6 +14,9 @@ Changelog
 * Added a post-install console warning if terra-toolkit is included as a hard dependency
 * Fallback theme generation strategy for theme aggregation.
 * Theme visual regression support.
+
+### Changed	
+* Updated webpack range from "webpack": "^4.30.0" to "webpack": ">=4.30.0 <4.40.0" to avoid consuming buggy behavior in webpack 4.40.0
 
 5.6.2 - (September 6, 2019)
 ----------

--- a/package-lock.json
+++ b/package-lock.json
@@ -1199,9 +1199,9 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/node": {
-      "version": "12.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.5.tgz",
-      "integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w=="
+      "version": "12.7.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.4.tgz",
+      "integrity": "sha512-W0+n1Y+gK/8G2P/piTkBBN38Qc5Q1ZSO6B5H3QmPCUewaiXOo2GCAWZ4ElZCcNhjJuBSUSLGFUJnmlCn5+nxOQ=="
     },
     "@types/source-list-map": {
       "version": "0.1.2",
@@ -1480,9 +1480,9 @@
       "dev": true
     },
     "acorn-globals": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
-      "integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.3.tgz",
+      "integrity": "sha512-vkR40VwS2SYO98AIeFvzWWh+xyc2qi9s7OoXSFEGIP/rOJKzjnhykaZJNnHdoq4BL2gGxI5EZOU16z896EYnOQ==",
       "dev": true,
       "requires": {
         "acorn": "^6.0.1",
@@ -2331,9 +2331,9 @@
       }
     },
     "buffer": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
-      "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.2.tgz",
+      "integrity": "sha512-iy9koArjAFCzGnx3ZvNA6Z0clIbbFgbdWQ0mKD3hO0krOrZh8UgA6qMKcZvwLJxS+D6iVR76+5/pV56yMNYTag==",
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4"
@@ -2508,9 +2508,9 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000994",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000994.tgz",
-      "integrity": "sha512-7KjfAAhO0qJOs92z8lMWkcRA2ig7Ewv5SQSAy+dik8MFQCDSua+j4RbPFnGrXuOSFe/3RhmGr+68DxKZrbJQGg==",
+      "version": "1.0.30000992",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000992.tgz",
+      "integrity": "sha512-9AZRaPuAGg7Dh3iiO5/i8APo9UjVEeyArfW1ZTvYpg0H/Eo4VrAe3ggqOaUY9mhyfxT3CLeAZgEKqo+1nRc0MA==",
       "dev": true
     },
     "caniuse-lite": {
@@ -3580,9 +3580,9 @@
       "integrity": "sha512-GJCAeDBKfREgkBtgrYSf9hQy9kTb3helv0zGdzqhM7iAkW8FA/ZF97VQDbwFiwIT8MQLLOe5VlPZOEvZAqtUAQ=="
     },
     "electron-to-chromium": {
-      "version": "1.3.257",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.257.tgz",
-      "integrity": "sha512-EcKVmUeHCZelPA0wnIaSmpAN8karKhKBwFb+xLUjSVZ8sGRE1l3fst1zQZ7KJUkyJ7H5edPd4RP94pzC9sG00A=="
+      "version": "1.3.254",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.254.tgz",
+      "integrity": "sha512-7I5/OkgR6JKy6RFLJeru0kc0RMmmMu1UnkHBKInFKRrg1/4EQKIqOaUqITSww/SZ1LqWwp1qc/LLoIGy449eYw=="
     },
     "elliptic": {
       "version": "6.5.1",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "regenerator-runtime": "^0.13.2",
     "webpack-cli": "^3.3.2",
     "webpack-dev-server": "^3.3.1",
-    "webpack": ">=4.30.0 <4.40.0"
+    "webpack": "^4.30.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",
@@ -128,7 +128,7 @@
     "jest": "^24.0.0",
     "raf": "^3.4.1",
     "regenerator-runtime": "^0.13.2",
-    "webpack": ">=4.30.0 <4.40.0",
+    "webpack": "^4.30.0",
     "webpack-cli": "^3.3.2",
     "webpack-dev-server": "^3.3.1"
   }


### PR DESCRIPTION
Reverts cerner/terra-toolkit#332

Webpack has resolved the issue we were seeing with multiple assets being named the same in the [4.40.1 release](https://github.com/webpack/webpack/releases/tag/v4.40.1):

https://github.com/webpack/webpack/issues/9692
https://github.com/webpack/webpack/issues/9693