### PR TITLE
[terra-functional-testing] Revert docker selenium to 3.14.0-helium

### DIFF
--- a/packages/terra-functional-testing/src/services/wdio-selenium-docker-service.js
+++ b/packages/terra-functional-testing/src/services/wdio-selenium-docker-service.js
@@ -12,7 +12,7 @@ class SeleniumDockerService {
   constructor(options = {}) {
     const { version } = options;
 
-    this.version = version || '3.141.59-20200525';
+    this.version = version || '3.14.0-helium';
   }
 
   /**

--- a/packages/terra-functional-testing/src/terra-dev-site/terra-functional-testing/wdio-services/SeleniumDockerService.tool.mdx
+++ b/packages/terra-functional-testing/src/terra-dev-site/terra-functional-testing/wdio-services/SeleniumDockerService.tool.mdx
@@ -42,7 +42,7 @@ Type: `string`
 
 Required: `false`
 
-Default: `3.141.59-20200525`
+Default: `3.14.0-helium`
 
 Example:
 
@@ -54,7 +54,7 @@ export.config = {
     // ...
     services: [
         [SeleniumDockerService, {
-          version: '3.141.59-20200525'
+          version: '3.14.0-helium'
         }]
     ],
     // ...

--- a/packages/terra-functional-testing/tests/jest/services/wdio-selenium-docker-service.test.js
+++ b/packages/terra-functional-testing/tests/jest/services/wdio-selenium-docker-service.test.js
@@ -135,7 +135,7 @@ describe('WDIO Selenium Docker Service', () => {
 
       const composeFilePath = path.resolve(__dirname, '../../../src/docker/docker-compose.yml');
 
-      expect(mockExec).toHaveBeenCalledWith(`TERRA_SELENIUM_DOCKER_VERSION=3.141.59-20200525 docker stack deploy -c ${composeFilePath} wdio`);
+      expect(mockExec).toHaveBeenCalledWith(`TERRA_SELENIUM_DOCKER_VERSION=3.14.0-helium docker stack deploy -c ${composeFilePath} wdio`);
     });
 
     it('should deploy the stack with the specified selenium version', async () => {


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

This PR reverts the selenium docker image to 3.14.0-helium. This is the current version being used in WDIO 4.

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

Selenium docker will be updated in the future, but will remain at 3.14.0-helium for the initial release of terra-functional-testing.

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
