### PR TITLE
Removed source map generation in loaders for prod.

### DIFF
--- a/packages/terra-toolkit-docs/CHANGELOG.md
+++ b/packages/terra-toolkit-docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Updated webpack config terra docs.
+
 ## 1.0.0 - (October 1, 2020)
 
 * Initial stable release

--- a/packages/terra-toolkit-docs/src/terra-dev-site/tool/webpackConfigTerra/About.a.tool.mdx
+++ b/packages/terra-toolkit-docs/src/terra-dev-site/tool/webpackConfigTerra/About.a.tool.mdx
@@ -96,6 +96,8 @@ Read more on webpack's doc site about [webpack environment options](https://webp
 |`disableHotReloading`|Bool|false|Disable hot reloading, this is generally used by CI.|
 |`disableCSSCustomProperties`|Bool|false|A webpack environment variable `disableCSSCustomProperties` to disable css custom properties.|
 |`defaultTheme`|string|none|Override the default theme set in the terra-theme.config.js file. Useful for testing.|
+|`generateLoaderSourceMaps`|Bool|True for dev false for prod|Used to enable source map generation for prod. This should be used in conjunction with setting the `devtool` webpack option. Caution, This may have a large performance impact, especially with large bundles.|
+
 #### options
 
 Options can be supplied to the terra webpack config as the third parameter after `env` and `argv`. For example:

--- a/packages/terra-toolkit-docs/src/terra-dev-site/tool/webpackConfigTerra/About.a.tool.mdx
+++ b/packages/terra-toolkit-docs/src/terra-dev-site/tool/webpackConfigTerra/About.a.tool.mdx
@@ -91,12 +91,12 @@ webpack --env.disableHotReloading=true
 Read more on webpack's doc site about [webpack environment options](https://webpack.js.org/api/cli/#environment-options)
 
 |name|Type|Default|Description|
-|---|---|---|
-|`disableAggregateTranslations`|Bool|false|Disable the aggregate translations feature.|
-|`disableHotReloading`|Bool|false|Disable hot reloading, this is generally used by CI.|
-|`disableCSSCustomProperties`|Bool|false|A webpack environment variable `disableCSSCustomProperties` to disable css custom properties.|
+|---|---|---|---|
+|`disableAggregateTranslations`|Bool|`false`|Disable the aggregate translations feature.|
+|`disableHotReloading`|Bool|`false`|Disable hot reloading, this is generally used by CI.|
+|`disableCSSCustomProperties`|Bool|`false`|A webpack environment variable `disableCSSCustomProperties` to disable css custom properties.|
 |`defaultTheme`|string|none|Override the default theme set in the terra-theme.config.js file. Useful for testing.|
-|`generateLoaderSourceMaps`|Bool|True for dev false for prod|Used to enable source map generation for prod. This should be used in conjunction with setting the `devtool` webpack option. Caution, This may have a large performance impact, especially with large bundles.|
+|`generateLoaderSourceMaps`|Bool|`true` for dev `false` for prod|Used to enable source map generation for prod. This should be used in conjunction with setting the `devtool` webpack option. Caution, This may have a large performance impact, especially with large bundles.|
 
 #### options
 

--- a/packages/webpack-config-terra/CHANGELOG.md
+++ b/packages/webpack-config-terra/CHANGELOG.md
@@ -3,7 +3,10 @@
 ## Unreleased
 
 * Changed
-  * Removed source map generation in loaders for prod. Added the generateLoaderSourceMaps env to re-enable it on demand.
+  * Removed default source map generation in loaders for prod.
+
+* Added
+  * Added the generateLoaderSourceMaps env to re-enable source map generation for loaders on demand.
 
 ## 1.0.0-alpha.0 - (October 1, 2020)
 

--- a/packages/webpack-config-terra/CHANGELOG.md
+++ b/packages/webpack-config-terra/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Removed source map generation in loaders for prod. Added the generateLoaderSourceMaps env to re-enable it on demand.
+
 ## 1.0.0-alpha.0 - (October 1, 2020)
 
 * Initial alpha release

--- a/packages/webpack-config-terra/webpack.config.js
+++ b/packages/webpack-config-terra/webpack.config.js
@@ -91,6 +91,7 @@ const defaultWebpackConfig = (env = {}, argv = {}, options = {}) => {
   const filename = argv['output-filename'] || fileNameStategy;
   const outputPath = argv['output-path'] || path.join(processPath, 'build');
   const publicPath = argv['output-public-path'] || '';
+  const sourceMap = env.generateLoaderSourceMaps || !production;
 
   const devConfig = {
     mode: 'development',
@@ -120,7 +121,6 @@ const defaultWebpackConfig = (env = {}, argv = {}, options = {}) => {
               loader: MiniCssExtractPlugin.loader,
               options: {
                 hmr: !production, // only enable hot module reloading in development
-                sourceMap: true,
               },
             },
             {
@@ -130,7 +130,7 @@ const defaultWebpackConfig = (env = {}, argv = {}, options = {}) => {
                   mode: 'global',
                   localIdentName: '[name]__[local]___[hash:base64:5]',
                 },
-                sourceMap: true,
+                sourceMap,
                 importLoaders: 2,
               },
             },
@@ -139,7 +139,7 @@ const defaultWebpackConfig = (env = {}, argv = {}, options = {}) => {
               options: {
                 // Add unique ident to prevent the loader from searching for a postcss.config file. See: https://github.com/postcss/postcss-loader#plugins
                 ident: 'postcss',
-                sourceMap: true,
+                sourceMap,
                 plugins: [
                   ThemePlugin(themeConfig),
                   rtl(),
@@ -150,7 +150,7 @@ const defaultWebpackConfig = (env = {}, argv = {}, options = {}) => {
             {
               loader: 'sass-loader',
               options: {
-                sourceMap: true,
+                sourceMap,
               },
             },
           ],
@@ -244,7 +244,7 @@ const defaultWebpackConfig = (env = {}, argv = {}, options = {}) => {
         new TerserPlugin({
           cache: true,
           parallel: true,
-          sourceMap: true,
+          sourceMap,
           terserOptions: {
             compress: {
               typeofs: false,


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

Removed source map generation in loaders for prod. Added the generate LoaderSourceMaps env to re-enable it on demand.

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
