### PR TITLE
[terra-functional-testing] Add name property to getViewports

### DIFF
--- a/packages/terra-functional-testing/src/commands/utils/getViewports.js
+++ b/packages/terra-functional-testing/src/commands/utils/getViewports.js
@@ -10,7 +10,11 @@ const ALL_VIEWPORTS = Object.keys(TERRA_VIEWPORTS);
 const getViewports = (...sizes) => {
   const viewports = sizes.length > 0 ? sizes : ALL_VIEWPORTS;
 
-  return viewports.map((name) => TERRA_VIEWPORTS[name]);
+  return viewports.map((name) => {
+    const { height, width } = TERRA_VIEWPORTS[name];
+
+    return { height, width, name };
+  });
 };
 
 module.exports = getViewports;

--- a/packages/terra-functional-testing/tests/jest/commands/utils/getViewports.test.js
+++ b/packages/terra-functional-testing/tests/jest/commands/utils/getViewports.test.js
@@ -1,22 +1,31 @@
 const getViewports = require('../../../../src/commands/utils/getViewports');
 const { TERRA_VIEWPORTS } = require('../../../../src/constants');
 
+const {
+  tiny,
+  small,
+  medium,
+  large,
+  huge,
+  enormous,
+} = TERRA_VIEWPORTS;
+
 describe('getViewports', () => {
   it('should get all viewports', () => {
     const viewports = getViewports();
 
-    expect(viewports[0]).toEqual(TERRA_VIEWPORTS.tiny);
-    expect(viewports[1]).toEqual(TERRA_VIEWPORTS.small);
-    expect(viewports[2]).toEqual(TERRA_VIEWPORTS.medium);
-    expect(viewports[3]).toEqual(TERRA_VIEWPORTS.large);
-    expect(viewports[4]).toEqual(TERRA_VIEWPORTS.huge);
-    expect(viewports[5]).toEqual(TERRA_VIEWPORTS.enormous);
+    expect(viewports[0]).toEqual({ ...tiny, name: 'tiny' });
+    expect(viewports[1]).toEqual({ ...small, name: 'small' });
+    expect(viewports[2]).toEqual({ ...medium, name: 'medium' });
+    expect(viewports[3]).toEqual({ ...large, name: 'large' });
+    expect(viewports[4]).toEqual({ ...huge, name: 'huge' });
+    expect(viewports[5]).toEqual({ ...enormous, name: 'enormous' });
   });
 
   it('should get specified viewport', () => {
     const viewports = getViewports('tiny');
 
     expect(viewports.length).toEqual(1);
-    expect(viewports[0]).toEqual(TERRA_VIEWPORTS.tiny);
+    expect(viewports[0]).toEqual({ ...tiny, name: 'tiny' });
   });
 });


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

This PR adds the `name` attribute to the return value of `getViewports` to match the previous API. This adds identification of each returned viewport object.

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
