### PR TITLE
[terra-functional-testing] Add warn API to axe rules

### DIFF
--- a/packages/terra-functional-testing/src/reporters/accessibility-reporter/wdio-accessibility-reporter.js
+++ b/packages/terra-functional-testing/src/reporters/accessibility-reporter/wdio-accessibility-reporter.js
@@ -35,7 +35,7 @@ class AccessibilityReporter extends WDIOReporter {
   /**
    * Hook invoked when accessibility results are reported.
    * @param {Object} results - Accessibility results.
-   * @param {array} results.incomplete - Incomplete accessibility results.
+   * @param {array} results.warnings - Accessibility warning results.
    */
   onReportAccessibility(results) {
     this.accessibilityResults[this.currentTest] = results;
@@ -112,9 +112,9 @@ class AccessibilityReporter extends WDIOReporter {
    */
   formatTestWarning(uid, indent) {
     const { title } = this.tests[uid];
-    const { incomplete } = this.accessibilityResults[uid];
+    const { warnings } = this.accessibilityResults[uid];
 
-    const string = `${chalk.yellow('warning')} ${title}\n\n ${chalk.yellow(`${JSON.stringify(incomplete, null, 2)}`)}`;
+    const string = `${chalk.yellow('warning')} ${title}\n\n ${chalk.yellow(`${JSON.stringify(warnings, null, 2)}`)}`;
 
     return AccessibilityReporter.indent(string, indent);
   }

--- a/packages/terra-functional-testing/tests/jest/commands/expect/__snapshots__/toBeAccessible.test.js.snap
+++ b/packages/terra-functional-testing/tests/jest/commands/expect/__snapshots__/toBeAccessible.test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`toBeAccessible should return a message function that filterers out rules set to warn 1`] = `
+"expected no accessibility violations but received [
+  {
+    \\"id\\": \\"mock-violation-2\\"
+  }
+]"
+`;
+
+exports[`toBeAccessible should return a message function that indicates the reason for the assertion failure 1`] = `
+"expected no accessibility violations but received [
+  {
+    \\"id\\": \\"mock-violation\\"
+  }
+]"
+`;

--- a/packages/terra-functional-testing/tests/jest/commands/expect/toBeAccessible.test.js
+++ b/packages/terra-functional-testing/tests/jest/commands/expect/toBeAccessible.test.js
@@ -11,6 +11,12 @@ describe('toBeAccessible', () => {
       },
     }));
 
+    global.Terra = {
+      axe: {
+        rules: {},
+      },
+    };
+
     const result = toBeAccessible();
 
     expect(result.pass).toBe(true);
@@ -19,7 +25,7 @@ describe('toBeAccessible', () => {
   it('should not pass if accessibility violations are found', () => {
     runAxe.mockImplementationOnce(() => ({
       result: {
-        violations: ['Mock Violation 1'],
+        violations: [{ id: 'Mock Violation 1' }],
       },
     }));
 
@@ -31,12 +37,34 @@ describe('toBeAccessible', () => {
   it('should return a message function that indicates the reason for the assertion failure', () => {
     runAxe.mockImplementationOnce(() => ({
       result: {
-        violations: [],
+        violations: [{ id: 'mock-violation' }],
       },
     }));
 
     const result = toBeAccessible();
 
-    expect(result.message()).toEqual('expected no accessibility violations but received []');
+    expect(result.message()).toMatchSnapshot();
+  });
+
+  it('should return a message function that filterers out rules set to warn', () => {
+    runAxe.mockImplementationOnce(() => ({
+      result: {
+        violations: [{ id: 'mock-violation-1' }, { id: 'mock-violation-2' }],
+      },
+    }));
+
+    global.Terra = {
+      axe: {
+        rules: {
+          'mock-violation-1': {
+            warn: true,
+          },
+        },
+      },
+    };
+
+    const result = toBeAccessible();
+
+    expect(result.message()).toMatchSnapshot();
   });
 });

--- a/packages/terra-functional-testing/tests/jest/reporters/accessibility-reporter/wdio-accessibility-reporter.test.js
+++ b/packages/terra-functional-testing/tests/jest/reporters/accessibility-reporter/wdio-accessibility-reporter.test.js
@@ -44,9 +44,9 @@ describe('Accessibility Reporter', () => {
       const reporter = new AccessibilityReporter({});
 
       reporter.onTestStart({ uid: 'mock' });
-      reporter.onReportAccessibility({ incomplete: [] });
+      reporter.onReportAccessibility({ warnings: [] });
 
-      expect(reporter.accessibilityResults.mock).toEqual({ incomplete: [] });
+      expect(reporter.accessibilityResults.mock).toEqual({ warnings: [] });
     });
   });
 
@@ -77,7 +77,7 @@ describe('Accessibility Reporter', () => {
     it('should print an accessibility report', () => {
       const reporter = new AccessibilityReporter({});
 
-      reporter.accessibilityResults = { 'test-id': { incomplete: [] } };
+      reporter.accessibilityResults = { 'test-id': { warnings: [] } };
 
       jest.spyOn(reporter, 'travelSuite').mockImplementationOnce(() => ('mock output'));
       jest.spyOn(reporter, 'write').mockImplementationOnce(() => {});
@@ -130,7 +130,7 @@ describe('Accessibility Reporter', () => {
 
       reporter.accessibilityResults = {
         'test-10-0': {
-          incomplete: ['mock warning'],
+          warnings: ['mock warning'],
         },
       };
 


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

This PR updates the accessibility reporter and axe rules to have an explicit `warn` API. The current warning strategy relies on marking rules `reviewOnFail` and marking them as `incomplete` in the results object. This works, but the incomplete array also contains rules that axe wasn't able to successfully determine as pass/fail. This can result in a tremendous amount of warnings for rules that are not explicitly marked as warnings. 

This API change creates an explicit distinction between rules set to `warn` and rules that axe was unable to successfully determine pass/fail. 

Rules can be marked as warnings by adding the `warn` key to the rules declared in the terra-service.

Example:

Configured color-contrast to warn on failure:

```js
   global.Terra.axe = {
      rules: {
        'color-contrast': {
          enabled: this.serviceOptions.theme !== 'clinical-lowlight-theme',
          warn: true,
        },
      },
    };
```

Resolves #562 