### PR TITLE
Exit wdio test run if webpack fails to compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Unreleased
 ----------
 ### Added
-* Tap into the `failed` webpack compiler hook to flag compilation failure.
+* Tap into the `failed` webpack compiler hook to exit the wdio test runner when compilation fails.
 
 5.12.0 - (October 30, 2019)
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Tap into the `failed` webpack compiler hook to flag compilation failure.
 
 5.12.0 - (October 30, 2019)
 ----------

--- a/src/wdio/services/ServeStaticService.js
+++ b/src/wdio/services/ServeStaticService.js
@@ -75,6 +75,11 @@ const startWebpackDevServer = (options) => {
       }
     });
 
+    compiler.hooks.failed.tap('Failed', () => {
+      Logger.warn('Webpack failed to compile', { context });
+      reject();
+    });
+
     // start that server.
     devServer.listen(port, host, (err) => {
       if (err) {


### PR DESCRIPTION
### Summary
Closes #345 

Tested it out by recreating the issue that we faced with postcss 7.20.0 and here's the output ⬇️

<details> <summary> Log </summary> 

```
[Terra-Toolkit:terra-service] Running tests against Selenium 3.14
[terra-aggregate-translations] Aggregating translations for en,en-AU,en-CA,en-US,en-GB,es,es-US,es-ES,de,fr,fr-FR,nl,nl-BE,pt,pt-BR,sv,sv-SE locales.
ℹ ｢wds｣: Project is running at http://0.0.0.0:8080/webpack-dev-server/
ℹ ｢wds｣: webpack output is served from
ℹ ｢wds｣: Content not from webpack is served from /Users/nr046097/terra-core
ℹ ｢wds｣: 404s will fallback to /index.html
[Terra-Toolkit:serve-static-service] Server started listening
[Terra-Toolkit:selenium-docker] Removing docker selenium stack
[Terra-Toolkit:selenium-docker] Deploying docker selenium stack
[Terra-Toolkit:selenium-docker] Ensuring selenium status is ready
[Terra-Toolkit:serve-static-service] Webpack failed to compile
✖ ｢wdm｣: TypeError: Cannot read property 'value' of undefined
    at /Users/nr046097/terra-core/5-e76c83cb981b6e5b5758.css:7:11962
    at new Quoted (/Users/nr046097/terra-core/node_modules/postcss-values-parser/lib/nodes/Quoted.js:19:28)
    at cloneNode (/Users/nr046097/terra-core/node_modules/postcss/lib/node.js:15:16)
    at Quoted.clone (/Users/nr046097/terra-core/node_modules/postcss/lib/node.js:248:18)
    at Func.Node (/Users/nr046097/terra-core/node_modules/postcss/lib/node.js:83:30)
    at new Container (/Users/nr046097/terra-core/node_modules/postcss/lib/container.js:45:18)
    at new Container (/Users/nr046097/terra-core/node_modules/postcss-values-parser/lib/nodes/Container.js:15:1)
    at new Func (/Users/nr046097/terra-core/node_modules/postcss-values-parser/lib/nodes/Func.js:19:5)
    at asClonedNode (/Users/nr046097/terra-core/node_modules/postcss-custom-properties/index.cjs.js:254:21)
    at array.map.node (/Users/nr046097/terra-core/node_modules/postcss-custom-properties/index.cjs.js:250:60)
    at Array.map (<anonymous>)
    at asClonedArray (/Users/nr046097/terra-core/node_modules/postcss-custom-properties/index.cjs.js:250:48)
    at asClonedArrayWithBeforeSpacing (/Users/nr046097/terra-core/node_modules/postcss-custom-properties/index.cjs.js:240:23)
    at root.nodes.slice.forEach.child (/Users/nr046097/terra-core/node_modules/postcss-custom-properties/index.cjs.js:213:44)
    at Array.forEach (<anonymous>)
    at transformValueAST (/Users/nr046097/terra-core/node_modules/postcss-custom-properties/index.cjs.js:193:24)
    at root.walkDecls.decl (/Users/nr046097/terra-core/node_modules/postcss-custom-properties/index.cjs.js:275:28)
/Users/nr046097/terra-core/node_modules/webdriverio/build/lib/cli.js:457
                throw e;
                ^

TypeError: Cannot read property 'stack' of undefined
    at Launcher._callee2$ (/Users/nr046097/terra-core/node_modules/webdriverio/build/lib/launcher.js:417:107)
    at tryCatch (/Users/nr046097/terra-core/node_modules/babel-runtime/node_modules/regenerator-runtime/runtime.js:62:40)
    at Generator.invoke [as _invoke] (/Users/nr046097/terra-core/node_modules/babel-runtime/node_modules/regenerator-runtime/runtime.js:296:22)
    at Generator.prototype.(anonymous function) [as throw] (/Users/nr046097/terra-core/node_modules/babel-runtime/node_modules/regenerator-runtime/runtime.js:114:21)
    at step (/Users/nr046097/terra-core/node_modules/babel-runtime/helpers/asyncToGenerator.js:17:30)
    at /Users/nr046097/terra-core/node_modules/babel-runtime/helpers/asyncToGenerator.js:30:13
    at <anonymous>
    at runMicrotasksCallback (internal/process/next_tick.js:122:5)
    at _combinedTickCallback (internal/process/next_tick.js:132:7)
    at process._tickDomainCallback (internal/process/next_tick.js:219:9)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! terra-core@0.1.0 wdio: `NODE_OPTIONS=--max-old-space-size=2048 wdio node_modules/terra-toolkit/config/wdio/wdio.conf.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the terra-core@0.1.0 wdio script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```
</details>
