### PR TITLE
Clarify Node Version Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Clarify node version support
 
 5.22.0 - (March 17, 2020)
 ----------

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Utilities to help when developing terra modules.",
   "main": "lib/index.js",
   "engines": {
-    "node": ">=8.9.2 <12"
+    "node": ">=8.10.0 <12"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Utilities to help when developing terra modules.",
   "main": "lib/index.js",
   "engines": {
-    "node": ">=8.9.2"
+    "node": ">=8.9.2 <12"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Summary
terra-toolkit depends on wdio 4 which depends on a version of fibers that is incompatible with node 12 +
