### PR TITLE
[terra-functional-testing] Add support for BROWSERS env string formats

### DIFF
--- a/packages/terra-functional-testing/src/config/utils/getCapabilities.js
+++ b/packages/terra-functional-testing/src/config/utils/getCapabilities.js
@@ -2,7 +2,7 @@ const { chrome, firefox, ie } = require('../capabilities');
 
 /**
  * Determines the browser capabilities for the WebDriver session.
- * @param {array} browsers - An array of browser names to enable. (chrome, firefox, ie)
+ * @param {string|array} browsers - A string or array containing a list of browser names. (chrome, firefox, ie)
  * @param {boolean} isGridEnabled - Whether the WebDriver session is running against the remote selenium grid.
  * @returns {array} - An array of browser capabilities.
  */
@@ -18,15 +18,17 @@ const getCapabilities = (browsers, isGridEnabled) => {
       capabilities.push(firefox, ie);
     }
   } else {
-    browsers.forEach((browser) => {
-      if (browser === 'chrome') {
-        capabilities.push(chrome);
-      } else if (browser === 'firefox') {
-        capabilities.push(firefox);
-      } else if (browser === 'ie' && isGridEnabled) {
-        capabilities.push(ie);
-      }
-    });
+    if (browsers.indexOf('chrome') > -1) {
+      capabilities.push(chrome);
+    }
+
+    if (browsers.indexOf('firefox') > -1) {
+      capabilities.push(firefox);
+    }
+
+    if (browsers.indexOf('ie') > -1 && isGridEnabled) {
+      capabilities.push(ie);
+    }
   }
 
   // Randomize the browser order.

--- a/packages/terra-functional-testing/src/config/wdio.conf.js
+++ b/packages/terra-functional-testing/src/config/wdio.conf.js
@@ -25,8 +25,6 @@ const {
   WDIO_HOSTNAME,
 } = process.env;
 
-// Convert BROWSERS into an array. When assigned to a process.env it is cast as a string.
-const browsers = BROWSERS ? BROWSERS.split(',') : undefined;
 const defaultWebpackPath = path.resolve(process.cwd(), 'webpack.config.js');
 
 exports.config = {
@@ -73,7 +71,7 @@ exports.config = {
   // Sauce Labs platform configurator - a great tool to configure your capabilities:
   // https://docs.saucelabs.com/reference/platforms-configurator
   //
-  capabilities: getCapabilities(browsers, !!SELENIUM_GRID_URL),
+  capabilities: getCapabilities(BROWSERS, !!SELENIUM_GRID_URL),
   //
   // ===================
   // Test Configurations

--- a/packages/terra-functional-testing/tests/jest/config/utils/getCapabilities.test.js
+++ b/packages/terra-functional-testing/tests/jest/config/utils/getCapabilities.test.js
@@ -42,4 +42,27 @@ describe('getCapabilities', () => {
     expect(capabilities.length).toEqual(1);
     expect(capabilities[0].browserName).toEqual('internet explorer');
   });
+
+  it('should include only chrome if provided as a string', () => {
+    const capabilities = getCapabilities('chrome');
+
+    expect(capabilities.length).toEqual(1);
+    expect(capabilities[0].browserName).toEqual('chrome');
+  });
+
+  it('should include chrome and firefox when provided as a string', () => {
+    const capabilities = getCapabilities('[chrome, firefox]');
+
+    expect(capabilities.length).toEqual(2);
+    expect(capabilities.findIndex(({ browserName }) => browserName === 'chrome')).toBeGreaterThanOrEqual(0);
+    expect(capabilities.findIndex(({ browserName }) => browserName === 'firefox')).toBeGreaterThanOrEqual(0);
+  });
+
+  it('should include chrome and firefox when provided as a comma delimited  string', () => {
+    const capabilities = getCapabilities('chrome,firefox');
+
+    expect(capabilities.length).toEqual(2);
+    expect(capabilities.findIndex(({ browserName }) => browserName === 'chrome')).toBeGreaterThanOrEqual(0);
+    expect(capabilities.findIndex(({ browserName }) => browserName === 'firefox')).toBeGreaterThanOrEqual(0);
+  });
 });


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

This PR adds support for the anticipated string formats the BROWSERS env can be supplied as.

All ENVs supplied to a node process are coerced into strings. The format of these strings can be slightly different depending on the environment that defined them.

In node the following will be cast into a comma delimited string.

```js
const browsers = ['chrome', 'firefox', 'ie'];

process.env.BROWSERS = browsers;

console.log(process.env.BROWSERS);

// Outputs: "chrome,firefox,ie"
```

In groovy the array will be cast in an array literal string:

```groovy
def browsers = ['chrome', 'firefox', 'ie'];
def string =  "-e 'BROWSERS=${browsers}'"

// Outputs: "[chrome,firefox,ie]"
```

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

This strategy caries forward a similar string parsing strategy as [implemented](https://github.com/cerner/terra-toolkit-boneyard/blob/main/config/wdio/selenium.config.js#L58-L66) in the existing terra-toolkit-boneyard:

The includes here is for the [String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes) object, but also works for [Arrays](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes). The updated indexOf also works for both Strings and Arrays. 

Resolves #560 

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
