### PR TITLE
Correct theme-aggregation logging prefix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Unreleased
 * Added `TERRA_AGGREGATED_LOCALES` global to the webpack bundle
 
 ### Fixed
-* Re-add log prefix to theme-aggregator
+* Fixed and updated theme-aggregator prefix to [Terra-Toolkit:theme-aggregator] to be consistent with logs from other WDIO services.
 
 5.20.0 - (January 28, 2020)
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Unreleased
 ### Added
 * Added `TERRA_AGGREGATED_LOCALES` global to the webpack bundle
 
+### Fixed
+* Re-add log prefix to theme-aggregator
+
 5.20.0 - (January 28, 2020)
 ----------
 ### Changed

--- a/scripts/aggregate-themes/theme-aggregator.js
+++ b/scripts/aggregate-themes/theme-aggregator.js
@@ -59,7 +59,7 @@ class ThemeAggregator {
 
     // This creates a generated-themes directory to house theme assets.
     fs.ensureDir(OUTPUT_DIR).catch(err => {
-      Logger.warn(err, { LOG_CONTEXT });
+      Logger.warn(err, { context: LOG_CONTEXT });
     });
 
     const {
@@ -103,7 +103,7 @@ class ThemeAggregator {
       return null;
     }
 
-    Logger.log(`Aggregating ${themeName} files...`, { LOG_CONTEXT });
+    Logger.log(`Aggregating ${themeName} files...`, { context: LOG_CONTEXT });
 
     const aggregatedAssets = ThemeAggregator.aggregateTheme(themeName, isRoot, options);
     const generatedAsset = ThemeAggregator.generateTheme(themeName, isRoot, options);
@@ -115,7 +115,7 @@ class ThemeAggregator {
     }
 
     if (!aggregatedAssets.length) {
-      Logger.warn(`No theme files found for ${themeName}.`, { LOG_CONTEXT });
+      Logger.warn(`No theme files found for ${themeName}.`, { context: LOG_CONTEXT });
       return null;
     }
 
@@ -163,7 +163,7 @@ class ThemeAggregator {
     const fileName = `${prefix}-${themeName}.scss`;
     const filePath = path.resolve(outputPath || OUTPUT_PATH, fileName);
     fs.writeFileSync(filePath, file);
-    Logger.log(`Successfully generated ${fileName}.`, { LOG_CONTEXT });
+    Logger.log(`Successfully generated ${fileName}.`, { context: LOG_CONTEXT });
 
     return `./${path.relative(outputPath || OUTPUT_PATH, filePath)}`;
   }
@@ -207,7 +207,7 @@ class ThemeAggregator {
     const { theme, scoped } = options;
 
     if (!theme && !scoped) {
-      Logger.warn('No theme provided.', { LOG_CONTEXT });
+      Logger.warn('No theme provided.', { context: LOG_CONTEXT });
       return false;
     }
 
@@ -239,7 +239,7 @@ class ThemeAggregator {
    */
   static writeJsFile(imports) {
     if (!imports.length) {
-      Logger.warn(`No themes to import. Skip generating ${OUTPUT}.`, { LOG_CONTEXT });
+      Logger.warn(`No themes to import. Skip generating ${OUTPUT}.`, { context: LOG_CONTEXT });
       return null;
     }
 
@@ -247,7 +247,7 @@ class ThemeAggregator {
     const filePath = `${path.resolve(OUTPUT_PATH, OUTPUT)}`;
     fs.writeFileSync(filePath, `${DISCLAIMER}${file}`);
 
-    Logger.log(`Successfully generated ${OUTPUT}.`, { LOG_CONTEXT });
+    Logger.log(`Successfully generated ${OUTPUT}.`, { context: LOG_CONTEXT });
     return filePath;
   }
 }

--- a/scripts/aggregate-themes/theme-aggregator.js
+++ b/scripts/aggregate-themes/theme-aggregator.js
@@ -13,7 +13,7 @@ const ROOT = 'root';
 const SCOPED = 'scoped';
 const ROOT_THEME = `${ROOT}-theme.scss`;
 const SCOPED_THEME = `${SCOPED}-theme.scss`;
-const LOG_CONTEXT = '[terra-theme-aggregator]';
+const LOG_CONTEXT = '[Terra-Toolkit:theme-aggregator]';
 
 /**
  * Aggregates and generates theme assets.


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->
Oops, this fixes theme-aggregation logs to correctly have `[theme-aggregation]` as a prefix to logs.

Verification PR: https://github.com/cerner/terra-clinical/pull/610

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
