### PR TITLE
Add precompile script

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "lint": "eslint --ext .js .",
     "pack": "webpack --config tests/test.config.js -p",
     "postinstall": "node ./scripts/post-install/post-install.js",
+    "precompile": "rm -rf lib",
     "prepare": "npm run compile",
     "prepublishOnly": "npm whoami && check-installed-dependencies && npm test",
     "pretest": "npm run lint",


### PR DESCRIPTION
### Summary
The last release published compiled nightwatch files that were removed in v5. a precompile set would have cleaned that up.

![Screen Shot 2020-02-06 at 11 08 23 AM](https://user-images.githubusercontent.com/14099737/73960975-69e1ec80-48d1-11ea-96e2-293ac81469ee.png)
