### PR TITLE
Fix --themes wdio cli flag for local testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Fixed
+* Fix --themes wdio cli flag to be correctly passed to the test runner.
 
 5.23.0 - (March 24, 2020)
 ----------

--- a/scripts/wdio/README.md
+++ b/scripts/wdio/README.md
@@ -1,7 +1,7 @@
 # Terra Toolkit Wdio Helpers
 
 ## Wdio Runner
-Terra Toolkit offers its own wdio test runner which runs wdio test runs for specified locales and form factors. This allows for locale test runs that can match parallelized container test runs by synchronously running the wdio for each test run variation. This runner is a replacement for webdriverio's bin script `wdio` by directly calling webdriverio's test launcher module for each test variation.
+Terra Toolkit offers its own wdio test runner which runs wdio test runs for specified locales, themes, and form factors. This allows for locale and/or theme test runs that can match parallelized container test runs by synchronously running the wdio for each test run variation. This runner is a replacement for webdriverio's bin script `wdio` by directly calling webdriverio's test launcher module for each test variation.
 
 Terra's wdio test runner is available via the `tt-wdio` cli or the `wdio-runner` javascript function.
 
@@ -17,7 +17,7 @@ In your package.json
 ```JSON
 {
   "pack": "NODE_ENV=production webpack --config ./webpack.config.js -p",
-  "test:wdio-locally": "npm run pack; tt-wdio --config ./wdio.conf.js --locales ['en','es']; rm -rf ./build"
+  "test:wdio-locally": "npm run pack; tt-wdio --config ./wdio.conf.js --locales ['en','es'] --themes ['orion-fusion-theme','cerner-clinical-theme']; rm -rf ./build"
 }
 ```
 
@@ -31,6 +31,7 @@ runner({
   continueOnFail: true,
   locales: ['en', 'es'],
   browsers: ['chrome', 'firefox'],
+  themes: ['orion-fusion-theme', 'cerner-clinical-theme'],
 });
 ```
 

--- a/scripts/wdio/wdio-runner-cli.js
+++ b/scripts/wdio/wdio-runner-cli.js
@@ -15,7 +15,7 @@ commander
   .option('--locales [list]', 'The list of locales to test. Defaults to [en]', parseCLIList, undefined)
   .option('--formFactors [list]', 'The list of viewport sizes to test.', parseCLIList, undefined)
   .option('--browsers [list]', 'The list of browsers to test. Defaults to [chrome].', parseCLIList, undefined)
-  .option('--themes [list]', 'List of themes to override defined default theme.', undefined)
+  .option('--themes [list]', 'List of themes to override defined default theme.', parseCLIList, undefined)
   .option('--gridUrl [url]', 'The selenium grid url to run tests against', undefined)
   .option('--continueOnFail', 'Pass to continue executing test runs when a run fails', false)
   .option('--updateReference', 'Pass to remove all reference screenshots during screenshot cleanup', false)
@@ -31,7 +31,7 @@ const {
   config,
   gridUrl,
   browsers,
-  theme,
+  themes,
   formFactors,
   locales,
   host,
@@ -56,7 +56,7 @@ runner({
   locales,
   gridUrl,
   browsers,
-  theme,
+  themes,
   // honored wdio cli options
   ...host && { host },
   ...port && { port },

--- a/scripts/wdio/wdio-runner.js
+++ b/scripts/wdio/wdio-runner.js
@@ -40,6 +40,10 @@ async function wdioRunner(options) {
 
       for (let factor = 0; factor < factors.length; factor += 1) {
         let envValues = `LOCALE=${locale} `;
+        if (theme) {
+          envValues += `THEME=${theme} `;
+        }
+
         let exitProcess = false;
         process.on('SIGINT', () => {
           exitProcess = true;


### PR DESCRIPTION
The `--themes` wdio cli flag never worked (oops). This allows consumers to use a `--themes` flag to override the theme per selenium test run.