### PR TITLE
Update Duplicate Checker List

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Add `terra-i18n` to the list provided to the duplicate package checker plugin in the webpack configuration.
+
 ### Fixed
 * Allow custom mismatch tolerance of 0
 

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -133,7 +133,6 @@ const webpackConfig = (options, env, argv) => {
           'terra-disclosure-manager',
           'terra-i18n',
           'terra-navigation-prompt',
-          'terra-theme-provider',
         ],
       }),
       new webpack.DefinePlugin({

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -128,10 +128,12 @@ const webpackConfig = (options, env, argv) => {
           'react-dom',
           'react-intl',
           'react-on-rails',
-          'terra-breakpoints',
           'terra-application',
+          'terra-breakpoints',
           'terra-disclosure-manager',
+          'terra-i18n',
           'terra-navigation-prompt',
+          'terra-theme-provider',
         ],
       }),
       new webpack.DefinePlugin({


### PR DESCRIPTION
### Summary
The the follow dependencies to the duplicate plugin checker list to ensure one version is included in the packed assets.