### PR TITLE
Adding git to terra-node-base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased
 ### Added
 * Add new terra docker containers based on alpine for ci and development
 * Add support for onBeforeUnload in firefox selenium testing
+* Adding git to terra-node-base to be able to reference git branches while testing.
 
 5.16.0 - (December 3, 2019)
 ----------

--- a/docker/terra-node-base/Dockerfile
+++ b/docker/terra-node-base/Dockerfile
@@ -6,6 +6,7 @@ EXPOSE 8080
 
 ENV CI true
 
-RUN npm config set unsafe-perm true -g
+RUN npm config set unsafe-perm true -g \
+  && apk add git
 
 WORKDIR /opt/module

--- a/docker/terra-node-dev/Dockerfile
+++ b/docker/terra-node-dev/Dockerfile
@@ -3,7 +3,7 @@
 FROM cerner/terra-node-base:latest
 
 #install zsh / oh-my-zsh
-RUN apk add zsh curl wget git \
+RUN apk add zsh curl wget \
   && wget https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh -O - | zsh || true
 
 ENV WDIO_BAIL false


### PR DESCRIPTION
### Summary
Adding git to terra-node-base so we can reference git dependencies during testing.

### Additional Details

@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
