### PR TITLE
[terra-functional-testing] Exclude selenium service if grid url exists | Update terra wdio script within documentation

### DIFF
--- a/packages/terra-functional-testing/src/config/wdio.conf.js
+++ b/packages/terra-functional-testing/src/config/wdio.conf.js
@@ -138,7 +138,7 @@ exports.config = {
       ...fs.existsSync(defaultWebpackPath) && { webpackConfig: defaultWebpackPath },
     }],
     // Do not add the docker service if disabled.
-    ...(WDIO_DISABLE_SELENIUM_SERVICE ? [] : [[SeleniumDockerService]]),
+    ...(WDIO_DISABLE_SELENIUM_SERVICE || SELENIUM_GRID_URL ? [] : [[SeleniumDockerService]]),
   ],
   // Framework you want to run your specs with.
   // The following are supported: Mocha, Jasmine, and Cucumber

--- a/packages/terra-functional-testing/src/terra-dev-site/terra-functional-testing/wdio-testing/About.tool.mdx
+++ b/packages/terra-functional-testing/src/terra-dev-site/terra-functional-testing/wdio-testing/About.tool.mdx
@@ -41,7 +41,7 @@ package.json
 ```json
 {
   "scripts": {
-    "wdio": "npm run terra -- wdio --locales en fr --formFactors tiny huge"
+    "wdio": "npm run terra wdio --locales en fr --formFactors tiny huge"
   }
 }
 ```


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->
* Closes #532 by adding a presence check for `SELENIUM_GRID_URL`
* Updates the terra wdio script within our documentation to be from a consumer's perspective, by omitting `--`.

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
