### PR TITLE
[terra-functional-testing] Throw SevereServiceError in onPrepare hook to bail test run

### DIFF
--- a/packages/terra-functional-testing/package.json
+++ b/packages/terra-functional-testing/package.json
@@ -64,6 +64,7 @@
     "node-resemble-js": "0.2.0",
     "platform": "^1.3.6",
     "uuid": "^3.0.0",
+    "webdriverio": "^6.5.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^3.11.0",

--- a/packages/terra-functional-testing/src/express-server/express-server.js
+++ b/packages/terra-functional-testing/src/express-server/express-server.js
@@ -41,7 +41,7 @@ class ExpressServer {
     // Check if the site exists prior to starting the express server.
     if (!fs.existsSync(this.site) || (fs.lstatSync(this.site).isDirectory() && fs.readdirSync(this.site).length === 0)) {
       logger.warn(`Cannot serve content from ${this.site} because it does not exist or it is empty.`);
-      return Promise.reject();
+      return Promise.reject(Error(`Cannot serve content from ${this.site} because it does not exist or it is empty.`));
     }
 
     return new Promise((resolve, reject) => {

--- a/packages/terra-functional-testing/src/services/wdio-asset-server-service.js
+++ b/packages/terra-functional-testing/src/services/wdio-asset-server-service.js
@@ -1,3 +1,4 @@
+const { SevereServiceError } = require('webdriverio');
 const ExpressServer = require('../express-server');
 const WebpackServer = require('../webpack-server');
 const Logger = require('../logger/logger');
@@ -21,13 +22,17 @@ class AssetServerService {
       return;
     }
 
-    if (site) {
-      this.server = new ExpressServer(this.options);
-    } else {
-      this.server = new WebpackServer(this.options);
-    }
+    try {
+      if (site) {
+        this.server = new ExpressServer(this.options);
+      } else {
+        this.server = new WebpackServer(this.options);
+      }
 
-    await this.server.start();
+      await this.server.start();
+    } catch (error) {
+      throw new SevereServiceError(error);
+    }
   }
 
   /**

--- a/packages/terra-functional-testing/src/services/wdio-selenium-docker-service.js
+++ b/packages/terra-functional-testing/src/services/wdio-selenium-docker-service.js
@@ -2,6 +2,7 @@
 const path = require('path');
 const util = require('util');
 const childProcess = require('child_process');
+const { SevereServiceError } = require('webdriverio');
 const Logger = require('../logger/logger');
 
 const exec = util.promisify(childProcess.exec);
@@ -26,11 +27,15 @@ class SeleniumDockerService {
       await exec('docker -v');
     } catch (error) {
       logger.error('Docker is not installed. Install docker to continue.');
-      throw error;
+      throw new SevereServiceError('Docker is not installed.');
     }
 
-    await this.initializeSwarm();
-    await this.deployStack();
+    try {
+      await this.initializeSwarm();
+      await this.deployStack();
+    } catch (error) {
+      throw new SevereServiceError(error);
+    }
   }
 
   /**

--- a/packages/terra-functional-testing/tests/jest/express-server/express-server.test.js
+++ b/packages/terra-functional-testing/tests/jest/express-server/express-server.test.js
@@ -49,7 +49,7 @@ describe('Express Server', () => {
 
       jest.spyOn(fs, 'existsSync').mockImplementation(() => false);
 
-      return expect(server.start()).rejects.toBeUndefined();
+      return expect(server.start()).rejects.toThrow('Cannot serve content from undefined because it does not exist or it is empty.');
     });
 
     it('should reject if the site directory exists but is empty', () => {
@@ -59,7 +59,7 @@ describe('Express Server', () => {
       jest.spyOn(fs, 'lstatSync').mockImplementation(() => ({ isDirectory: () => true }));
       jest.spyOn(fs, 'readdirSync').mockImplementation(() => []);
 
-      return expect(server.start()).rejects.toBeUndefined();
+      return expect(server.start()).rejects.toThrow('Cannot serve content from undefined because it does not exist or it is empty.');
     });
 
     it('should start an express server', () => {

--- a/packages/terra-functional-testing/tests/jest/services/wdio-asset-server-service.test.js
+++ b/packages/terra-functional-testing/tests/jest/services/wdio-asset-server-service.test.js
@@ -40,6 +40,22 @@ describe('WDIO Asset Server Service', () => {
 
       expect(WebpackServer).toHaveBeenCalledTimes(1);
     });
+
+    it('should throw a SevereServiceError if the server fails to start', async () => {
+      const service = new AssetService({ webpackConfig: 'webpack.config.js' });
+
+      WebpackServer.mockImplementationOnce(() => ({
+        start: () => Promise.reject(),
+      }));
+
+      try {
+        await service.onPrepare();
+      } catch (error) {
+        expect(error.name).toEqual('SevereServiceError');
+      }
+
+      expect.assertions(1);
+    });
   });
 
   describe('onComplete', () => {

--- a/packages/terra-functional-testing/tests/jest/services/wdio-selenium-docker-service.test.js
+++ b/packages/terra-functional-testing/tests/jest/services/wdio-selenium-docker-service.test.js
@@ -49,7 +49,7 @@ describe('WDIO Selenium Docker Service', () => {
 
     it('should throw an error if docker is not installed', async () => {
       const service = new SeleniumDockerService();
-      const mockError = Error('Mock Error');
+      const mockError = Error('Docker is not installed.');
 
       mockExec.mockImplementation(() => Promise.reject(mockError));
 
@@ -57,6 +57,42 @@ describe('WDIO Selenium Docker Service', () => {
         await service.onPrepare({});
       } catch (error) {
         expect(error).toEqual(mockError);
+      }
+
+      expect.assertions(1);
+    });
+
+    it('should throw a SevereServiceError if initialize swarm fails', async () => {
+      const service = new SeleniumDockerService();
+
+      const mockError = Error('Mock Error.');
+      mockExec.mockImplementation(() => Promise.resolve());
+
+      jest.spyOn(service, 'initializeSwarm').mockImplementationOnce(() => Promise.reject(mockError));
+      jest.spyOn(service, 'deployStack').mockImplementationOnce(() => Promise.resolve());
+
+      try {
+        await service.onPrepare({});
+      } catch (error) {
+        expect(error.name).toEqual('SevereServiceError');
+      }
+
+      expect.assertions(1);
+    });
+
+    it('should throw a SevereServiceError if deploy stack fails', async () => {
+      const service = new SeleniumDockerService();
+
+      const mockError = Error('Mock Error.');
+      mockExec.mockImplementation(() => Promise.resolve());
+
+      jest.spyOn(service, 'initializeSwarm').mockImplementationOnce(() => Promise.resolve());
+      jest.spyOn(service, 'deployStack').mockImplementationOnce(() => Promise.reject(mockError));
+
+      try {
+        await service.onPrepare({});
+      } catch (error) {
+        expect(error.name).toEqual('SevereServiceError');
       }
 
       expect.assertions(1);


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

This PR introduces a change that will stop the test runner if an error occurs during the onPrepare lifecycle of a custom service.

By default, the test runner will continue in the event of a failure in the onPrepare lifecycle of services. To bail, a [SevereServiceError](https://github.com/webdriverio/webdriverio/blob/master/docs/CustomServices.md) error must be thrown to terminate the test run. 

Resolves #436
 
### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

Original issue logged to WebdriverIO: https://github.com/webdriverio/webdriverio/issues/5398

Custom Service/Error Documentation: https://github.com/webdriverio/webdriverio/blob/master/docs/CustomServices.md

@cerner/terra
