### PR TITLE
[terra-functional-testing] Support finding the local ip address when connected to the vpn

### DIFF
--- a/packages/terra-functional-testing/src/config/utils/getIpAddress.js
+++ b/packages/terra-functional-testing/src/config/utils/getIpAddress.js
@@ -1,0 +1,12 @@
+const ip = require('ip');
+const os = require('os');
+
+module.exports = () => {
+  const utun = Object.entries(os.networkInterfaces()).find(([key, networkInterface]) => key.includes('utun') && networkInterface[0] && networkInterface[0].family === 'IPv4');
+
+  if (utun && utun[1]) {
+    return utun[1][0].address;
+  }
+
+  return ip.address();
+};

--- a/packages/terra-functional-testing/src/config/wdio.conf.js
+++ b/packages/terra-functional-testing/src/config/wdio.conf.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
-const ip = require('ip');
 const getCapabilities = require('./utils/getCapabilities');
+const getIpAddress = require('./utils/getIpAddress');
 
 const SeleniumDockerService = require('../services/wdio-selenium-docker-service');
 const TerraService = require('../services/wdio-terra-service');
@@ -109,7 +109,7 @@ exports.config = {
   // with `/`, the base url gets prepended, not including the path portion of your baseUrl.
   // If your `url` parameter starts without a scheme or `/` (like `some/path`), the base url
   // gets prepended directly.
-  baseUrl: `http://${WDIO_EXTERNAL_HOST || ip.address()}:${WDIO_EXTERNAL_PORT || 8080}`,
+  baseUrl: `http://${WDIO_EXTERNAL_HOST || getIpAddress()}:${WDIO_EXTERNAL_PORT || 8080}`,
   //
   // Default timeout for all waitFor* commands.
   waitforTimeout: 10000,


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

This pr will iterate through utun network entries until the first ipv4 entry, and will use that ip address for testing. This allows wdio to be run locally on macos while connected to the vpn.

Companion to terra-toolkit-boneyard pr #[75](https://github.com/cerner/terra-toolkit-boneyard/pull/75)

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
