### PR TITLE
Update node version to erbium

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/dubnium
+lts/erbium

--- a/app.json
+++ b/app.json
@@ -28,7 +28,7 @@
       "size": "free"
     }
   },
-  "stack": "heroku-16",
+  "stack": "heroku-20",
   "addons": [],
   "buildpacks": []
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "5.25.0",
   "description": "Utilities to help when developing terra modules.",
   "engines": {
-    "node": ">=8.10.0 <12"
+    "node": ">=10 <13"
   },
   "repository": {
     "type": "git",

--- a/packages/eslint-config-terra/CHANGELOG.md
+++ b/packages/eslint-config-terra/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Opened the node version to allow versions higher than node 10.
+
 ## 4.2.0 - (November 24, 2020)
 
 * Fixed

--- a/packages/eslint-config-terra/package.json
+++ b/packages/eslint-config-terra/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/cerner/terra-toolkit/issues"
   },
   "engines": {
-    "node": "^10.13.0 || >=11.10.1"
+    "node": ">=10.13.0"
   },
   "homepage": "https://github.com/cerner/terra-toolkit",
   "scripts": {

--- a/packages/stylelint-config-terra/CHANGELOG.md
+++ b/packages/stylelint-config-terra/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Changed
   * Use jest for tests.
   * Added publish config to package.json.
+  * Opened the node version to allow versions higher than node 10.
 
 ## 3.7.0 - (July 28, 2020)
 

--- a/packages/stylelint-config-terra/package.json
+++ b/packages/stylelint-config-terra/package.json
@@ -24,7 +24,7 @@
     "linter"
   ],
   "engines": {
-    "node": "^10.0.0"
+    "node": ">=10"
   },
   "author": "Cerner Corporation",
   "license": "Apache-2.0",

--- a/packages/terra-cli/CHANGELOG.md
+++ b/packages/terra-cli/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Changed
   * Moved documentation to terra-toolkit-docs
+  * Opened the node version to allow versions higher than node 10.
 
 ## 1.3.0 - (December 4, 2020)
 

--- a/packages/terra-cli/package.json
+++ b/packages/terra-cli/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/cerner/terra-toolkit/issues"
   },
   "engines": {
-    "node": "^10.13.0"
+    "node": ">=10.13.0"
   },
   "homepage": "https://github.com/cerner/terra-toolkit",
   "scripts": {

--- a/packages/terra-functional-testing/package.json
+++ b/packages/terra-functional-testing/package.json
@@ -6,6 +6,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "engines": {
+    "node": ">=10 <13"
+  },
   "files": [
     "bin",
     "lib",

--- a/packages/terra-open-source-scripts/CHANGELOG.md
+++ b/packages/terra-open-source-scripts/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Opened the node version to allow versions higher than node 10.
+
 ## 1.3.0 - (December 4, 2020)
 
 * Changed

--- a/packages/terra-open-source-scripts/package.json
+++ b/packages/terra-open-source-scripts/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/cerner/terra-toolkit/issues"
   },
   "engines": {
-    "node": "^10.13.0"
+    "node": ">=10.13.0"
   },
   "homepage": "https://github.com/cerner/terra-toolkit",
   "scripts": {

--- a/packages/terra-toolkit-docs/CHANGELOG.md
+++ b/packages/terra-toolkit-docs/CHANGELOG.md
@@ -8,6 +8,7 @@
   * Add stylelint-config-terra documentation
   * Add browserslist-config-terra upgrade guide
   * Moved Terra-cli docs into terra-toolkit-docs
+  * Opened the node version to allow versions higher than node 10.
 
 ## 1.3.0 - (December 7, 2020)
 

--- a/packages/terra-toolkit-docs/package.json
+++ b/packages/terra-toolkit-docs/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/cerner/terra-toolkit/issues"
   },
   "engines": {
-    "node": "^10.13.0"
+    "node": ">=10.13.0"
   },
   "homepage": "https://github.com/cerner/terra-toolkit",
   "scripts": {

--- a/packages/webpack-config-terra/CHANGELOG.md
+++ b/packages/webpack-config-terra/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Changed
   * Added optional support for aggregate themes.
   * Make postcss a peer dependency.
+  * Opened the node version to allow versions higher than node 10.
 
 ## 1.1.0 - (December 7, 2020)
 

--- a/packages/webpack-config-terra/package.json
+++ b/packages/webpack-config-terra/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/cerner/terra-toolkit/issues"
   },
   "engines": {
-    "node": "^10.13.0"
+    "node": ">=10.13.0"
   },
   "homepage": "https://github.com/cerner/terra-toolkit",
   "scripts": {


### PR DESCRIPTION
### Summary
With terra-functional testing using wdio version 6 we can now upgrade to node 12 (yay), however until wdio updates to fibers version 5 we can't upgrade to node 14 (Boo).

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

As a bonus I'm updating the heroku stack we're building on because heroku keeps bugging me.

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
