### PR TITLE
[terra-functional-testing] Add browsers and grid url options to the test runner cli

### DIFF
--- a/packages/terra-functional-testing/src/config/capabilities.js
+++ b/packages/terra-functional-testing/src/config/capabilities.js
@@ -1,0 +1,39 @@
+/**
+ * This file contains the capability configurations for each supported browser.
+ */
+
+module.exports = {
+  chrome: {
+    browserName: 'chrome',
+    maxInstances: 1,
+    'goog:chromeOptions': {
+      /**
+       * Run in headless mode because Chrome 69+ cannot be resized to the tiny viewport due to a omnibox size change
+       * made by the chrome team. See https://bugs.chromium.org/p/chromedriver/issues/detail?id=2626#c1 &&
+       * https://bugs.chromium.org/p/chromium/issues/detail?id=849784.
+       *
+       * Headless Chrome: https://developers.google.com/web/updates/2017/04/headless-chrome
+       */
+      args: ['--headless', '--disable-gpu'],
+    },
+  },
+  firefox: {
+    browserName: 'firefox',
+    maxInstances: 1,
+    'moz:firefoxOptions': {
+      prefs: {
+        'dom.disable_beforeunload': false,
+      },
+    },
+  },
+  ie: {
+    browserName: 'internet explorer',
+    maxInstances: 1,
+    'se:ieOptions': {
+      javascriptEnabled: true,
+      locationContextEnabled: true,
+      handlesAlerts: true,
+      rotatable: true,
+    },
+  },
+};

--- a/packages/terra-functional-testing/src/config/utils/getCapabilities.js
+++ b/packages/terra-functional-testing/src/config/utils/getCapabilities.js
@@ -1,0 +1,37 @@
+const { chrome, firefox, ie } = require('../capabilities');
+
+/**
+ * Determines the browser capabilities for the WebDriver session.
+ * @param {array} browsers - An array of browser names to enable. (chrome, firefox, ie)
+ * @param {boolean} isGridEnabled - Whether the WebDriver session is running against the remote selenium grid.
+ * @returns {array} - An array of browser capabilities.
+ */
+const getCapabilities = (browsers, isGridEnabled) => {
+  const capabilities = [];
+
+  if (!browsers) {
+    // Enable chrome as the default browser.
+    capabilities.push(chrome);
+
+    // Enable all supported grid browsers by default.
+    if (isGridEnabled) {
+      capabilities.push(firefox, ie);
+    }
+  } else {
+    browsers.forEach((browser) => {
+      if (browser === 'chrome') {
+        capabilities.push(chrome);
+      } else if (browser === 'firefox') {
+        capabilities.push(firefox);
+      } else if (browser === 'ie' && isGridEnabled) {
+        capabilities.push(ie);
+      }
+    });
+  }
+
+  // Randomize the browser order.
+  return capabilities.sort(() => 0.5 - Math.random());
+};
+
+module.exports = getCapabilities;
+

--- a/packages/terra-functional-testing/src/config/wdio.conf.js
+++ b/packages/terra-functional-testing/src/config/wdio.conf.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const ip = require('ip');
+const getCapabilities = require('./utils/getCapabilities');
 
 const SeleniumDockerService = require('../services/wdio-selenium-docker-service');
 const TerraService = require('../services/wdio-terra-service');
@@ -8,8 +9,10 @@ const AssetServerService = require('../services/wdio-asset-server-service');
 const AccessibilityReporter = require('../reporters/wdio-accessibility-reporter');
 
 const {
+  BROWSERS,
   FORM_FACTOR,
   LOCALE,
+  SELENIUM_GRID_URL,
   SITE,
   THEME,
   WDIO_DISABLE_SELENIUM_SERVICE,
@@ -19,6 +22,8 @@ const {
   WDIO_HOSTNAME,
 } = process.env;
 
+// Convert BROWSERS into an array. When assigned to a process.env it is cast as a string.
+const browsers = BROWSERS ? BROWSERS.split(',') : undefined;
 const defaultWebpackPath = path.resolve(process.cwd(), 'webpack.config.js');
 
 exports.config = {
@@ -65,18 +70,7 @@ exports.config = {
   // Sauce Labs platform configurator - a great tool to configure your capabilities:
   // https://docs.saucelabs.com/reference/platforms-configurator
   //
-  capabilities: [{
-    // maxInstances can get overwritten per capability. So if you have an in-house Selenium
-    // grid with only 5 firefox instances available you can make sure that not more than
-    // 5 instances get started at a time.
-    maxInstances: 5,
-    //
-    browserName: 'chrome',
-    // If outputDir is provided WebdriverIO can capture driver session logs
-    // it is possible to configure which logTypes to include/exclude.
-    // excludeDriverLogs: ['*'], // pass '*' to exclude all driver session logs
-    // excludeDriverLogs: ['bugreport', 'server'],
-  }],
+  capabilities: getCapabilities(browsers, !!SELENIUM_GRID_URL),
   //
   // ===================
   // Test Configurations
@@ -106,9 +100,9 @@ exports.config = {
   // Set the path to connect to the selenium container.
   path: '/wd/hub',
   // The hostname of the driver server.
-  hostname: WDIO_HOSTNAME || 'localhost',
-  // The port the driver server is on.
-  port: 4444,
+  hostname: SELENIUM_GRID_URL || WDIO_HOSTNAME || 'localhost',
+  // The port the driver server is on. The selenium grid uses port 80.
+  port: SELENIUM_GRID_URL ? 80 : 4444,
   //
   // Set a base URL in order to shorten url command calls. If your `url` parameter starts
   // with `/`, the base url gets prepended, not including the path portion of your baseUrl.

--- a/packages/terra-functional-testing/src/terra-cli/wdio/index.js
+++ b/packages/terra-functional-testing/src/terra-cli/wdio/index.js
@@ -5,6 +5,10 @@ const cli = {
   describe: 'Run wdio tests',
   builder: (yargs) => (
     yargs.options({
+      browsers: {
+        type: 'array',
+        describe: 'A list of browsers for the test run.',
+      },
       c: {
         type: 'string',
         alias: 'config',
@@ -13,6 +17,10 @@ const cli = {
       formFactors: {
         type: 'array',
         describe: 'A list of form factors for the test run.',
+      },
+      gridUrl: {
+        type: 'string',
+        describe: 'The remote selenium grid address.',
       },
       locales: {
         type: 'array',

--- a/packages/terra-functional-testing/src/terra-cli/wdio/test-runner.js
+++ b/packages/terra-functional-testing/src/terra-cli/wdio/test-runner.js
@@ -75,8 +75,10 @@ class TestRunner {
 
   /**
    * Starts the test runner.
+   * @param {string} options.browsers - A list of browsers for the test run.
    * @param {string} options.config - A file path to the test runner configuration.
    * @param {string} options.formFactors - A list of form factors for the test run.
+   * @param {string} options.gridUrl - The remote selenium grid address.
    * @param {string} options.locales - A list of language locales for the test run.
    * @param {string} options.themes - A list of themes for the test run.
    * @param {string} options.hostname - Automation driver host address.
@@ -87,12 +89,22 @@ class TestRunner {
    */
   static async start(options) {
     const {
+      browsers,
       config,
       formFactors = [],
+      gridUrl,
       locales,
       themes,
       ...launcherOptions // hostname, port, baseUrl, suite, and spec
     } = options;
+
+    if (browsers) {
+      process.env.BROWSERS = browsers;
+    }
+
+    if (gridUrl) {
+      process.env.SELENIUM_GRID_URL = gridUrl;
+    }
 
     /**
      * The following code loops through each permutation of theme, locale, and form factor.

--- a/packages/terra-functional-testing/src/terra-dev-site/terra-functional-testing/wdio-testing/About.tool.mdx
+++ b/packages/terra-functional-testing/src/terra-dev-site/terra-functional-testing/wdio-testing/About.tool.mdx
@@ -14,7 +14,7 @@ npm install --save-dev @cerner/terra-functional-testing
 
 ## Test Runner
 
-A test runner is provided for local development and should be invoked using the [terra-cli](dev_tools/terra-cli/terra-cli). The test runner is a convenience utility for defining multiple run configuration options invoked from a single command.
+A test runner is provided for local development and should be invoked using the [terra-cli](dev_tools/terra-cli/terra-cli).
 
 ### Options
 

--- a/packages/terra-functional-testing/src/terra-dev-site/terra-functional-testing/wdio-testing/About.tool.mdx
+++ b/packages/terra-functional-testing/src/terra-dev-site/terra-functional-testing/wdio-testing/About.tool.mdx
@@ -14,14 +14,16 @@ npm install --save-dev @cerner/terra-functional-testing
 
 ## Test Runner
 
-A test runner is provided for local development and should be invoked using the [terra-cli](dev_tools/terra-cli/terra-cli).
+A test runner is provided for local development and should be invoked using the [terra-cli](dev_tools/terra-cli/terra-cli). The test runner is a convenience utility for defining multiple run configuration options invoked from a single command.
 
 ### Options
 
 | Option Name | Type   | Required | Default                 | Description                                                                                   |
 |-------------|--------|----------|-------------------------|-----------------------------------------------------------------------------------------------|
+| browsers    | array  | false    |                         | A list of browsers for the test run.                                                          |
 | config      | string | false    |                         | A file path to the test runner configuration.                                                 |
 | formFactors | array  | false    |                         | A list of form factors for the test run. One of tiny, small, medium, large, huge, or enormous |
+| gridUrl     | string | false    |                         | The remote selenium grid address.                                                             |
 | locales     | array  | false    | ['en']                  | A list of language locales for the test run.                                                  |
 | themes      | array  | false    | ['terra-default-theme'] | A list of themes for the test run.                                                            |
 | hostname    | string | false    | localhost               | Automation driver host address.                                                               |

--- a/packages/terra-functional-testing/tests/jest/config/capabilities.test.js
+++ b/packages/terra-functional-testing/tests/jest/config/capabilities.test.js
@@ -1,0 +1,11 @@
+const capabilities = require('../../../src/config/capabilities');
+
+describe('capabilities', () => {
+  it('should export the capabilities for each supported browser', () => {
+    const { chrome, firefox, ie } = capabilities;
+
+    expect(chrome).toBeDefined();
+    expect(firefox).toBeDefined();
+    expect(ie).toBeDefined();
+  });
+});

--- a/packages/terra-functional-testing/tests/jest/config/utils/getCapabilities.test.js
+++ b/packages/terra-functional-testing/tests/jest/config/utils/getCapabilities.test.js
@@ -1,0 +1,45 @@
+const getCapabilities = require('../../../../src/config/utils/getCapabilities');
+
+describe('getCapabilities', () => {
+  it('should return chrome by default', () => {
+    const capabilities = getCapabilities();
+
+    expect(capabilities.length).toEqual(1);
+    expect(capabilities[0].browserName).toEqual('chrome');
+  });
+
+  it('should return all browsers if none are provided and the selenium grid is enabled', () => {
+    const capabilities = getCapabilities(undefined, true);
+
+    expect(capabilities.length).toEqual(3);
+  });
+
+  it('should exclude ie if the selenium grid is not enabled', () => {
+    const capabilities = getCapabilities(['chrome', 'firefox', 'ie']);
+
+    expect(capabilities.length).toEqual(2);
+    expect(capabilities.findIndex(({ browserName }) => browserName === 'internet explorer')).toEqual(-1);
+  });
+
+  it('should include only chrome', () => {
+    const capabilities = getCapabilities(['chrome']);
+
+    expect(capabilities.length).toEqual(1);
+    expect(capabilities.findIndex(({ browserName }) => browserName === 'chrome')).toBeGreaterThanOrEqual(0);
+  });
+
+  it('should include chrome and firefox', () => {
+    const capabilities = getCapabilities(['chrome', 'firefox']);
+
+    expect(capabilities.length).toEqual(2);
+    expect(capabilities.findIndex(({ browserName }) => browserName === 'chrome')).toBeGreaterThanOrEqual(0);
+    expect(capabilities.findIndex(({ browserName }) => browserName === 'firefox')).toBeGreaterThanOrEqual(0);
+  });
+
+  it('should include only ie', () => {
+    const capabilities = getCapabilities(['ie'], true);
+
+    expect(capabilities.length).toEqual(1);
+    expect(capabilities[0].browserName).toEqual('internet explorer');
+  });
+});

--- a/packages/terra-functional-testing/tests/jest/terra-cli/wdio/__snapshots__/index.test.js.snap
+++ b/packages/terra-functional-testing/tests/jest/terra-cli/wdio/__snapshots__/index.test.js.snap
@@ -8,8 +8,10 @@ Run wdio tests
 Options:
       --version      Show version number                               [boolean]
       --help         Show help                                         [boolean]
+      --browsers     A list of browsers for the test run.                [array]
   -c, --config       A file path to the test runner configuration.      [string]
       --formFactors  A list of form factors for the test run.            [array]
+      --gridUrl      The remote selenium grid address.                  [string]
       --locales      A list of language locales for the test run.
                                                        [array] [default: [\\"en\\"]]
       --themes       A list of themes for the test run.


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

This PR adds the browsers and grid url options to the test runner cli.

```
npm run terra -- wdio --browsers chrome firefox --gridUrl grid.test.com
```

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

Some of the previous chrome logging information has been deprecated and/or had API changes. This PR does not carry forward the chrome performance logging.

Many of these changes are carried forward from here:

https://github.com/cerner/terra-toolkit-boneyard/blob/main/config/wdio/selenium.config.js

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
