### PR TITLE
[terra-functional-testing] Fix object short hand usage in browser execute

### DIFF
--- a/packages/terra-functional-testing/src/commands/axe/run.js
+++ b/packages/terra-functional-testing/src/commands/axe/run.js
@@ -31,7 +31,8 @@ const runAxe = (options = {}) => {
   return browser.executeAsync(function (opts, done) {
     // eslint-disable-next-line prefer-arrow-callback, func-names
     axe.run(document, opts, function (error, result) {
-      done({ error, result });
+      // eslint-disable-next-line object-shorthand
+      done({ error: error, result: result }); // IE 10 does not support object short hand. This line must explicity define the key and value of the object.
     });
   }, { rules, runOnly: ['wcag2a', 'wcag2aa', 'wcag21aa', 'section508'] });
 };


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

This PR removes the usage of object short hand inside of browser.execute. IE 10 does not support the shorthand syntax and throws an error. 

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
