### PR TITLE
add inTest env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Added an 'inTest' env to the serveStaticService to allow webpack to render the test site differently.
 
 5.20.0 - (January 28, 2020)
 ----------

--- a/src/wdio/services/ServeStaticService.js
+++ b/src/wdio/services/ServeStaticService.js
@@ -40,6 +40,7 @@ const startWebpackDevServer = (options) => {
     const env = {
       ...locale && { defaultLocale: locale },
       ...theme && { theme },
+      inTest: true,
     };
 
     config = config(env, { p: true });


### PR DESCRIPTION
### Summary
We can improve test times by flexing how we build our test site to not render doc when running the test site. Long term this begs the question of should these be the same site?

### Additional Details
Should we disable theme aggregation  based on the presence of the `inTest` env? We the change may not be passive if any consumers are testing themes by theme switching instead of building another site with the theme defaulted.

Anyone have a better name than `inTest`?

@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
