### PR TITLE
[eslint-config-terra] Fix missing peer dependency

### DIFF
--- a/packages/eslint-config-terra/CHANGELOG.md
+++ b/packages/eslint-config-terra/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Resolved missing peer dependency warning by locking into a previous version of eslint-config-airbnb.
+
 ## 4.4.0 - (January 27, 2021)
 
 * Changed

--- a/packages/eslint-config-terra/package.json
+++ b/packages/eslint-config-terra/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "babel-eslint": "^10.1.0",
-    "eslint-config-airbnb": "^18.0.0",
+    "eslint-config-airbnb": "18.1.0",
     "eslint-plugin-compat": "^3.3.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.1",


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

Installing eslint-config-terra produces the following missing peer dependency warning:

>eslint-config-airbnb@18.2.1 requires a peer of eslint-plugin-react@^7.21.5 but none is installed. 

Due to passivity concerns we've locked this package to eslint-plugin-react 7.19.0. This warning was introduced by eslint-config-airbnb version 18.2.0 updating it's peer dependency on eslint-plugin-react from 7.19.0 to 7.21.5. Technically changing a peer dependency versions should be considered non-passive but i'll give airbnb a pass this time because peer dependencies are confusing and passivity is hard.

There are two ways we could fix this. Either by downgrading and locking eslint-config-airbnb to version 18.1.0 or by upgrading eslint-plugin-react to 18.2.1. Upgrading would be non-passive, so the easiest way to address this warning is to downgrade which is what i have done in this PR.

Any major version upgrades of this package should also include updating to eslint 7 so it would be a more involved change.

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
