### PR TITLE
[eslint-config-terra] Add full stack specs to lint overrides to allow test globals

### DIFF
--- a/packages/eslint-config-terra/CHANGELOG.md
+++ b/packages/eslint-config-terra/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 -----------------
+### Added
+* Add full stack specs to lint overrides to ignore undefined test global lint errors.
 
 4.0.0 - (May 5, 2020)
 ------------------

--- a/packages/eslint-config-terra/eslint.config.js
+++ b/packages/eslint-config-terra/eslint.config.js
@@ -66,7 +66,7 @@ module.exports = {
       },
     },
     {
-      files: ['**/wdio/**/*-spec.*'],
+      files: ['**/wdio/**/*-spec.*', '**/full-stack/**/*-spec.*'],
       rules: {
         'no-unused-expressions': 'off',
       },


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->
Add full stack spec glob to lint overrides. this will ignore undefined global lint errors for our testing globals

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->
ideally, full-stack and component level wdio testing should not diverge on what testing technologies they use (mocha, visual regression, etc)
@cerner/terra
<!-- If you haven't done so already, please...
full stack testing has access to the same test globals that component level wdio use. i see these remaining in alignment in the future

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
