### PR TITLE
Added browser to mainFields

### DIFF
--- a/packages/webpack-config-terra/CHANGELOG.md
+++ b/packages/webpack-config-terra/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Added
-  * Added `browser` to webpack module list.
+  * Added `browser` to `resolve.mainFields` in webpack module list.
 
 ## 1.2.0 - (January 5, 2021)
 

--- a/packages/webpack-config-terra/CHANGELOG.md
+++ b/packages/webpack-config-terra/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Added `browser` to webpack module list.
+
 ## 1.2.0 - (January 5, 2021)
 
 * Changed

--- a/packages/webpack-config-terra/src/webpack.config.js
+++ b/packages/webpack-config-terra/src/webpack.config.js
@@ -227,7 +227,7 @@ const defaultWebpackConfig = (env = {}, argv = {}, options = {}) => {
     resolve: {
       extensions: ['.js', '.jsx'],
       modules: getResolveModules(env),
-      mainFields: ['main'],
+      mainFields: ['browser', 'main'],
     },
     output: {
       filename: `${filename}.js`,


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->
This PR adds `browser` to `resolve.mainFields` in webpack.

closes #522 

These changes have been tested on Framework.

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
