### PR TITLE
Fix issue with setting up git on publish

### DIFF
--- a/packages/terra-open-source-scripts/CHANGELOG.md
+++ b/packages/terra-open-source-scripts/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Fix issue with setting up git on publish
+
 ## 1.0.0 - (November 17, 2020)
 
 * Initial stable release

--- a/packages/terra-open-source-scripts/src/terra-cli/release/setupGit.js
+++ b/packages/terra-open-source-scripts/src/terra-cli/release/setupGit.js
@@ -12,7 +12,7 @@ module.exports = async () => {
   if (travis) {
     await exec('git config --global user.email "travis@travis-ci.org"');
     await exec('git config --global user.name "Travis CI"');
-    const remoteUrl = (await exec('git config --get remote.origin.url', { encoding: 'utf8' })).trim();
+    const remoteUrl = (await exec('git config --get remote.origin.url', { encoding: 'utf8' })).stdout.trim();
     const token = process.env.GITHUB_TOKEN;
     const newUrl = remoteUrl.replace('https://', `https://${token}@`);
     await exec(`git remote set-url origin "${newUrl}" > /dev/null 2>&1`);

--- a/packages/terra-open-source-scripts/tests/jest/terra-cli/release/setupGit.test.js
+++ b/packages/terra-open-source-scripts/tests/jest/terra-cli/release/setupGit.test.js
@@ -17,7 +17,7 @@ describe('setupGit', () => {
 
     mockExec.mockResolvedValueOnce();
     mockExec.mockResolvedValueOnce();
-    mockExec.mockResolvedValueOnce('    https://remote-url   ');
+    mockExec.mockResolvedValueOnce({ stdout: '    https://remote-url   ' });
     mockExec.mockResolvedValueOnce();
 
     await setupGit();


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->
Fix issue with setting up git on publish. Async exec resolves to a { stdout: } structure rather than stdout directly.