### PR TITLE
Add TERRA_AGGREGATED_LOCALES global to the webpack bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Unreleased
 ----------
 ### Added
-* Added `TERRA_SUPPORTED_LOCALES` global to the webpack bundle
+* Added `TERRA_AGGREGATED_LOCALES` global to the webpack bundle
 
 5.20.0 - (January 28, 2020)
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added `SUPPORTED_LOCALES` global to the webpack bundle
 
 5.20.0 - (January 28, 2020)
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Unreleased
 ----------
 ### Added
-* Added `SUPPORTED_LOCALES` global to the webpack bundle
+* Added `TERRA_SUPPORTED_LOCALES` global to the webpack bundle
 
 5.20.0 - (January 28, 2020)
 ----------

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -18,6 +18,7 @@ const webpackConfig = (options, env, argv) => {
     rootPath,
     resolveModules,
     staticOptions,
+    supportedLocales,
     themeFile,
   } = options;
 
@@ -137,6 +138,9 @@ const webpackConfig = (options, env, argv) => {
       new webpack.DefinePlugin({
         CERNER_BUILD_TIMESTAMP: JSON.stringify(new Date(Date.now()).toISOString()),
       }),
+      new webpack.DefinePlugin({
+        SUPPORTED_LOCALES: JSON.stringify(supportedLocales),
+      }),
     ],
     resolve: {
       extensions: ['.js', '.jsx'],
@@ -210,8 +214,9 @@ const defaultWebpackConfig = (env = {}, argv = {}) => {
 
   const resolveModules = ['node_modules'];
 
+  let supportedLocales;
   if (!disableAggregateTranslations) {
-    aggregateTranslations({ baseDir: rootPath, ...env.aggregateOptions });
+    supportedLocales = aggregateTranslations({ baseDir: rootPath, ...env.aggregateOptions });
     resolveModules.unshift(path.resolve(rootPath, 'aggregated-translations'));
   }
 
@@ -222,6 +227,7 @@ const defaultWebpackConfig = (env = {}, argv = {}) => {
     rootPath,
     resolveModules,
     staticOptions,
+    supportedLocales,
     themeFile,
   };
 

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -139,7 +139,7 @@ const webpackConfig = (options, env, argv) => {
         CERNER_BUILD_TIMESTAMP: JSON.stringify(new Date(Date.now()).toISOString()),
       }),
       new webpack.DefinePlugin({
-        SUPPORTED_LOCALES: JSON.stringify(supportedLocales),
+        TERRA_SUPPORTED_LOCALES: JSON.stringify(supportedLocales),
       }),
     ],
     resolve: {

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -137,7 +137,7 @@ const webpackConfig = (options, env, argv) => {
       }),
       new webpack.DefinePlugin({
         CERNER_BUILD_TIMESTAMP: JSON.stringify(new Date(Date.now()).toISOString()),
-        TERRA_SUPPORTED_LOCALES: JSON.stringify(supportedLocales),
+        TERRA_AGGREGATED_LOCALES: JSON.stringify(supportedLocales),
       }),
     ],
     resolve: {

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -18,7 +18,7 @@ const webpackConfig = (options, env, argv) => {
     rootPath,
     resolveModules,
     staticOptions,
-    supportedLocales,
+    aggregatedLocales,
     themeFile,
   } = options;
 
@@ -137,7 +137,7 @@ const webpackConfig = (options, env, argv) => {
       }),
       new webpack.DefinePlugin({
         CERNER_BUILD_TIMESTAMP: JSON.stringify(new Date(Date.now()).toISOString()),
-        TERRA_AGGREGATED_LOCALES: JSON.stringify(supportedLocales),
+        TERRA_AGGREGATED_LOCALES: JSON.stringify(aggregatedLocales),
       }),
     ],
     resolve: {
@@ -212,9 +212,9 @@ const defaultWebpackConfig = (env = {}, argv = {}) => {
 
   const resolveModules = ['node_modules'];
 
-  let supportedLocales;
+  let aggregatedLocales;
   if (!disableAggregateTranslations) {
-    supportedLocales = aggregateTranslations({ baseDir: rootPath, ...env.aggregateOptions });
+    aggregatedLocales = aggregateTranslations({ baseDir: rootPath, ...env.aggregateOptions });
     resolveModules.unshift(path.resolve(rootPath, 'aggregated-translations'));
   }
 
@@ -225,7 +225,7 @@ const defaultWebpackConfig = (env = {}, argv = {}) => {
     rootPath,
     resolveModules,
     staticOptions,
-    supportedLocales,
+    aggregatedLocales,
     themeFile,
   };
 

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -137,8 +137,6 @@ const webpackConfig = (options, env, argv) => {
       }),
       new webpack.DefinePlugin({
         CERNER_BUILD_TIMESTAMP: JSON.stringify(new Date(Date.now()).toISOString()),
-      }),
-      new webpack.DefinePlugin({
         TERRA_SUPPORTED_LOCALES: JSON.stringify(supportedLocales),
       }),
     ],

--- a/docs/Webpack.md
+++ b/docs/Webpack.md
@@ -17,7 +17,7 @@ React 16 depends on the collection types ``Map`` and ``Set`` and it depends on `
 ### JavaScript Plugins
 - [DefinePlugin](https://webpack.js.org/plugins/define-plugin/) - Plugin to define global compile-time values, including:
   - `CERNER_BUILD_TIMESTAMP` - The time that webpack was executed in ISO8601 format.
-  - `TERRA_SUPPORTED_LOCALES` - The list of successfully aggregated locales available to the browser.
+  - `TERRA_AGGREGATED_LOCALES` - The list of successfully aggregated locales available to the browser.
 
 ### CSS Loaders and Plugins
 - [autoprefixer](https://github.com/postcss/autoprefixer) - Plugin to parse CSS and add vendor prefixes to CSS rules. This should be configured with [`browserslist-config-terra`](https://github.com/cerner/browserslist-config-terra). \*

--- a/docs/Webpack.md
+++ b/docs/Webpack.md
@@ -17,6 +17,7 @@ React 16 depends on the collection types ``Map`` and ``Set`` and it depends on `
 ### JavaScript Plugins
 - [DefinePlugin](https://webpack.js.org/plugins/define-plugin/) - Plugin to define global compile-time values, including:
   - `CERNER_BUILD_TIMESTAMP` - The time that webpack was executed in ISO8601 format.
+  - `SUPPORTED_LOCALES` - The list of successfully aggregated locales available to the browser.
 
 ### CSS Loaders and Plugins
 - [autoprefixer](https://github.com/postcss/autoprefixer) - Plugin to parse CSS and add vendor prefixes to CSS rules. This should be configured with [`browserslist-config-terra`](https://github.com/cerner/browserslist-config-terra). \*

--- a/docs/Webpack.md
+++ b/docs/Webpack.md
@@ -17,7 +17,7 @@ React 16 depends on the collection types ``Map`` and ``Set`` and it depends on `
 ### JavaScript Plugins
 - [DefinePlugin](https://webpack.js.org/plugins/define-plugin/) - Plugin to define global compile-time values, including:
   - `CERNER_BUILD_TIMESTAMP` - The time that webpack was executed in ISO8601 format.
-  - `SUPPORTED_LOCALES` - The list of successfully aggregated locales available to the browser.
+  - `TERRA_SUPPORTED_LOCALES` - The list of successfully aggregated locales available to the browser.
 
 ### CSS Loaders and Plugins
 - [autoprefixer](https://github.com/postcss/autoprefixer) - Plugin to parse CSS and add vendor prefixes to CSS rules. This should be configured with [`browserslist-config-terra`](https://github.com/cerner/browserslist-config-terra). \*

--- a/package-lock.json
+++ b/package-lock.json
@@ -11171,9 +11171,8 @@
       }
     },
     "terra-aggregate-translations": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/terra-aggregate-translations/-/terra-aggregate-translations-1.5.0.tgz",
-      "integrity": "sha512-hexQb4jIGgayrPZ3IRvD/sGXqesR2gfA3TJQ5BlpsOhRIyMLv2KpuJcoldiRLD+KDjbe/zkhFuKU+z1B5LQbCw==",
+      "version": "git+https://github.com/cerner/terra-aggregate-translations.git#685d7353e2e9da44f62339be39ec6fefa045eb84",
+      "from": "git+https://github.com/cerner/terra-aggregate-translations.git#supported-locales",
       "requires": {
         "chalk": "^2.4.2",
         "commander": "^3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@babel/cli": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.8.3.tgz",
-      "integrity": "sha512-K2UXPZCKMv7KwWy9Bl4sa6+jTNP7JyDiHKzoOiUUygaEDbC60vaargZDnO9oFMvlq8pIKOOyUUgeMYrsaN9djA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.8.4.tgz",
+      "integrity": "sha512-XXLgAm6LBbaNxaGhMAznXXaxtCWfuv6PIDJ9Alsy9JYTOh+j2jJz+L/162kkfU1j/pTSxK1xGmlwI4pdIMkoag==",
       "dev": true,
       "requires": {
         "chokidar": "^2.1.8",
@@ -22,9 +22,9 @@
       },
       "dependencies": {
         "commander": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.0.tgz",
-          "integrity": "sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
           "dev": true
         },
         "source-map": {
@@ -45,28 +45,28 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.8.1.tgz",
-      "integrity": "sha512-Z+6ZOXvyOWYxJ50BwxzdhRnRsGST8Y3jaZgxYig575lTjVSs3KtJnmESwZegg6e2Dn0td1eDhoWlp1wI4BTCPw==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.8.5.tgz",
+      "integrity": "sha512-jWYUqQX/ObOhG1UiEkbH5SANsE/8oKXiQWjj7p7xgj9Zmnt//aUvyz4dBkK0HNsS8/cbyC5NmmH87VekW+mXFg==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.8.2",
+        "browserslist": "^4.8.5",
         "invariant": "^2.2.4",
         "semver": "^5.5.0"
       }
     },
     "@babel/core": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.3.tgz",
-      "integrity": "sha512-4XFkf8AwyrEG7Ziu3L2L0Cv+WyY47Tcsp70JFmpftbAA1K7YL/sgE9jh9HyNj08Y/U50ItUchpN0w6HxAoX1rA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.4.tgz",
+      "integrity": "sha512-0LiLrB2PwrVI+a2/IEskBopDYSd8BCb3rOvH7D5tzoWd696TBEduBvuLVm4Nx6rltrLZqvI3MCalB2K2aVzQjA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.8.3",
-        "@babel/helpers": "^7.8.3",
-        "@babel/parser": "^7.8.3",
+        "@babel/generator": "^7.8.4",
+        "@babel/helpers": "^7.8.4",
+        "@babel/parser": "^7.8.4",
         "@babel/template": "^7.8.3",
-        "@babel/traverse": "^7.8.3",
+        "@babel/traverse": "^7.8.4",
         "@babel/types": "^7.8.3",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
@@ -111,9 +111,9 @@
       }
     },
     "@babel/generator": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.3.tgz",
-      "integrity": "sha512-WjoPk8hRpDRqqzRpvaR8/gDUPkrnOOeuT2m8cNICJtZH6mwaCo3v0OKMI7Y6SM1pBtyijnLtAL0HDi41pf41ug==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
+      "integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.8.3",
@@ -161,15 +161,15 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.3.tgz",
-      "integrity": "sha512-JLylPCsFjhLN+6uBSSh3iYdxKdeO9MNmoY96PE/99d8kyBFaXLORtAVhqN6iHa+wtPeqxKLghDOZry0+Aiw9Tw==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.4.tgz",
+      "integrity": "sha512-3k3BsKMvPp5bjxgMdrFyq0UaEO48HciVrOVF0+lon8pp95cyJ2ujAh0TrBHNMnJGT2rr0iKOJPFFbSqjDyf/Pg==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.8.1",
-        "browserslist": "^4.8.2",
+        "@babel/compat-data": "^7.8.4",
+        "browserslist": "^4.8.5",
         "invariant": "^2.2.4",
-        "levenary": "^1.1.0",
+        "levenary": "^1.1.1",
         "semver": "^5.5.0"
       }
     },
@@ -346,13 +346,13 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.8.3.tgz",
-      "integrity": "sha512-LmU3q9Pah/XyZU89QvBgGt+BCsTPoQa+73RxAQh8fb8qkDyIfeQnmgs+hvzhTCKTzqOyk7JTkS3MS1S8Mq5yrQ==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.8.4.tgz",
+      "integrity": "sha512-VPbe7wcQ4chu4TDQjimHv/5tj73qz88o12EPkO2ValS2QiQS/1F2SsjyIGNnAD0vF/nZS6Cf9i+vW6HIlnaR8w==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.8.3",
-        "@babel/traverse": "^7.8.3",
+        "@babel/traverse": "^7.8.4",
         "@babel/types": "^7.8.3"
       }
     },
@@ -368,9 +368,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.3.tgz",
-      "integrity": "sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
+      "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
@@ -629,9 +629,9 @@
       }
     },
     "@babel/plugin-transform-for-of": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.8.3.tgz",
-      "integrity": "sha512-ZjXznLNTxhpf4Q5q3x1NsngzGA38t9naWH8Gt+0qYZEJAcvPI9waSStSh56u19Ofjr7QmD0wUsQ8hw8s/p1VnA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.8.4.tgz",
+      "integrity": "sha512-iAXNlOWvcYUYoV8YIxwS7TxGRJcxyl8eQCfT+A5j8sKUzRFvJdcyjp97jL2IghWSRDaL2PU2O2tX8Cu9dTBq5A==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3"
@@ -748,9 +748,9 @@
       }
     },
     "@babel/plugin-transform-parameters": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.8.3.tgz",
-      "integrity": "sha512-/pqngtGb54JwMBZ6S/D3XYylQDFtGjWrnoCF4gXZOUpFV/ujbxnoNGNvDGu6doFWRPBveE72qTx/RRU44j5I/Q==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.8.4.tgz",
+      "integrity": "sha512-IsS3oTxeTsZlE5KqzTbcC2sV0P9pXdec53SU+Yxv7o/6dvGM5AkTotQKhoSffhNgZ/dftsSiOoxy7evCYJXzVA==",
       "dev": true,
       "requires": {
         "@babel/helper-call-delegate": "^7.8.3",
@@ -836,9 +836,9 @@
       }
     },
     "@babel/plugin-transform-typeof-symbol": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.8.3.tgz",
-      "integrity": "sha512-3TrkKd4LPqm4jHs6nPtSDI/SV9Cm5PRJkHLUgTcqRQQTMAZ44ZaAdDZJtvWFSaRcvT0a1rTmJ5ZA5tDKjleF3g==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.8.4.tgz",
+      "integrity": "sha512-2QKyfjGdvuNfHsb7qnBBlKclbD4CfshH2KvDabiijLMGXPHJXGxtDzwIF7bQP+T0ysw8fYTtxPafgfs/c1Lrqg==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3"
@@ -855,13 +855,13 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.8.3.tgz",
-      "integrity": "sha512-Rs4RPL2KjSLSE2mWAx5/iCH+GC1ikKdxPrhnRS6PfFVaiZeom22VFKN4X8ZthyN61kAaR05tfXTbCvatl9WIQg==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.8.4.tgz",
+      "integrity": "sha512-HihCgpr45AnSOHRbS5cWNTINs0TwaR8BS8xIIH+QwiW8cKL0llV91njQMpeMReEPVs+1Ao0x3RLEBLtt1hOq4w==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.8.0",
-        "@babel/helper-compilation-targets": "^7.8.3",
+        "@babel/compat-data": "^7.8.4",
+        "@babel/helper-compilation-targets": "^7.8.4",
         "@babel/helper-module-imports": "^7.8.3",
         "@babel/helper-plugin-utils": "^7.8.3",
         "@babel/plugin-proposal-async-generator-functions": "^7.8.3",
@@ -890,7 +890,7 @@
         "@babel/plugin-transform-dotall-regex": "^7.8.3",
         "@babel/plugin-transform-duplicate-keys": "^7.8.3",
         "@babel/plugin-transform-exponentiation-operator": "^7.8.3",
-        "@babel/plugin-transform-for-of": "^7.8.3",
+        "@babel/plugin-transform-for-of": "^7.8.4",
         "@babel/plugin-transform-function-name": "^7.8.3",
         "@babel/plugin-transform-literals": "^7.8.3",
         "@babel/plugin-transform-member-expression-literals": "^7.8.3",
@@ -901,7 +901,7 @@
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
         "@babel/plugin-transform-new-target": "^7.8.3",
         "@babel/plugin-transform-object-super": "^7.8.3",
-        "@babel/plugin-transform-parameters": "^7.8.3",
+        "@babel/plugin-transform-parameters": "^7.8.4",
         "@babel/plugin-transform-property-literals": "^7.8.3",
         "@babel/plugin-transform-regenerator": "^7.8.3",
         "@babel/plugin-transform-reserved-words": "^7.8.3",
@@ -909,32 +909,22 @@
         "@babel/plugin-transform-spread": "^7.8.3",
         "@babel/plugin-transform-sticky-regex": "^7.8.3",
         "@babel/plugin-transform-template-literals": "^7.8.3",
-        "@babel/plugin-transform-typeof-symbol": "^7.8.3",
+        "@babel/plugin-transform-typeof-symbol": "^7.8.4",
         "@babel/plugin-transform-unicode-regex": "^7.8.3",
         "@babel/types": "^7.8.3",
-        "browserslist": "^4.8.2",
+        "browserslist": "^4.8.5",
         "core-js-compat": "^3.6.2",
         "invariant": "^2.2.2",
-        "levenary": "^1.1.0",
+        "levenary": "^1.1.1",
         "semver": "^5.5.0"
       }
     },
     "@babel/runtime": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.3.tgz",
-      "integrity": "sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
+      "integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
       "dev": true,
       "requires": {
-        "regenerator-runtime": "^0.13.2"
-      }
-    },
-    "@babel/runtime-corejs3": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.8.3.tgz",
-      "integrity": "sha512-lrIU4aVbmlM/wQPzhEvzvNJskKyYptuXb0fGC0lTQTupTOYtR2Vqbu6/jf8vTr4M8Wt1nIzxVrSvPI5qESa/xA==",
-      "dev": true,
-      "requires": {
-        "core-js-pure": "^3.0.0",
         "regenerator-runtime": "^0.13.2"
       }
     },
@@ -950,16 +940,16 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.3.tgz",
-      "integrity": "sha512-we+a2lti+eEImHmEXp7bM9cTxGzxPmBiVJlLVD+FuuQMeeO7RaDbutbgeheDkw+Xe3mCfJHnGOWLswT74m2IPg==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
+      "integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.8.3",
+        "@babel/generator": "^7.8.4",
         "@babel/helper-function-name": "^7.8.3",
         "@babel/helper-split-export-declaration": "^7.8.3",
-        "@babel/parser": "^7.8.3",
+        "@babel/parser": "^7.8.4",
         "@babel/types": "^7.8.3",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
@@ -1006,9 +996,9 @@
       }
     },
     "@cnakazawa/watch": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
-      "integrity": "sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
+      "integrity": "sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==",
       "dev": true,
       "requires": {
         "exec-sh": "^0.3.2",
@@ -1300,9 +1290,9 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/node": {
-      "version": "13.5.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.1.tgz",
-      "integrity": "sha512-Jj2W7VWQ2uM83f8Ls5ON9adxN98MvyJsMSASYFuSvrov8RMRY64Ayay7KV35ph1TSGIJ2gG9ZVDdEq3c3zaydA=="
+      "version": "13.7.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.1.tgz",
+      "integrity": "sha512-Zq8gcQGmn4txQEJeiXo/KiLpon8TzAl0kmKH4zdWctPj05nWwp1ClMdAVEloqrQKfaC48PNLdgN/aVaLqUrluA=="
     },
     "@types/source-list-map": {
       "version": "0.1.2",
@@ -1329,9 +1319,9 @@
       }
     },
     "@types/webpack": {
-      "version": "4.41.3",
-      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.3.tgz",
-      "integrity": "sha512-dH+BZ6pHBZFrXpnif0YU/PbmUq3lQrvRPnqkxsciSIzvG/DE+Vm/Wrjn56T7V3+B5ryQa5fw0oGnHL8tk4ll6w==",
+      "version": "4.41.6",
+      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.6.tgz",
+      "integrity": "sha512-iWRpV5Ej+8uKrgxp6jXz3v7ZTjgtuMXY+rsxQjFNU0hYCnHkpA7vtiNffgxjuxX4feFHBbz0IF76OzX2OqDYPw==",
       "requires": {
         "@types/anymatch": "*",
         "@types/node": "*",
@@ -1352,9 +1342,9 @@
       }
     },
     "@types/yargs": {
-      "version": "13.0.7",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.7.tgz",
-      "integrity": "sha512-Sg9kNeJz+V+W+0fugcVhHC+mNHnydDR1RJrW5Qn2jVrDQARF8wfPVqIqwEzZp+bneuEBIm2ClsJ1/je42ZBzSg==",
+      "version": "13.0.8",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+      "integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
       "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
@@ -2006,14 +1996,10 @@
       "integrity": "sha512-g7MguJCPvWgEvdJHDnWG+xDbDqiiy7t+KvryGUc8y8Pv4ElLpCnpa6CWMvqRozpojRgXR/ubCIsoVljhDEk2lA=="
     },
     "axobject-query": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.1.1.tgz",
-      "integrity": "sha512-lF98xa/yvy6j3fBHAgQXIYl+J4eZadOSqsPojemUqClzNbBV38wWGpUbQbVEyf4eUF5yF7eHmGgGA2JiHyjeqw==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.7.4",
-        "@babel/runtime-corejs3": "^7.7.4"
-      }
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.1.2.tgz",
+      "integrity": "sha512-ICt34ZmrVt8UQnvPl6TVyDTkmhXmAyAT4Jh5ugfGUX4MOrZ+U/ZY6/sdylRw3qGNr9Ub5AJsaHeDMzNLehRdOQ==",
+      "dev": true
     },
     "babel-jest": {
       "version": "24.9.0",
@@ -2429,13 +2415,13 @@
       }
     },
     "browserslist": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.5.tgz",
-      "integrity": "sha512-4LMHuicxkabIB+n9874jZX/az1IaZ5a+EUuvD7KFOu9x/Bd5YHyO0DIz2ls/Kl8g0ItS4X/ilEgf4T1Br0lgSg==",
+      "version": "4.8.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.7.tgz",
+      "integrity": "sha512-gFOnZNYBHrEyUML0xr5NJ6edFaaKbTFX9S9kQHlYfCP0Rit/boRIz4G+Avq6/4haEKJXdGGUnoolx+5MWW2BoA==",
       "requires": {
-        "caniuse-lite": "^1.0.30001022",
-        "electron-to-chromium": "^1.3.338",
-        "node-releases": "^1.1.46"
+        "caniuse-lite": "^1.0.30001027",
+        "electron-to-chromium": "^1.3.349",
+        "node-releases": "^1.1.49"
       }
     },
     "browserslist-config-terra": {
@@ -2631,15 +2617,15 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30001023",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001023.tgz",
-      "integrity": "sha512-EnlshvE6oAum+wWwKmJNVaoqJMjIc0bLUy4Dj77VVnz1o6bzSPr1Ze9iPy6g5ycg1xD6jGU6vBmo7pLEz2MbCQ==",
+      "version": "1.0.30001027",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001027.tgz",
+      "integrity": "sha512-Ublzr9IN2X91lTvJzehRUlK+hREae1Hi+0TIh7rH5fAcsuPWycwBAszhRGF22gf5xbDXXUdYQ6fSfPSQEqQhkw==",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001023",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001023.tgz",
-      "integrity": "sha512-C5TDMiYG11EOhVOA62W1p3UsJ2z4DsHtMBQtjzp3ZsUglcQn62WOUgW0y795c7A5uZ+GCEIvzkMatLIlAsbNTA=="
+      "version": "1.0.30001027",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001027.tgz",
+      "integrity": "sha512-7xvKeErvXZFtUItTHgNtLgS9RJpVnwBlWX8jSo/BO8VsF6deszemZSkJJJA1KOKrXuzZH4WALpAJdq5EyfgMLg=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -2753,9 +2739,9 @@
       }
     },
     "chownr": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
-      "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "chrome-trace-event": {
       "version": "1.0.2",
@@ -3102,12 +3088,6 @@
           "dev": true
         }
       }
-    },
-    "core-js-pure": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.4.tgz",
-      "integrity": "sha512-epIhRLkXdgv32xIUFaaAry2wdxZYBi6bgM7cB136dzzXXa+dFyRLTZeLUJxnd8ShrmyVXBub63n2NHo2JAt8Cw==",
-      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -3694,9 +3674,9 @@
       "integrity": "sha512-GJCAeDBKfREgkBtgrYSf9hQy9kTb3helv0zGdzqhM7iAkW8FA/ZF97VQDbwFiwIT8MQLLOe5VlPZOEvZAqtUAQ=="
     },
     "electron-to-chromium": {
-      "version": "1.3.341",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.341.tgz",
-      "integrity": "sha512-iezlV55/tan1rvdvt7yg7VHRSkt+sKfzQ16wTDqTbQqtl4+pSUkKPXpQHDvEt0c7gKcUHHwUbffOgXz6bn096g=="
+      "version": "1.3.349",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.349.tgz",
+      "integrity": "sha512-uEb2zs6EJ6OZIqaMsCSliYVgzE/f7/s1fLWqtvRtHg/v5KBF2xds974fUnyatfxIDgkqzQVwFtam5KExqywx0Q=="
     },
     "elliptic": {
       "version": "6.5.2",
@@ -3828,9 +3808,9 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.13.0.tgz",
-      "integrity": "sha512-eYk2dCkxR07DsHA/X2hRBj0CFAZeri/LyDMc0C8JT1Hqi6JnVpMhJ7XFITbb0+yZS3lVkaPL2oCkZ3AVmeVbMw==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
+      "integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
       "dev": true,
       "requires": {
         "esprima": "^4.0.1",
@@ -4250,9 +4230,9 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.20.0.tgz",
-      "integrity": "sha512-NK42oA0mUc8Ngn4kONOPsPB1XhbUvNHqF+g307dPV28aknPoiNnKLFd9em4nkswwepdF5ouieqv5Th/63U7YJQ==",
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.20.1.tgz",
+      "integrity": "sha512-qQHgFOTjguR+LnYRoToeZWT62XM55MBVXObHM6SKFd1VzDcX/vqT1kAz8ssqigh5eMj8qXcRoXXGZpPP6RfdCw==",
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
@@ -4479,9 +4459,9 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.1.0.tgz",
+      "integrity": "sha512-MxYW9xKmROWF672KqjO75sszsA8Mxhw06YFeS5VHlB98KDHbOSurm3ArsjO60Eaf3QmGMCP1yn+0JQkNLo/97Q==",
       "dev": true,
       "requires": {
         "estraverse": "^4.0.0"
@@ -5894,12 +5874,12 @@
       }
     },
     "globule": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.0.tgz",
-      "integrity": "sha512-YlD4kdMqRCQHrhVdonet4TdRtv1/sZKepvoxNT4Nrhrp5HI8XFfc8kFlGlBn2myBo80aGp8Eft259mbcUJhgSg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.1.tgz",
+      "integrity": "sha512-OVyWOHgw29yosRHCHo7NncwR1hW5ew0W/UrvtwvjefVJeQ26q4/8r8FmPsSF1hJ93IgWkyv16pCTz6WblMzm/g==",
       "requires": {
         "glob": "~7.1.1",
-        "lodash": "~4.17.10",
+        "lodash": "~4.17.12",
         "minimatch": "~3.0.2"
       }
     },
@@ -6669,12 +6649,9 @@
       "dev": true
     },
     "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w=="
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
@@ -7632,9 +7609,9 @@
       "integrity": "sha1-U+RI7J0mPmgyZkZ+lELSxaLvVII="
     },
     "js-base64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
-      "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.2.tgz",
+      "integrity": "sha512-Vg8czh0Q7sFBSUMWWArX/miJeBWYBPpdU/3M/DKSaekLMqrqVPaedp+5mZhie/r0lgrcaYBfwXatEew6gwgiQQ=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -7930,9 +7907,9 @@
       "dev": true
     },
     "loglevel": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.6.tgz",
-      "integrity": "sha512-Sgr5lbboAUBo3eXCSPL4/KoVz3ROKquOjcctxmHIt+vol2DrqTQe3SwkKKuYhEiWB5kYa13YyopJ69deJ1irzQ==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.7.tgz",
+      "integrity": "sha512-cY2eLFrQSAfVPhCgH1s7JI73tMbg9YC3v3+ZHVW67sBS7UxWzNEk/ZBbSfLykBWHp33dqqtOv82gjhKEi81T/A==",
       "dev": true
     },
     "loose-envify": {
@@ -8033,9 +8010,9 @@
       }
     },
     "mdn-browser-compat-data": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-1.0.6.tgz",
-      "integrity": "sha512-XljrVZJi3y3v9+QkNyalvyWgvKU3io7vHqLJtbJewRHrEKJKt+mvznJZljLtYST9MRhe+5/db7yzRQW4YjT7yA==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-1.0.8.tgz",
+      "integrity": "sha512-kKeKCj/QAkCf9B/trLeYMCDBw0Jz1jMQvjNXnw1ZT++4xVUqvWs4dcUAPkp47q5x8N8sYpNXXnG8XghUsR+PfQ==",
       "dev": true,
       "requires": {
         "extend": "3.0.2"
@@ -8532,9 +8509,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.47",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.47.tgz",
-      "integrity": "sha512-k4xjVPx5FpwBUj0Gw7uvFOTF4Ep8Hok1I6qjwL3pLfwe7Y0REQSAqOwwv9TWBCUtMHxcXfY4PgRLRozcChvTcA==",
+      "version": "1.1.49",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.49.tgz",
+      "integrity": "sha512-xH8t0LS0disN0mtRCh+eByxFPie+msJUBL/lJDBuap53QGiYPa9joh83K4pCZgWJ+2L4b9h88vCVdXQ60NO2bg==",
       "requires": {
         "semver": "^6.3.0"
       },
@@ -9026,9 +9003,9 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "pako": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
-      "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "dev": true
     },
     "parallel-transform": {
@@ -9471,9 +9448,9 @@
       "integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ=="
     },
     "postcss-values-parser": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-3.0.5.tgz",
-      "integrity": "sha512-0N6EUBx2Vzl0c9LQipuus90EkVh7saBQFRhgAYpHHcDCIvxRt+K/q0zwcIYtDQVNs5Y9NGqei4AuCEvAOsePfQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-3.1.1.tgz",
+      "integrity": "sha512-p56/Cu9wb8+lck/iOTeuFeSHKEUH1bbWQ03T6N3jDkw+15pV65rMY5pK+OWhVpRn5TIrByS6UVpO3mSqvlhZYA==",
       "requires": {
         "color-name": "^1.1.4",
         "is-number": "^7.0.0",
@@ -9983,9 +9960,9 @@
       }
     },
     "request": {
-      "version": "2.88.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -9994,7 +9971,7 @@
         "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
         "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
+        "har-validator": "~5.1.3",
         "http-signature": "~1.2.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
@@ -10004,7 +9981,7 @@
         "performance-now": "^2.1.0",
         "qs": "~6.5.2",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
+        "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
       },
@@ -10051,9 +10028,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.0.tgz",
-      "integrity": "sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+      "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -10151,9 +10128,9 @@
       "dev": true
     },
     "rtlcss": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-2.4.1.tgz",
-      "integrity": "sha512-pOY30CIGvvQTW1iBfxO6Ry6/J/C4U7fcOhtF0pm5fNgwmJXOtx5gib6czFmWyp1KXN/6rbMRsTZwWlAridxBTQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-2.5.0.tgz",
+      "integrity": "sha512-NCVdF45w70/3CQeqVvQ84bu2HN8agNn+CDjw+RxXaiWb7mPOmEvltdd1z4qzm9kin4Jnu9ShFBIx28yvWerZ2g==",
       "requires": {
         "chalk": "^2.4.2",
         "findup": "^0.1.5",
@@ -11171,8 +11148,9 @@
       }
     },
     "terra-aggregate-translations": {
-      "version": "git+https://github.com/cerner/terra-aggregate-translations.git#685d7353e2e9da44f62339be39ec6fefa045eb84",
-      "from": "git+https://github.com/cerner/terra-aggregate-translations.git#supported-locales",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/terra-aggregate-translations/-/terra-aggregate-translations-1.6.0.tgz",
+      "integrity": "sha512-6/sbAwI93NOJukZ8a96kCZgyg/wv3jzkd3VZlzk6v7vN702lBOoDrJ36R+DdlB8MFCNapC7XpP+lTGgTnE+dvw==",
       "requires": {
         "chalk": "^2.4.2",
         "commander": "^3.0.1",
@@ -11471,19 +11449,12 @@
       "dev": true
     },
     "tough-cookie": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-        }
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
       }
     },
     "tr46": {
@@ -12031,9 +12002,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "4.41.5",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.5.tgz",
-      "integrity": "sha512-wp0Co4vpyumnp3KlkmpM5LWuzvZYayDwM2n17EHFr4qxBBbRokC7DJawPJC7TfSFZ9HZ6GsdH40EBj4UV0nmpw==",
+      "version": "4.41.6",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.6.tgz",
+      "integrity": "sha512-yxXfV0Zv9WMGRD+QexkZzmGIh54bsvEs+9aRWxnN8erLWEOehAKUTeNBoUbA6HPEZPlRo7KDi2ZcNveoZgK9MA==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -12091,9 +12062,9 @@
       }
     },
     "webpack-cli": {
-      "version": "3.3.10",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.10.tgz",
-      "integrity": "sha512-u1dgND9+MXaEt74sJR4PR7qkPxXUSQ0RXYq8x1L6Jg1MYVEmGPrH6Ah6C4arD4r0J1P5HKjRqpab36k0eIzPqg==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.11.tgz",
+      "integrity": "sha512-dXlfuml7xvAFwYUPsrtQAA9e4DOe58gnzSxhgrO/ZM/gyXTBowrsYeubyN4mqGhYdpXMFNyQ6emjJS9M7OBd4g==",
       "dev": true,
       "requires": {
         "chalk": "2.4.2",
@@ -12311,9 +12282,9 @@
       }
     },
     "webpack-dev-server": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.10.1.tgz",
-      "integrity": "sha512-AGG4+XrrXn4rbZUueyNrQgO4KGnol+0wm3MPdqGLmmA+NofZl3blZQKxZ9BND6RDNuvAK9OMYClhjOSnxpWRoA==",
+      "version": "3.10.3",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.10.3.tgz",
+      "integrity": "sha512-e4nWev8YzEVNdOMcNzNeCN947sWJNd43E5XvsJzbAL08kGc2frm1tQ32hTJslRS+H65LCb/AaUCYU7fjHCpDeQ==",
       "dev": true,
       "requires": {
         "ansi-html": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "postcss-rtl": "^1.3.3",
     "raw-loader": "^3.0.0",
     "sass-loader": "^7.0.1",
-    "terra-aggregate-translations": "^1.0.0",
+    "terra-aggregate-translations": "git+https://github.com/cerner/terra-aggregate-translations.git#supported-locales",
     "terser-webpack-plugin": "^1.1.0",
     "wdio-mocha-framework": "^0.6.4",
     "wdio-visual-regression-service": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "postcss-rtl": "^1.3.3",
     "raw-loader": "^3.0.0",
     "sass-loader": "^7.0.1",
-    "terra-aggregate-translations": "git+https://github.com/cerner/terra-aggregate-translations.git#supported-locales",
+    "terra-aggregate-translations": "^1.6.0",
     "terser-webpack-plugin": "^1.1.0",
     "wdio-mocha-framework": "^0.6.4",
     "wdio-visual-regression-service": "^0.9.0",

--- a/tests/jest/config/webpack/webpack.config.test.js
+++ b/tests/jest/config/webpack/webpack.config.test.js
@@ -220,6 +220,10 @@ describe('webpack config', () => {
       expect(config.resolve.modules).toHaveLength(1);
       expect(config.resolveLoader.modules).not.toEqual(expectedModules);
     });
+
+    it('should add the SUPPORTED_LOCALES global as undefined if locale aggregation is disabled', () => {
+      expect(DefinePlugin).toBeCalledWith({ SUPPORTED_LOCALES: undefined });
+    });
   });
 
   describe('accepts aggregateOptions env variable', () => {

--- a/tests/jest/config/webpack/webpack.config.test.js
+++ b/tests/jest/config/webpack/webpack.config.test.js
@@ -67,7 +67,7 @@ describe('webpack config', () => {
 
     it('adds the plugins', () => {
       expect(config).toHaveProperty('plugins');
-      expect(config.plugins).toHaveLength(4);
+      expect(config.plugins).toHaveLength(5);
 
       expect(MiniCssExtractPlugin).toBeCalledWith({
         chunkFilename: '[name].css',
@@ -164,7 +164,7 @@ describe('webpack config', () => {
 
     it('adds the CleanWebpackPlugin', () => {
       expect(config).toHaveProperty('plugins');
-      expect(config.plugins).toHaveLength(5);
+      expect(config.plugins).toHaveLength(6);
 
       expect(MiniCssExtractPlugin).toBeCalledWith({
         chunkFilename: '[name].css',
@@ -205,7 +205,7 @@ describe('webpack config', () => {
   describe('accepts disableAggregateTranslations env variable', () => {
     const disableAggregateTranslations = true;
     beforeAll(() => {
-      config = webpackConfig({ disableAggregateTranslations }, { });
+      config = webpackConfig({ disableAggregateTranslations }, {});
     });
 
     it('and it does not aggregate translations', () => {
@@ -223,20 +223,25 @@ describe('webpack config', () => {
   });
 
   describe('accepts aggregateOptions env variable', () => {
-    const aggregateOptions = { baseDir: 'test/dir' };
+    const aggregateOptions = { baseDir: 'test/dir', locales: ['en', 'es', 'pl'] };
     beforeAll(() => {
-      config = webpackConfig({ aggregateOptions }, { });
+      aggregateTranslations.mockImplementation(() => aggregateOptions.locales);
+      config = webpackConfig({ aggregateOptions }, {});
     });
 
     it('and it aggregates translations with these options', () => {
       expect(aggregateTranslations).toBeCalledWith(expect.objectContaining(aggregateOptions));
+    });
+
+    it('should add the SUPPORTED_LOCALES global with the translation locale options', () => {
+      expect(DefinePlugin).toBeCalledWith({ SUPPORTED_LOCALES: JSON.stringify(aggregateOptions.locales) });
     });
   });
 
   describe('accepts disableHotReloading env variable', () => {
     const disableHotReloading = true;
     beforeAll(() => {
-      config = webpackConfig({ disableHotReloading }, { });
+      config = webpackConfig({ disableHotReloading }, {});
     });
 
     it('and adds to dev server options', () => {

--- a/tests/jest/config/webpack/webpack.config.test.js
+++ b/tests/jest/config/webpack/webpack.config.test.js
@@ -221,8 +221,8 @@ describe('webpack config', () => {
       expect(config.resolveLoader.modules).not.toEqual(expectedModules);
     });
 
-    it('should add the SUPPORTED_LOCALES global as undefined if locale aggregation is disabled', () => {
-      expect(DefinePlugin).toBeCalledWith({ SUPPORTED_LOCALES: undefined });
+    it('should add the TERRA_SUPPORTED_LOCALES global as undefined if locale aggregation is disabled', () => {
+      expect(DefinePlugin).toBeCalledWith({ TERRA_SUPPORTED_LOCALES: undefined });
     });
   });
 
@@ -237,8 +237,8 @@ describe('webpack config', () => {
       expect(aggregateTranslations).toBeCalledWith(expect.objectContaining(aggregateOptions));
     });
 
-    it('should add the SUPPORTED_LOCALES global with the translation locale options', () => {
-      expect(DefinePlugin).toBeCalledWith({ SUPPORTED_LOCALES: JSON.stringify(aggregateOptions.locales) });
+    it('should add the TERRA_SUPPORTED_LOCALES global with the translation locale options', () => {
+      expect(DefinePlugin).toBeCalledWith({ TERRA_SUPPORTED_LOCALES: JSON.stringify(aggregateOptions.locales) });
     });
   });
 

--- a/tests/jest/config/webpack/webpack.config.test.js
+++ b/tests/jest/config/webpack/webpack.config.test.js
@@ -67,7 +67,7 @@ describe('webpack config', () => {
 
     it('adds the plugins', () => {
       expect(config).toHaveProperty('plugins');
-      expect(config.plugins).toHaveLength(5);
+      expect(config.plugins).toHaveLength(4);
 
       expect(MiniCssExtractPlugin).toBeCalledWith({
         chunkFilename: '[name].css',
@@ -82,6 +82,7 @@ describe('webpack config', () => {
 
       const definePluginOptions = expect.objectContaining({
         CERNER_BUILD_TIMESTAMP: JSON.stringify(new Date(mockDate).toISOString()),
+        TERRA_SUPPORTED_LOCALES: undefined,
       });
       expect(DefinePlugin).toBeCalledWith(definePluginOptions);
     });
@@ -164,7 +165,7 @@ describe('webpack config', () => {
 
     it('adds the CleanWebpackPlugin', () => {
       expect(config).toHaveProperty('plugins');
-      expect(config.plugins).toHaveLength(6);
+      expect(config.plugins).toHaveLength(5);
 
       expect(MiniCssExtractPlugin).toBeCalledWith({
         chunkFilename: '[name].css',
@@ -175,6 +176,7 @@ describe('webpack config', () => {
 
       const definePluginOptions = expect.objectContaining({
         CERNER_BUILD_TIMESTAMP: JSON.stringify(new Date(mockDate).toISOString()),
+        TERRA_SUPPORTED_LOCALES: undefined,
       });
       expect(DefinePlugin).toBeCalledWith(definePluginOptions);
 
@@ -222,7 +224,11 @@ describe('webpack config', () => {
     });
 
     it('should add the TERRA_SUPPORTED_LOCALES global as undefined if locale aggregation is disabled', () => {
-      expect(DefinePlugin).toBeCalledWith({ TERRA_SUPPORTED_LOCALES: undefined });
+      const expected = {
+        CERNER_BUILD_TIMESTAMP: JSON.stringify(new Date(mockDate).toISOString()),
+        TERRA_SUPPORTED_LOCALES: undefined,
+      };
+      expect(DefinePlugin).toBeCalledWith(expected);
     });
   });
 
@@ -238,7 +244,11 @@ describe('webpack config', () => {
     });
 
     it('should add the TERRA_SUPPORTED_LOCALES global with the translation locale options', () => {
-      expect(DefinePlugin).toBeCalledWith({ TERRA_SUPPORTED_LOCALES: JSON.stringify(aggregateOptions.locales) });
+      const expected = {
+        CERNER_BUILD_TIMESTAMP: JSON.stringify(new Date(mockDate).toISOString()),
+        TERRA_SUPPORTED_LOCALES: JSON.stringify(aggregateOptions.locales),
+      };
+      expect(DefinePlugin).toBeCalledWith(expected);
     });
   });
 

--- a/tests/jest/config/webpack/webpack.config.test.js
+++ b/tests/jest/config/webpack/webpack.config.test.js
@@ -82,7 +82,7 @@ describe('webpack config', () => {
 
       const definePluginOptions = expect.objectContaining({
         CERNER_BUILD_TIMESTAMP: JSON.stringify(new Date(mockDate).toISOString()),
-        TERRA_SUPPORTED_LOCALES: undefined,
+        TERRA_AGGREGATED_LOCALES: undefined,
       });
       expect(DefinePlugin).toBeCalledWith(definePluginOptions);
     });
@@ -176,7 +176,7 @@ describe('webpack config', () => {
 
       const definePluginOptions = expect.objectContaining({
         CERNER_BUILD_TIMESTAMP: JSON.stringify(new Date(mockDate).toISOString()),
-        TERRA_SUPPORTED_LOCALES: undefined,
+        TERRA_AGGREGATED_LOCALES: undefined,
       });
       expect(DefinePlugin).toBeCalledWith(definePluginOptions);
 
@@ -223,10 +223,10 @@ describe('webpack config', () => {
       expect(config.resolveLoader.modules).not.toEqual(expectedModules);
     });
 
-    it('should add the TERRA_SUPPORTED_LOCALES global as undefined if locale aggregation is disabled', () => {
+    it('should add the TERRA_AGGREGATED_LOCALES global as undefined if locale aggregation is disabled', () => {
       const expected = {
         CERNER_BUILD_TIMESTAMP: JSON.stringify(new Date(mockDate).toISOString()),
-        TERRA_SUPPORTED_LOCALES: undefined,
+        TERRA_AGGREGATED_LOCALES: undefined,
       };
       expect(DefinePlugin).toBeCalledWith(expected);
     });
@@ -243,10 +243,10 @@ describe('webpack config', () => {
       expect(aggregateTranslations).toBeCalledWith(expect.objectContaining(aggregateOptions));
     });
 
-    it('should add the TERRA_SUPPORTED_LOCALES global with the translation locale options', () => {
+    it('should add the TERRA_AGGREGATED_LOCALES global with the translation locale options', () => {
       const expected = {
         CERNER_BUILD_TIMESTAMP: JSON.stringify(new Date(mockDate).toISOString()),
-        TERRA_SUPPORTED_LOCALES: JSON.stringify(aggregateOptions.locales),
+        TERRA_AGGREGATED_LOCALES: JSON.stringify(aggregateOptions.locales),
       };
       expect(DefinePlugin).toBeCalledWith(expected);
     });


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

This PR adds a SUPPORTED_LOCALES global to the webpack bundle that includes the list of locales that were successfully aggregated. This gives the client access to the supported locales list to allow the preferred browser locale safety be used if it is a supported locale.

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

This is a sibling PR to the changes in terra-aggregate-translations:  https://github.com/cerner/terra-aggregate-translations/pull/19

If locale aggregation is disabled SUPPORTED_LOCALES will be undefined.

Resolves #382 

@cerner/terra