### PR TITLE
Update eslint.config.js

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -25,6 +25,7 @@ Cerner Corporation
 - Nathan Faltermeier [@Blackop778]
 - Avinash Gupta [@avinashg1994]
 - Jack Vande Ven [@jv075002]
+- Saurabh Khare [@saurabhkhare86]
 
 [@emilyrohrbough]: https://github.com/emilyrohrbough
 [@brettjankord]: https://github.com/bjankord
@@ -51,3 +52,4 @@ Cerner Corporation
 [@Blackop778]: https://github.com/Blackop778
 [@avinashg1994]: https://github.com/avinashg1994
 [@jv075002]: https://github.com/jv075002
+[@saurabhkhare86]: https://github.com/SaurabhKhare86

--- a/packages/eslint-config-terra/CHANGELOG.md
+++ b/packages/eslint-config-terra/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Fixed
   * The badges in the readme were pointing to an incorrect url.
 
+* Changed
+  * Updated eslint config file to use `off`, `warn` and `error` instead of `0`, `1` and `2`.
+
 ## 4.1.0 - (August 4, 2020)
 
 * Added

--- a/packages/eslint-config-terra/eslint.config.js
+++ b/packages/eslint-config-terra/eslint.config.js
@@ -24,7 +24,7 @@ module.exports = {
     // Replaces jsx-a11y/label-has-for rule. By default, it wants inputs to be both wrapped in a label
     // and include a id/for attribute mapping with label.
     // This config updates the rule to require one or the other.
-    'jsx-a11y/label-has-associated-control': 'error', { assert: 'either' }],
+    'jsx-a11y/label-has-associated-control': ['error', { assert: 'either' }],
     'no-multiple-empty-lines': ['warn', {
       max: 1,
       maxEOF: 1,

--- a/packages/eslint-config-terra/eslint.config.js
+++ b/packages/eslint-config-terra/eslint.config.js
@@ -24,15 +24,15 @@ module.exports = {
     // Replaces jsx-a11y/label-has-for rule. By default, it wants inputs to be both wrapped in a label
     // and include a id/for attribute mapping with label.
     // This config updates the rule to require one or the other.
-    'jsx-a11y/label-has-associated-control': [2, { assert: 'either' }],
-    'no-multiple-empty-lines': [1, {
+    'jsx-a11y/label-has-associated-control': 'error', { assert: 'either' }],
+    'no-multiple-empty-lines': ['warn', {
       max: 1,
       maxEOF: 1,
       maxBOF: 0,
     }],
     'react/destructuring-assignment': 'off',
-    'react/forbid-component-props': [2, { forbid: ['style'] }],
-    'react/forbid-dom-props': [2, { forbid: ['style'] }],
+    'react/forbid-component-props': ['error', { forbid: ['style'] }],
+    'react/forbid-dom-props': ['error', { forbid: ['style'] }],
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'error',
     'react/jsx-props-no-spreading': 'off',


### PR DESCRIPTION
### Summary
Updated eslint config for consistency. In all places it will use `off`, `warn` and `error` instead of `0`, `1` and `2`.

### Additional Details
Just updated config to use string values instead of numbers
