### PR TITLE
Unlock postcss version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Unlocked the version of postcss from "v7.0.18" to "v7.0.21".
 
 5.11.0 - (October 25, 2019)
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+
+5.11.0 - (October 25, 2019)
+----------
 ### Fixed
 * Lock down postcss dependency to v7.0.18
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "terra-toolkit",
-  "version": "5.10.0",
+  "version": "5.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9107,9 +9107,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "7.0.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-      "integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+      "version": "7.0.21",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
+      "integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
       "requires": {
         "chalk": "^2.4.2",
         "source-map": "^0.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terra-toolkit",
-  "version": "5.10.0",
+  "version": "5.11.0",
   "description": "Utilities to help when developing terra modules.",
   "main": "lib/index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "memory-fs": "^0.4.1",
     "mini-css-extract-plugin": "^0.8.0",
     "node-sass": "^4.11.0",
-    "postcss": "7.0.18",
+    "postcss": "^7.0.21",
     "postcss-assets-webpack-plugin": "^3.0.0",
     "postcss-custom-properties": "^9.0.2",
     "postcss-loader": "^3.0.0",


### PR DESCRIPTION
### Summary
Postcss v7.0.21 fixes our issue.

### Additional Details
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
