### PR TITLE
[terra-functional-testing] Update global axe option API

### DIFF
--- a/packages/terra-functional-testing/src/commands/axe/run.js
+++ b/packages/terra-functional-testing/src/commands/axe/run.js
@@ -33,7 +33,7 @@ const runAxe = (overrides = {}) => {
   // Merge the global rules and overrides together.
   const rules = {
     ...ruleOverrides,
-    ...axeOptions && axeOptions.rules.reduce((acc, rule) => ({ ...acc, [rule.id]: rule }), {}),
+    ...axeOptions && axeOptions.rules,
     ...overrides.rules,
   };
 

--- a/packages/terra-functional-testing/src/terra-dev-site/terra-functional-testing/wdio-services/TerraService.tool.mdx
+++ b/packages/terra-functional-testing/src/terra-dev-site/terra-functional-testing/wdio-services/TerraService.tool.mdx
@@ -52,9 +52,9 @@ export.config = {
     services: [
         [TerraService, {
           axe: {
-            rules: [
-              { id: 'color-contrast', enabled: true },
-            ]
+            rules: {
+              'color-contrast': { enabled: true },
+            }
           }
         }]
     ],

--- a/packages/terra-functional-testing/tests/jest/commands/axe/run.test.js
+++ b/packages/terra-functional-testing/tests/jest/commands/axe/run.test.js
@@ -32,13 +32,13 @@ describe('Run Axe', () => {
 
   it('should run axe with the service options', () => {
     const TerraService = () => { };
-    const serviceOptions = { axe: { rules: [{ id: 'mock-rule', enabled: true }] } };
+    const serviceOptions = { axe: { rules: { 'mock-rule': { enabled: true } } } };
 
     const mockExecuteAsync = jest.fn().mockImplementation((func, opts) => {
       const { rules } = opts;
 
       const expectedRules = {
-        'mock-rule': { enabled: true, id: 'mock-rule' },
+        'mock-rule': { enabled: true },
         'scrollable-region-focusable': { enabled: false },
       };
 
@@ -65,7 +65,7 @@ describe('Run Axe', () => {
       const { rules } = opts;
 
       const expectedRules = {
-        'mock-rule': { enabled: true, id: 'mock-rule' },
+        'mock-rule': { enabled: true },
         'scrollable-region-focusable': { enabled: false },
       };
 
@@ -81,21 +81,21 @@ describe('Run Axe', () => {
       },
     };
 
-    runAxe({ rules: { 'mock-rule': { enabled: true, id: 'mock-rule' } } });
+    runAxe({ rules: { 'mock-rule': { enabled: true } } });
 
     expect.assertions(1);
   });
 
   it('should run axe with merged rules from the service and from options provided', () => {
     const TerraService = () => { };
-    const serviceOptions = { axe: { rules: [{ id: 'mock-rule-1', enabled: true }] } };
+    const serviceOptions = { axe: { rules: { 'mock-rule-1': { enabled: true } } } };
 
     const mockExecuteAsync = jest.fn().mockImplementation((func, opts) => {
       const { rules } = opts;
 
       const expectedRules = {
-        'mock-rule-1': { enabled: true, id: 'mock-rule-1' },
-        'mock-rule-2': { enabled: true, id: 'mock-rule-2' },
+        'mock-rule-1': { enabled: true },
+        'mock-rule-2': { enabled: true },
         'scrollable-region-focusable': { enabled: false },
       };
 
@@ -111,7 +111,7 @@ describe('Run Axe', () => {
       },
     };
 
-    runAxe({ rules: { 'mock-rule-2': { enabled: true, id: 'mock-rule-2' } } });
+    runAxe({ rules: { 'mock-rule-2': { enabled: true } } });
 
     expect.assertions(1);
   });


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

This PR updates the global axe overrides to align with the axe-core API.

Previous overrides expect an array of objects:

```js
  axe: {
    rules: [
      { id: 'color-contrast', enabled: true },
    ],
  },
```

axe-core is expecting an object keyed by the id of each rule:

```js
  axe: {
    rules: {
      'color-contrast': { enabled: true },
    },
  },
```

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

This decision was made to align the declaration of the global overrides to match the declarations of the axe-core API and the individual test helper APIs. This removes the need to transform the array back into an object prior to running axe.

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
