### PR TITLE
Guard against empty scoped value within theme config.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,14 @@ Changelog
 
 Unreleased
 ----------
+### Fixed
+* Guard against empty scope value passed by theme config.
 
 5.8.0 - (September 16, 2019)
 ----------
 ### Fixed
 * Resolve issues with theme files within node modules being aggregated multiple times.
-### Changed	
+### Changed
 * Revert change to webpack range from "webpack": "^4.30.0" to "webpack": ">=4.30.0 <4.40.0"
 
 5.7.1 - (September 12, 2019)

--- a/scripts/aggregate-themes/theme-aggregator.js
+++ b/scripts/aggregate-themes/theme-aggregator.js
@@ -113,7 +113,7 @@ class ThemeAggregator {
    */
   static aggregateThemes(options) {
     if (!ThemeAggregator.validate(options)) {
-      return [];
+      return null;
     }
 
     // Create generated-themes directory.
@@ -147,6 +147,10 @@ class ThemeAggregator {
 
       if (defaultFlag) defaultFlag = false; // There can only be one instance of the default theme. This stops multiple root themes from being generated.
     });
+
+    if (!assets.length) {
+      return null;
+    }
 
     return assets;
   }

--- a/scripts/aggregate-themes/theme-aggregator.js
+++ b/scripts/aggregate-themes/theme-aggregator.js
@@ -50,7 +50,6 @@ class ThemeAggregator {
     const { theme, scoped = [] } = options;
 
     if (!themeName) {
-      Logger.warn(`Failed to aggregate '${themeName}'. Falsey values are not accepted.`);
       return null;
     }
 

--- a/scripts/aggregate-themes/theme-aggregator.js
+++ b/scripts/aggregate-themes/theme-aggregator.js
@@ -50,7 +50,7 @@ class ThemeAggregator {
     const { theme, scoped = [] } = options;
 
     if (!themeName) {
-      Logger.warn(`Failed to aggregate ${themeName}. Falsey values are not accepted.`);
+      Logger.warn(`Failed to aggregate '${themeName}'. Falsey values are not accepted.`);
       return null;
     }
 
@@ -110,7 +110,7 @@ class ThemeAggregator {
   /**
    * Aggregates theme assets into a js file.
    * @param {Object} options - The aggregation options.
-   * @returns {string} - The file path of the generated js file.
+   * @returns {array} - An array of aggregated theme files
    */
   static aggregateThemes(options) {
     if (!ThemeAggregator.validate(options)) {
@@ -143,11 +143,7 @@ class ThemeAggregator {
     themesToAggregate.forEach((theme) => {
       asset = ThemeAggregator.aggregateTheme(theme, options, defaultFlag);
       if (asset) {
-        if (asset.length > 1) {
           assets.push(...asset);
-        } else {
-          assets.push(asset.pop());
-        }
       }
 
       if (defaultFlag) defaultFlag = false; // There can only be one instance of the default theme. This stops multiple root themes from being generated.

--- a/scripts/aggregate-themes/theme-aggregator.js
+++ b/scripts/aggregate-themes/theme-aggregator.js
@@ -143,7 +143,7 @@ class ThemeAggregator {
     themesToAggregate.forEach((theme) => {
       asset = ThemeAggregator.aggregateTheme(theme, options, defaultFlag);
       if (asset) {
-          assets.push(...asset);
+        assets.push(...asset);
       }
 
       if (defaultFlag) defaultFlag = false; // There can only be one instance of the default theme. This stops multiple root themes from being generated.

--- a/scripts/aggregate-themes/theme-aggregator.js
+++ b/scripts/aggregate-themes/theme-aggregator.js
@@ -129,7 +129,7 @@ class ThemeAggregator {
     }
 
     let themesToAggregate = defaultTheme ? [defaultTheme] : [];
-    if (scoped.length) {
+    if (scoped) {
       themesToAggregate = themesToAggregate.concat(scoped);
     }
 

--- a/scripts/aggregate-themes/theme-aggregator.js
+++ b/scripts/aggregate-themes/theme-aggregator.js
@@ -72,8 +72,7 @@ class ThemeAggregator {
         return ThemeAggregator.writeSCSSFile(fileAttrs);
       }
 
-      const name = themeName.name || themeName;
-      Logger.warn(`No theme files found for ${name}.`);
+      Logger.warn(`No theme files found for ${themeName}.`);
       return null;
     }
 
@@ -130,7 +129,9 @@ class ThemeAggregator {
     }
 
     let themesToAggregate = defaultTheme ? [defaultTheme] : [];
-    themesToAggregate = themesToAggregate.concat(scoped);
+    if (scoped.length) {
+      themesToAggregate = themesToAggregate.concat(scoped);
+    }
 
     themesToAggregate.forEach((theme) => {
       asset = ThemeAggregator.aggregateTheme(theme, options, defaultFlag);

--- a/scripts/aggregate-themes/theme-aggregator.js
+++ b/scripts/aggregate-themes/theme-aggregator.js
@@ -32,7 +32,7 @@ class ThemeAggregator {
       // eslint-disable-next-line global-require, import/no-dynamic-require
       themeConfig = require(defaultConfig);
       const assets = ThemeAggregator.aggregateThemes({ ...themeConfig, ...theme && { theme } });
-      if (assets.length) {
+      if (assets) {
         return ThemeAggregator.writeJsFile(assets);
       }
     }

--- a/tests/jest/aggregate-themes.test.js
+++ b/tests/jest/aggregate-themes.test.js
@@ -4,13 +4,13 @@ const ThemeAggregator = require('../../scripts/aggregate-themes/theme-aggregator
 global.console = { log: jest.fn(), warn: jest.fn() };
 
 describe('Theme Aggregator', () => {
+  /* eslint-disable no-console */
   describe('validate', () => {
     it('does not warn if there is a default theme but not a scoped theme', () => {
       const options = { theme: 'terra-mock-dark-theme' };
 
       ThemeAggregator.validate(options);
 
-      // eslint-disable-next-line no-console
       expect(console.warn).toHaveBeenCalledTimes(0);
     });
 
@@ -19,7 +19,6 @@ describe('Theme Aggregator', () => {
 
       ThemeAggregator.validate(options);
 
-      // eslint-disable-next-line no-console
       expect(console.warn).toHaveBeenCalledTimes(0);
     });
 
@@ -28,9 +27,12 @@ describe('Theme Aggregator', () => {
 
       ThemeAggregator.validate(options);
 
-      // eslint-disable-next-line no-console
       expect(console.warn).toHaveBeenCalled();
     });
+
+    console.warn.mockClear();
+    console.log.mockClear();
+    /* eslint-enable no-console */
   });
 
   describe('aggregate', () => {

--- a/tests/jest/aggregate-themes.test.js
+++ b/tests/jest/aggregate-themes.test.js
@@ -4,6 +4,35 @@ const ThemeAggregator = require('../../scripts/aggregate-themes/theme-aggregator
 global.console = { log: jest.fn(), warn: jest.fn() };
 
 describe('Theme Aggregator', () => {
+  describe('validate', () => {
+    it('does not warn if there is a default theme but not a scoped theme', () => {
+      const options = { theme: 'terra-mock-dark-theme' };
+
+      ThemeAggregator.validate(options);
+
+      // eslint-disable-next-line no-console
+      expect(console.warn).toHaveBeenCalledTimes(0);
+    });
+
+    it('does not warn if there is a scoped theme but not a default theme', () => {
+      const options = { scoped: ['terra-mock-dark-theme'] };
+
+      ThemeAggregator.validate(options);
+
+      // eslint-disable-next-line no-console
+      expect(console.warn).toHaveBeenCalledTimes(0);
+    });
+
+    it('warns if there is not a default theme or a scoped theme', () => {
+      const options = {};
+
+      ThemeAggregator.validate(options);
+
+      // eslint-disable-next-line no-console
+      expect(console.warn).toHaveBeenCalled();
+    });
+  });
+
   describe('aggregate', () => {
     it('returns null if there is no terra-theme-config.js and no config passed by env var.', () => {
       const file = ThemeAggregator.aggregate();
@@ -12,7 +41,72 @@ describe('Theme Aggregator', () => {
     });
   });
 
+  describe('aggregateThemes', () => {
+    it('returns an empty array for an empty default theme and empty array scope theme', () => {
+      const options = { theme: '', scoped: [] };
+
+      const files = ThemeAggregator.aggregateThemes(options);
+      expect(files).toEqual([]);
+    });
+
+    it('returns an empty array for an null default theme and null array scope theme', () => {
+      const options = { theme: null, scoped: null };
+
+      const files = ThemeAggregator.aggregateThemes(options);
+      expect(files).toEqual([]);
+    });
+
+    it('returns an empty array for a null default theme and scope theme array containing null and a non existent theme.', () => {
+      const options = { theme: null, scoped: [null, 'non-existent'] };
+
+      const files = ThemeAggregator.aggregateThemes(options);
+      expect(files).toEqual([]);
+    });
+
+    it('returns an empty array for a non existent default theme and empty scope theme', () => {
+      const options = { theme: 'unknown-theme', scoped: '' };
+
+      const files = ThemeAggregator.aggregateThemes(options);
+      expect(files).toEqual([]);
+    });
+
+    it('returns the aggregated scoped theme for a non existent default theme and defined scope theme', () => {
+      const options = { theme: '', scoped: ['terra-mock-dark-theme'] };
+
+      const files = ThemeAggregator.aggregateThemes(options);
+      const expected = ['../tests/jest/fixtures/themes/terra-mock-dark-theme/scoped-theme.scss'];
+
+      expect(files).toEqual(expected);
+    });
+
+    it('returns the aggregated default theme for a defined default theme and non existent scope theme', () => {
+      const options = { theme: 'terra-mock-dark-theme', scoped: ['unkown-theme'] };
+
+      const files = ThemeAggregator.aggregateThemes(options);
+      const expected = ['../tests/jest/fixtures/themes/terra-mock-dark-theme/root-theme.scss'];
+
+      expect(files).toEqual(expected);
+    });
+
+    it('returns the aggregated default theme for a defined default theme and empty scope theme', () => {
+      const options = { theme: 'terra-mock-dark-theme', scoped: [] };
+
+      const files = ThemeAggregator.aggregateThemes(options);
+      const expected = ['../tests/jest/fixtures/themes/terra-mock-dark-theme/root-theme.scss'];
+
+      expect(files).toEqual(expected);
+    });
+  });
+
   describe('aggregateTheme', () => {
+    it('warns if a blank value is passed as a themename and returns null', () => {
+      const files = ThemeAggregator.aggregateTheme('');
+
+      // eslint-disable-next-line no-console
+      expect(console.warn).toHaveBeenCalled();
+      expect(files).toEqual(null);
+    });
+
     it('returns an array of aggregated default theme file paths', () => {
       const options = { theme: 'terra-mock-dark-theme' };
 
@@ -114,34 +208,6 @@ describe('Theme Aggregator', () => {
     });
   });
 
-  describe('validate', () => {
-    it('does not warn if there is a default theme but not a scoped theme', () => {
-      const options = { theme: 'terra-mock-dark-theme' };
-
-      ThemeAggregator.validate(options);
-
-      // eslint-disable-next-line no-console
-      expect(console.warn).toHaveBeenCalledTimes(0);
-    });
-
-    it('does not warn if there is a scoped theme but not a default theme', () => {
-      const options = { scoped: ['terra-mock-dark-theme'] };
-
-      ThemeAggregator.validate(options);
-
-      // eslint-disable-next-line no-console
-      expect(console.warn).toHaveBeenCalledTimes(0);
-    });
-
-    it('warns if there is not a default theme or a scoped theme', () => {
-      const options = {};
-
-      ThemeAggregator.validate(options);
-
-      // eslint-disable-next-line no-console
-      expect(console.warn).toHaveBeenCalled();
-    });
-  });
 
   describe('writeSCSSFile', () => {
     it('returns the generated SCSS file path relative to the given output path.', () => {

--- a/tests/jest/aggregate-themes.test.js
+++ b/tests/jest/aggregate-themes.test.js
@@ -3,14 +3,14 @@ const ThemeAggregator = require('../../scripts/aggregate-themes/theme-aggregator
 
 global.console = { log: jest.fn(), warn: jest.fn() };
 
-/* eslint-disable no-console */
-afterEach(() => {
-  console.warn.mockClear();
-  console.log.mockClear();
-});
-
 describe('Theme Aggregator', () => {
   describe('validate', () => {
+    /* eslint-disable no-console */
+    afterEach(() => {
+      console.warn.mockClear();
+      console.log.mockClear();
+    });
+
     it('does not warn if there is a default theme but not a scoped theme', () => {
       const options = { theme: 'terra-mock-dark-theme' };
 
@@ -107,8 +107,6 @@ describe('Theme Aggregator', () => {
     it('warns if a blank value is passed as a themename and returns null', () => {
       const files = ThemeAggregator.aggregateTheme('');
 
-      // eslint-disable-next-line no-console
-      expect(console.warn).toHaveBeenCalled();
       expect(files).toEqual(null);
     });
 

--- a/tests/jest/aggregate-themes.test.js
+++ b/tests/jest/aggregate-themes.test.js
@@ -47,32 +47,32 @@ describe('Theme Aggregator', () => {
   });
 
   describe('aggregateThemes', () => {
-    it('returns an empty array for an empty default theme and empty array scope theme', () => {
+    it('returns null for an empty default theme and empty array scope theme', () => {
       const options = { theme: '', scoped: [] };
 
       const files = ThemeAggregator.aggregateThemes(options);
-      expect(files).toEqual([]);
+      expect(files).toBeNull();
     });
 
-    it('returns an empty array for an null default theme and null array scope theme', () => {
+    it('returns null for an null default theme and null array scope theme', () => {
       const options = { theme: null, scoped: null };
 
       const files = ThemeAggregator.aggregateThemes(options);
-      expect(files).toEqual([]);
+      expect(files).toBeNull();
     });
 
-    it('returns an empty array for a null default theme and scope theme array containing null and a non existent theme.', () => {
+    it('returns null for a null default theme and scope theme array containing null and a non existent theme.', () => {
       const options = { theme: null, scoped: [null, 'non-existent'] };
 
       const files = ThemeAggregator.aggregateThemes(options);
-      expect(files).toEqual([]);
+      expect(files).toBeNull();
     });
 
-    it('returns an empty array for a non existent default theme and empty scope theme', () => {
+    it('returns null for a non existent default theme and empty scope theme', () => {
       const options = { theme: 'unknown-theme', scoped: '' };
 
       const files = ThemeAggregator.aggregateThemes(options);
-      expect(files).toEqual([]);
+      expect(files).toBeNull();
     });
 
     it('returns the aggregated scoped theme for a non existent default theme and defined scope theme', () => {

--- a/tests/jest/aggregate-themes.test.js
+++ b/tests/jest/aggregate-themes.test.js
@@ -3,8 +3,13 @@ const ThemeAggregator = require('../../scripts/aggregate-themes/theme-aggregator
 
 global.console = { log: jest.fn(), warn: jest.fn() };
 
+/* eslint-disable no-console */
+afterEach(() => {
+  console.warn.mockClear();
+  console.log.mockClear();
+});
+
 describe('Theme Aggregator', () => {
-  /* eslint-disable no-console */
   describe('validate', () => {
     it('does not warn if there is a default theme but not a scoped theme', () => {
       const options = { theme: 'terra-mock-dark-theme' };
@@ -30,8 +35,6 @@ describe('Theme Aggregator', () => {
       expect(console.warn).toHaveBeenCalled();
     });
 
-    console.warn.mockClear();
-    console.log.mockClear();
     /* eslint-enable no-console */
   });
 


### PR DESCRIPTION
### Summary
Sorry everyone, another theme update. 

This guards against the possibility someone passes an empty array for `scoped` via theme config.