### PR TITLE
[terra-functional-testing] auto update screenshots

### DIFF
--- a/packages/terra-functional-testing/src/commands/axe/run.js
+++ b/packages/terra-functional-testing/src/commands/axe/run.js
@@ -4,7 +4,7 @@ const injectAxe = require('./inject');
 /**
  * Executes axe on the browser.
  * @param {Object} options - The axe options.
- * @param {Array} options.rules - The rule overrides.
+ * @param {array} options.rules - The rule overrides.
  */
 const runAxe = (options = {}) => {
   // eslint-disable-next-line prefer-arrow-callback

--- a/packages/terra-functional-testing/src/commands/expect/toMatchReference.js
+++ b/packages/terra-functional-testing/src/commands/expect/toMatchReference.js
@@ -3,11 +3,11 @@
  * the mismatch tolerance and are the same size.
  *
  * @param {Object} screenshot - The comparison result.
- * @param {Boolean} screenshot.isNewScreenshot - If the latest screenshot was a new screenshot that has no reference screenshot.
- * @param {Boolean} screenshot.isSameDimensions - If the latest screenshot was the same size as the reference screenshot.
- * @param {Boolean} screenshot.isWithinMismatchTolerance - If the latest screenshot was within the mismatch tolerance.
- * @param {Number} screenshot.misMatchPercentage - The mismatch percentage when comparing the latest screenshot to the reference screenshot.
- * @param {Boolean} screenshot.screenshotWasUpdated - If the reference screenshot was updated with the latest captured screenshot.
+ * @param {boolean} screenshot.isNewScreenshot - If the latest screenshot was a new screenshot that has no reference screenshot.
+ * @param {boolean} screenshot.isSameDimensions - If the latest screenshot was the same size as the reference screenshot.
+ * @param {boolean} screenshot.isWithinMismatchTolerance - If the latest screenshot was within the mismatch tolerance.
+ * @param {number} screenshot.misMatchPercentage - The mismatch percentage when comparing the latest screenshot to the reference screenshot.
+ * @param {boolean} screenshot.screenshotWasUpdated - If the reference screenshot was updated with the latest captured screenshot.
  * @returns {Object} - An object that indicates if the assertion passed or failed with a message.
  */
 function toMatchReference(screenshot) {

--- a/packages/terra-functional-testing/src/commands/expect/toMatchReference.js
+++ b/packages/terra-functional-testing/src/commands/expect/toMatchReference.js
@@ -3,10 +3,11 @@
  * the mismatch tolerance and are the same size.
  *
  * @param {Object} screenshot - The comparison result.
- * @param {boolean} screenshot.isNewScreenshot - If the latest screenshot was a new screenshot that has no reference screenshot.
- * @param {boolean} screenshot.isSameDimensions - If the latest screenshot was the same size as the reference screenshot.
- * @param {boolean} screenshot.isWithinMismatchTolerance - If the latest screenshot was within the mismatch tolerance.
+ * @param {Boolean} screenshot.isNewScreenshot - If the latest screenshot was a new screenshot that has no reference screenshot.
+ * @param {Boolean} screenshot.isSameDimensions - If the latest screenshot was the same size as the reference screenshot.
+ * @param {Boolean} screenshot.isWithinMismatchTolerance - If the latest screenshot was within the mismatch tolerance.
  * @param {Number} screenshot.misMatchPercentage - The mismatch percentage when comparing the latest screenshot to the reference screenshot.
+ * @param {Boolean} screenshot.screenshotWasUpdated - If the reference screenshot was updated with the latest captured screenshot.
  * @returns {Object} - An object that indicates if the assertion passed or failed with a message.
  */
 function toMatchReference(screenshot) {
@@ -15,11 +16,12 @@ function toMatchReference(screenshot) {
     isSameDimensions,
     isWithinMismatchTolerance,
     misMatchPercentage,
+    screenshotWasUpdated,
   } = screenshot;
 
   // Validate the screenshot is the same size for the case when the new screenshot matches 100% but is 'n' pixel taller due to new content.
   // For example: the latest screenshot of a list has two more items than the reference screenshot so it is 60 pixels taller. That should fail.
-  const imagesMatch = isNewScreenshot || (isSameDimensions && isWithinMismatchTolerance);
+  const imagesMatch = isNewScreenshot || screenshotWasUpdated || (isSameDimensions && isWithinMismatchTolerance);
   let message = '';
 
   if (!isSameDimensions) {

--- a/packages/terra-functional-testing/src/commands/utils/dispatchCustomEvent.js
+++ b/packages/terra-functional-testing/src/commands/utils/dispatchCustomEvent.js
@@ -1,7 +1,7 @@
 /**
  * Utility to send a custom event containing metadata.
  * @param {string} options.name - name of event
- * @param {object} options.metaData - metadata pertaining to event
+ * @param {Object} options.metaData - metadata pertaining to event
  */
 const dispatchCustomEvent = (options) => {
   const { name, metaData } = options;

--- a/packages/terra-functional-testing/src/commands/validates/element.js
+++ b/packages/terra-functional-testing/src/commands/validates/element.js
@@ -9,7 +9,7 @@ const screenshot = require('./screenshot');
  * @param {string} [testName] - the required test case name.
  * @param {Object} [options] - the test options
  * @param {Object} [options.rules] - the axe rules to use to assert accessibility.
- * @param {Number} [options.mismatchTolerance] - the mismatch tolerance for the screenshot comparison.
+ * @param {number} [options.mismatchTolerance] - the mismatch tolerance for the screenshot comparison.
  * @param {string} [options.selector] - the element selector to use for the screenshot comparison.
  */
 const element = (testName, options = {}) => {

--- a/packages/terra-functional-testing/src/commands/validates/screenshot.js
+++ b/packages/terra-functional-testing/src/commands/validates/screenshot.js
@@ -17,6 +17,7 @@ const screenshot = (testName, options = {}) => {
   const { selector } = options;
   const wrappedOptions = {
     name: testName,
+    updateScreenshots: global.Terra.serviceOptions.updateScreenshots,
     ...options,
   };
 

--- a/packages/terra-functional-testing/src/commands/validates/screenshot.js
+++ b/packages/terra-functional-testing/src/commands/validates/screenshot.js
@@ -16,9 +16,9 @@ const screenshot = (testName, options = {}) => {
 
   const { selector } = options;
   const wrappedOptions = {
-    name: testName,
-    updateScreenshots: global.Terra.serviceOptions.updateScreenshots,
     ...options,
+    name: testName,
+    updateScreenshots: global.Terra.serviceOptions.updateScreenshots === true,
   };
 
   const screenshotResult = global.browser.checkElement(selector || global.Terra.serviceOptions.selector, wrappedOptions);

--- a/packages/terra-functional-testing/src/services/wdio-selenium-docker-service.js
+++ b/packages/terra-functional-testing/src/services/wdio-selenium-docker-service.js
@@ -22,7 +22,11 @@ class SeleniumDockerService {
   async onPrepare(config) {
     this.host = config.hostname;
     this.port = config.port;
-    this.keepAliveSeleniumDockerService = config.keepAliveSeleniumDockerService;
+
+    const { launcherOptions } = config;
+    const { keepAliveSeleniumDockerService } = launcherOptions || {};
+
+    this.keepAliveSeleniumDockerService = keepAliveSeleniumDockerService === true;
 
     // Verify docker is installed before proceeding.
     try {

--- a/packages/terra-functional-testing/src/services/wdio-terra-service.js
+++ b/packages/terra-functional-testing/src/services/wdio-terra-service.js
@@ -21,7 +21,8 @@ class TerraService {
    */
   beforeSession(config) {
     global.Terra = {};
-    const { serviceOptions, updateScreenshots } = config;
+    const { serviceOptions, launcherOptions } = config;
+    const { updateScreenshots } = launcherOptions || {};
 
     this.serviceOptions = {
       theme: 'terra-default-theme',

--- a/packages/terra-functional-testing/src/services/wdio-terra-service.js
+++ b/packages/terra-functional-testing/src/services/wdio-terra-service.js
@@ -21,11 +21,12 @@ class TerraService {
    */
   beforeSession(config) {
     global.Terra = {};
-    const { serviceOptions } = config;
+    const { serviceOptions, updateScreenshots } = config;
 
     this.serviceOptions = {
       theme: 'terra-default-theme',
       selector: '[data-terra-test-content] *:first-child',
+      updateScreenshots: updateScreenshots === true,
       ...this.serviceOptions,
       ...serviceOptions,
     };

--- a/packages/terra-functional-testing/src/services/wdio-terra-service.js
+++ b/packages/terra-functional-testing/src/services/wdio-terra-service.js
@@ -17,7 +17,7 @@ class TerraService {
 
   /**
    * Service hook executed prior to initializing the webdriver session.
-   * @param {object} config - The WebdriverIO configuration object.
+   * @param {Object} config - The WebdriverIO configuration object.
    */
   beforeSession(config) {
     global.Terra = {};

--- a/packages/terra-functional-testing/src/services/wdio-visual-regression-service/VisualRegressionLauncher.js
+++ b/packages/terra-functional-testing/src/services/wdio-visual-regression-service/VisualRegressionLauncher.js
@@ -82,6 +82,7 @@ class VisualRegressionLauncher {
      * @param {String} options.ignoreComparison - The image comparison algorithm to use when processing the screenshot comparison.
      * @param {Number} options.mismatchTolerance - The acceptable mismatch tolerance the screenshot can have when processing the screenshot comparison.
      * @param {String} options.name - The name of the screenshot.
+     * @param {Boolean} options.updateScreenshots - Whether or not to automatically update all reference screenshots with the latest screenshots.
      * @returns {Object} - The screenshot comparison results returned as { misMatchPercentage: Number, isSameDimensions: Boolean, getImageDataUrl: function }.
      */
     return async function wrappedScreenshotCommand(elementSelector, options) {

--- a/packages/terra-functional-testing/src/services/wdio-visual-regression-service/VisualRegressionLauncher.js
+++ b/packages/terra-functional-testing/src/services/wdio-visual-regression-service/VisualRegressionLauncher.js
@@ -21,7 +21,7 @@ class VisualRegressionLauncher {
   /**
    * Gets executed before test execution begins. At this point you can access
    * all global variables, such as `browser`.
-   * @param {object} capabilities - desiredCapabilities
+   * @param {Object} capabilities - desiredCapabilities
    * @param {[type]} specs
    * @return null
    */
@@ -68,21 +68,21 @@ class VisualRegressionLauncher {
    * Command wrapper to setup the command with the correct context values defined from the global
    * webdriver.IO WebDriver instance.
    *
-   * @param {object} browser - The global webdriver.IO WebDriver instance.
+   * @param {Object} browser - The global webdriver.IO WebDriver instance.
    * @param {function} command - The test command that should be executed.
    */
   wrapCommand(browser, command) {
     /**
      * The wrapped command with access to the global webdriver.IO WebDriver instance.
      *
-     * @param {String} elementSelector - The css selector of the element that should be captured in the screenshot.
+     * @param {string} elementSelector - The css selector of the element that should be captured in the screenshot.
      * @param {Object=} options - The screenshot capturing and comparison options.
-     * @param {String[]} options.hide - The list of elements to set opacity 0 on to 'hide' from the dom when capturing the screenshot.
-     * @param {String[]} options.remove - The list of elements to set display: none on to 'remove' from dom when capturing the screenshot.
-     * @param {String} options.ignoreComparison - The image comparison algorithm to use when processing the screenshot comparison.
-     * @param {Number} options.mismatchTolerance - The acceptable mismatch tolerance the screenshot can have when processing the screenshot comparison.
-     * @param {String} options.name - The name of the screenshot.
-     * @param {Boolean} options.updateScreenshots - Whether or not to automatically update all reference screenshots with the latest screenshots.
+     * @param {string[]} options.hide - The list of elements to set opacity 0 on to 'hide' from the dom when capturing the screenshot.
+     * @param {string[]} options.remove - The list of elements to set display: none on to 'remove' from dom when capturing the screenshot.
+     * @param {string} options.ignoreComparison - The image comparison algorithm to use when processing the screenshot comparison.
+     * @param {number} options.mismatchTolerance - The acceptable mismatch tolerance the screenshot can have when processing the screenshot comparison.
+     * @param {string} options.name - The name of the screenshot.
+     * @param {boolean} options.updateScreenshots - Whether or not to automatically update all reference screenshots with the latest screenshots.
      * @returns {Object} - The screenshot comparison results returned as { misMatchPercentage: Number, isSameDimensions: Boolean, getImageDataUrl: function }.
      */
     return async function wrappedScreenshotCommand(elementSelector, options) {

--- a/packages/terra-functional-testing/src/services/wdio-visual-regression-service/commands/saveElementScreenshot.js
+++ b/packages/terra-functional-testing/src/services/wdio-visual-regression-service/commands/saveElementScreenshot.js
@@ -12,10 +12,10 @@ const saveBase64Image = require('../utils/saveBase64Image');
  *
  * @alias browser.checkElement
  * @param {string=} fileName - The filename to use to save the screenshot.
- * @param {String} elementSelector - The css selector of the element that should be captured in the screenshot.
+ * @param {string} elementSelector - The css selector of the element that should be captured in the screenshot.
  * @param {Object=} options - The screenshot capturing and comparison options.
- * @param {String[]} options.hide - The list of elements to set opacity 0 on to 'hide' from the dom when capturing the screenshot.
- * @param {String[]} options.remove - The list of elements to set display: none on to 'remove' from dom when capturing the screenshot.
+ * @param {string[]} options.hide - The list of elements to set opacity 0 on to 'hide' from the dom when capturing the screenshot.
+ * @param {string[]} options.remove - The list of elements to set display: none on to 'remove' from dom when capturing the screenshot.
  * @returns {String} - The base64 string of the screenshot image that was captured.
  */
 // Note: function name must be async to signalize WebdriverIO that this function returns a promise

--- a/packages/terra-functional-testing/src/services/wdio-visual-regression-service/methods/BaseCompare.js
+++ b/packages/terra-functional-testing/src/services/wdio-visual-regression-service/methods/BaseCompare.js
@@ -40,8 +40,8 @@ class BaseCompare {
   /**
    * Creates the sanitized test name for the screenshot.
    *
-   * @param {String} fullName - The test name.
-   * @returns {String} - The test name.
+   * @param {string} fullName - The test name.
+   * @returns {string} - The test name.
    */
   createTestName(fullName) {
     const matches = TEST_ID_REGEX.exec(fullName);
@@ -117,11 +117,11 @@ class BaseCompare {
   /**
    * Creates the screenshot comparison report object.
    *
-   * @param {Boolean} referenceExists - Whether or not the screenshot was just created.
-   * @param {Number} misMatchPercentage - The percent mismatched of the latest screenshot compared to the reference screenshot.
-   * @param {Boolean} isWithinMismatchTolerance - Whether or not the latest screenshot is a close enough match the reference screenshot.
-   * @param {Boolean} isSameDimensions - Whether or not the latest screenshot was the same dimensions as the reference screenshot.
-   * @param {Boolean} screenshotWasUpdated - Whether or not the reference screenshot was updated with the latest captured screenshot.
+   * @param {boolean} referenceExists - Whether or not the screenshot was just created.
+   * @param {number} misMatchPercentage - The percent mismatched of the latest screenshot compared to the reference screenshot.
+   * @param {boolean} isWithinMismatchTolerance - Whether or not the latest screenshot is a close enough match the reference screenshot.
+   * @param {boolean} isSameDimensions - Whether or not the latest screenshot was the same dimensions as the reference screenshot.
+   * @param {boolean} screenshotWasUpdated - Whether or not the reference screenshot was updated with the latest captured screenshot.
    * @returns {Object} - The relevant comparison results to report.
    */
   createResultReport(referenceExists, misMatchPercentage, isWithinMismatchTolerance, isSameDimensions, screenshotWasUpdated) {

--- a/packages/terra-functional-testing/src/services/wdio-visual-regression-service/methods/BaseCompare.js
+++ b/packages/terra-functional-testing/src/services/wdio-visual-regression-service/methods/BaseCompare.js
@@ -121,9 +121,10 @@ class BaseCompare {
    * @param {Number} misMatchPercentage - The percent mismatched of the latest screenshot compared to the reference screenshot.
    * @param {Boolean} isWithinMismatchTolerance - Whether or not the latest screenshot is a close enough match the reference screenshot.
    * @param {Boolean} isSameDimensions - Whether or not the latest screenshot was the same dimensions as the reference screenshot.
+   * @param {Boolean} screenshotWasUpdated - Whether or not the reference screenshot was updated with the latest captured screenshot.
    * @returns {Object} - The relevant comparison results to report.
    */
-  createResultReport(referenceExists, misMatchPercentage, isWithinMismatchTolerance, isSameDimensions) {
+  createResultReport(referenceExists, misMatchPercentage, isWithinMismatchTolerance, isSameDimensions, screenshotWasUpdated) {
     if (!referenceExists) {
       return { isNewScreenshot: true };
     }
@@ -132,6 +133,7 @@ class BaseCompare {
       misMatchPercentage,
       isWithinMismatchTolerance,
       isSameDimensions,
+      screenshotWasUpdated,
     };
   }
 }

--- a/packages/terra-functional-testing/src/services/wdio-visual-regression-service/methods/LocalCompare.js
+++ b/packages/terra-functional-testing/src/services/wdio-visual-regression-service/methods/LocalCompare.js
@@ -85,9 +85,9 @@ class LocalCompare extends BaseCompare {
   /**
    * Compares the latest image to the latest image with resemble to determine if they are the same.
    *
-   * @param {String} referencePath - Path to reference image.
+   * @param {string} referencePath - Path to reference image.
    * @param {Buffer} latestScreenshot - Buffer of the latest image.
-   * @param {String} ignoreComparison - The image comparison algorithm to use.
+   * @param {string} ignoreComparison - The image comparison algorithm to use.
    * @returns {Object} - The screenshot comparison results returned as { misMatchPercentage: Number, isSameDimensions: Boolean, getImageDataUrl: function }.
    */
   // eslint-disable-next-line class-methods-use-this

--- a/packages/terra-functional-testing/src/services/wdio-visual-regression-service/modules/afterScreenshot.js
+++ b/packages/terra-functional-testing/src/services/wdio-visual-regression-service/modules/afterScreenshot.js
@@ -10,8 +10,8 @@ const logger = new Logger('[wdio-visual-regression-service:afterScreenshot]');
  *
  * @param {Object} browser - The global webdriver.io WebDriver instance.
  * @param {Object=} options - The screenshot capturing and comparison options.
- * @param {String[]} options.hide - The list of elements to set opacity 0 on to 'hide' from the dom when capturing the screenshot.
- * @param {String[]} options.remove - The list of elements to set display: none on to 'remove' from dom when capturing the screenshot.
+ * @param {string[]} options.hide - The list of elements to set opacity 0 on to 'hide' from the dom when capturing the screenshot.
+ * @param {string[]} options.remove - The list of elements to set display: none on to 'remove' from dom when capturing the screenshot.
  * @returns {undefined}
  */
 async function beforeScreenshot(browser, options = {}) {

--- a/packages/terra-functional-testing/src/services/wdio-visual-regression-service/modules/beforeScreenshot.js
+++ b/packages/terra-functional-testing/src/services/wdio-visual-regression-service/modules/beforeScreenshot.js
@@ -13,8 +13,8 @@ const logger = new Logger('[wdio-visual-regression-service:beforeScreenshot]');
  *
  * @param {Object} browser - The global webdriver.io WebDriver instance.
  * @param {Object=} options - The screenshot capturing and comparison options.
- * @param {String[]} options.hide - The list of elements to set opacity 0 on to 'hide' from the dom when capturing the screenshot.
- * @param {String[]} options.remove - The list of elements to set display: none on to 'remove' from dom when capturing the screenshot.
+ * @param {string[]} options.hide - The list of elements to set opacity 0 on to 'hide' from the dom when capturing the screenshot.
+ * @param {string[]} options.remove - The list of elements to set display: none on to 'remove' from dom when capturing the screenshot.
  * @returns {undefined}
  */
 async function beforeScreenshot(browser, options = {}) {

--- a/packages/terra-functional-testing/src/services/wdio-visual-regression-service/modules/makeElementScreenshot.js
+++ b/packages/terra-functional-testing/src/services/wdio-visual-regression-service/modules/makeElementScreenshot.js
@@ -14,11 +14,11 @@ const logger = new Logger('[wdio-visual-regression-service:makeDocumentScreensho
  *
  * @alias browser.checkElement
  * @param {string=} fileName - The filename to use to save the screenshot.
- * @param {String} elementSelector - The css selector of the element that should be captured in the screenshot.
+ * @param {string} elementSelector - The css selector of the element that should be captured in the screenshot.
  * @param {Object=} options - The screenshot capturing and comparison options.
- * @param {String[]} options.hide - The list of elements to set opacity 0 on to 'hide' from the dom when capturing the screenshot.
- * @param {String[]} options.remove - The list of elements to set display: none on to 'remove' from dom when capturing the screenshot.
- * @returns {String} - The base64 string of the screenshot image that was captured.
+ * @param {string[]} options.hide - The list of elements to set opacity 0 on to 'hide' from the dom when capturing the screenshot.
+ * @param {string[]} options.remove - The list of elements to set display: none on to 'remove' from dom when capturing the screenshot.
+ * @returns {string} - The base64 string of the screenshot image that was captured.
  */
 async function makeElementScreenshot(browser, elementSelector, options = {}) {
   logger.verbose('start element screenshot');

--- a/packages/terra-functional-testing/src/services/wdio-visual-regression-service/scripts/pageHeight.js
+++ b/packages/terra-functional-testing/src/services/wdio-visual-regression-service/scripts/pageHeight.js
@@ -1,7 +1,7 @@
 /**
  * Script to set the document height.
  *
- * @param {String} height - The height to set the document to.
+ * @param {string} height - The height to set the document to.
  * @returns {undefined}
  */
 function pageHeight(height) {

--- a/packages/terra-functional-testing/src/services/wdio-visual-regression-service/scripts/scroll.js
+++ b/packages/terra-functional-testing/src/services/wdio-visual-regression-service/scripts/scroll.js
@@ -1,8 +1,8 @@
 /**
  * Script to scroll to a particular set of coordinates in the document.
  *
- * @param {Number} x - The pixel along the horizontal axis of the document.
- * @param {Number} y - The pixel along the vertical axis of the document.
+ * @param {number} x - The pixel along the horizontal axis of the document.
+ * @param {number} y - The pixel along the vertical axis of the document.
  * @returns {undefined}
  */
 function scroll(x, y) {

--- a/packages/terra-functional-testing/src/services/wdio-visual-regression-service/scripts/scrollbars.js
+++ b/packages/terra-functional-testing/src/services/wdio-visual-regression-service/scripts/scrollbars.js
@@ -1,7 +1,7 @@
 /**
  * Script to add or remove the scrollbars from the document.
  *
- * @param {Boolean} enabled - Whether or not the scrollbars should be visible.
+ * @param {boolean} enabled - Whether or not the scrollbars should be visible.
  * @returns {undefined}
  */
 function scrollbars(enabled) {

--- a/packages/terra-functional-testing/src/services/wdio-visual-regression-service/scripts/virtualScroll.js
+++ b/packages/terra-functional-testing/src/services/wdio-visual-regression-service/scripts/virtualScroll.js
@@ -2,9 +2,9 @@
  * Script to apply a negative 2D-translate transformation method to move the document from its current position
  * to the specified number of pixels horizontally and vertically.
  *
- * @param {Number} x - The number of pixels moved along the horizontal axis from the current position.
- * @param {Number} y - The number of pixels moved along the vertical axis from the current position.
- * @param {Boolean} enabled - Whether or not the transform style should be applied.
+ * @param {number} x - The number of pixels moved along the horizontal axis from the current position.
+ * @param {number} y - The number of pixels moved along the vertical axis from the current position.
+ * @param {boolean} enabled - Whether or not the transform style should be applied.
  * @returns {undefined}
  */
 function virtualScroll(x, y, enabled) {

--- a/packages/terra-functional-testing/src/services/wdio-visual-regression-service/utils/image/gm.js
+++ b/packages/terra-functional-testing/src/services/wdio-visual-regression-service/utils/image/gm.js
@@ -40,7 +40,7 @@ async function cropImage(base64Screenshot, cropDimensions) {
 /**
  * Scales an image down or up.
  * @param {string} base64Screenshot - image to scale
- * @param {Number} scaleFactor - scale factor, e.g. 0.5 for downscale or 1.5 for upscale
+ * @param {number} scaleFactor - scale factor, e.g. 0.5 for downscale or 1.5 for upscale
  * @return {Promise} resolves to cropped image
  */
 async function scaleImage(base64Screenshot, scaleFactor) {

--- a/packages/terra-functional-testing/src/terra-cli/wdio/index.js
+++ b/packages/terra-functional-testing/src/terra-cli/wdio/index.js
@@ -57,9 +57,9 @@ const cli = {
         type: 'array',
         describe: 'A list of spec file paths.',
       },
-      updateScreenshots: {
+      u: {
         type: 'boolean',
-        alias: 'u',
+        alias: 'updateScreenshots',
         describe: 'Whether or not to automatically update all reference screenshots with the latest screenshots.',
         default: false,
       },

--- a/packages/terra-functional-testing/src/terra-cli/wdio/index.js
+++ b/packages/terra-functional-testing/src/terra-cli/wdio/index.js
@@ -57,6 +57,11 @@ const cli = {
         type: 'array',
         describe: 'A list of spec file paths.',
       },
+      updateScreenshots: {
+        type: 'boolean',
+        describe: 'Whether or not to automatically update all reference screenshots with the latest screenshots.',
+        default: false,
+      },
     })
   ),
   handler: TestRunner.start,

--- a/packages/terra-functional-testing/src/terra-cli/wdio/index.js
+++ b/packages/terra-functional-testing/src/terra-cli/wdio/index.js
@@ -59,6 +59,7 @@ const cli = {
       },
       updateScreenshots: {
         type: 'boolean',
+        alias: 'u',
         describe: 'Whether or not to automatically update all reference screenshots with the latest screenshots.',
         default: false,
       },

--- a/packages/terra-functional-testing/src/terra-cli/wdio/test-runner.js
+++ b/packages/terra-functional-testing/src/terra-cli/wdio/test-runner.js
@@ -39,6 +39,7 @@ class TestRunner {
    * @param {string} options.baseUrl - The base url.
    * @param {array} options.suite - Overrides specs and runs only the defined suites.
    * @param {array} options.spec - A list of spec file paths.
+   * @param {boolean} options.updateScreenshots - Updates all reference screenshots with the latest screenshots.
    * @returns {Promise} A promise that resolves with the test run exit code.
    */
   static async run(options) {
@@ -50,7 +51,7 @@ class TestRunner {
         formFactor,
         locale,
         theme,
-        ...launcherOptions // hostname, port, baseUrl, suite, spec, and keepAliveSeleniumDockerService
+        ...launcherOptions // hostname, port, baseUrl, suite, spec, updateScreenshots, and keepAliveSeleniumDockerService
       } = options;
 
       process.env.LOCALE = locale;
@@ -88,6 +89,7 @@ class TestRunner {
    * @param {string} options.baseUrl - The base url.
    * @param {array} options.suite - Overrides specs and runs only the defined suites.
    * @param {array} options.spec - A list of spec file paths.
+   * @param {boolean} options.updateScreenshots - Updates all reference screenshots with the latest screenshots.
    */
   static async start(options) {
     const {
@@ -97,7 +99,7 @@ class TestRunner {
       gridUrl,
       locales,
       themes,
-      ...launcherOptions // hostname, port, baseUrl, suite, spec, and keepAliveSeleniumDockerService
+      ...launcherOptions // hostname, port, baseUrl, suite, spec, updateScreenshots, and keepAliveSeleniumDockerService
     } = options;
 
     if (browsers) {

--- a/packages/terra-functional-testing/src/terra-dev-site/terra-functional-testing/wdio-testing/About.tool.mdx
+++ b/packages/terra-functional-testing/src/terra-dev-site/terra-functional-testing/wdio-testing/About.tool.mdx
@@ -18,21 +18,21 @@ A test runner is provided for local development and should be invoked using the 
 
 ### Options
 
-| Option Name                    | Alias | Type    | Required | Default                 | Description                                                                                   |
-|--------------------------------|-------|---------|----------|-------------------------|-----------------------------------------------------------------------------------------------|
-| browsers                       |       | array   | false    |                         | A list of browsers for the test run.                                                          |
-| config                         | c     | string  | false    |                         | A file path to the test runner configuration.                                                 |
-| formFactors                    |       | array   | false    |                         | A list of form factors for the test run. One of tiny, small, medium, large, huge, or enormous |
-| gridUrl                        |       | string  | false    |                         | The remote selenium grid address.                                                             |
-| keepAliveSeleniumDockerService |       | boolean | false    | false                   | Determines to keep the selenium docker service running upon test completion.                  |
-| locales                        |       | array   | false    | ['en']                  | A list of language locales for the test run.                                                  |
-| themes                         |       | array   | false    | ['terra-default-theme'] | A list of themes for the test run.                                                            |
-| hostname                       |       | string  | false    | localhost               | Automation driver host address.                                                               |
-| port                           |       | number  | false    | 4444                    | Automation driver port.                                                                       |
-| baseUrl                        |       | string  | false    |                         | The base url.                                                                                 |
-| suite                          |       | array   | false    |                         | Overrides specs and runs only the defined suites.                                             |
-| spec                           |       | array   | false    |                         | A list of spec file paths.                                                                    |
-| updateScreenshots              | u     | boolean | false    | false                   | Updates all reference screenshots with the latest screenshots.                                |
+| Option                           | Type    | Default                 | Description                                                                                   |
+|----------------------------------|---------|-------------------------|-----------------------------------------------------------------------------------------------|
+| --baseUrl                        | string  |                         | The base url.                                                                                 |
+| --browsers                       | array   |                         | A list of browsers for the test run.                                                          |
+| --config, -c                     | string  |                         | A file path to the test runner configuration.                                                 |
+| --formFactors                    | array   |                         | A list of form factors for the test run. One of tiny, small, medium, large, huge, or enormous |
+| --gridUrl                        | string  |                         | The remote selenium grid address.                                                             |
+| --hostname                       | string  | localhost               | Automation driver host address.                                                               |
+| --keepAliveSeleniumDockerService | boolean | false                   | Determines to keep the selenium docker service running upon test completion.                  |
+| --locales                        | array   | ['en']                  | A list of language locales for the test run.                                                  |
+| --port                           | number  | 4444                    | Automation driver port.                                                                       |
+| --spec                           | array   |                         | A list of spec file paths.                                                                    |
+| --suite                          | array   |                         | Overrides specs and runs only the defined suites.                                             |
+| --themes                         | array   | ['terra-default-theme'] | A list of themes for the test run.                                                            |
+| --updateScreenshots, -u          | boolean | false                   | Updates all reference screenshots with the latest screenshots.                                |
 
 The following example will run the test suite a total of four times. Once for each permutation of the specified locales and form factors.
 

--- a/packages/terra-functional-testing/src/terra-dev-site/terra-functional-testing/wdio-testing/About.tool.mdx
+++ b/packages/terra-functional-testing/src/terra-dev-site/terra-functional-testing/wdio-testing/About.tool.mdx
@@ -18,21 +18,21 @@ A test runner is provided for local development and should be invoked using the 
 
 ### Options
 
-| Option Name                    | Type    | Required | Default                 | Description                                                                                   |
-|--------------------------------|---------|----------|-------------------------|-----------------------------------------------------------------------------------------------|
-| browsers                       | array   | false    |                         | A list of browsers for the test run.                                                          |
-| config                         | string  | false    |                         | A file path to the test runner configuration.                                                 |
-| formFactors                    | array   | false    |                         | A list of form factors for the test run. One of tiny, small, medium, large, huge, or enormous |
-| gridUrl                        | string  | false    |                         | The remote selenium grid address.                                                             |
-| keepAliveSeleniumDockerService | boolean | false    | false                   | Determines to keep the selenium docker service running upon test completion.                  |
-| locales                        | array   | false    | ['en']                  | A list of language locales for the test run.                                                  |
-| themes                         | array   | false    | ['terra-default-theme'] | A list of themes for the test run.                                                            |
-| hostname                       | string  | false    | localhost               | Automation driver host address.                                                               |
-| port                           | number  | false    | 4444                    | Automation driver port.                                                                       |
-| baseUrl                        | string  | false    |                         | The base url.                                                                                 |
-| suite                          | array   | false    |                         | Overrides specs and runs only the defined suites.                                             |
-| spec                           | array   | false    |                         | A list of spec file paths.                                                                    |
-| updateScreenshots              | boolean | false    | false                   | Updates all reference screenshots with the latest screenshots.                                |
+| Option Name                    | Alias | Type    | Required | Default                 | Description                                                                                   |
+|--------------------------------|-------|---------|----------|-------------------------|-----------------------------------------------------------------------------------------------|
+| browsers                       |       | array   | false    |                         | A list of browsers for the test run.                                                          |
+| config                         | c     | string  | false    |                         | A file path to the test runner configuration.                                                 |
+| formFactors                    |       | array   | false    |                         | A list of form factors for the test run. One of tiny, small, medium, large, huge, or enormous |
+| gridUrl                        |       | string  | false    |                         | The remote selenium grid address.                                                             |
+| keepAliveSeleniumDockerService |       | boolean | false    | false                   | Determines to keep the selenium docker service running upon test completion.                  |
+| locales                        |       | array   | false    | ['en']                  | A list of language locales for the test run.                                                  |
+| themes                         |       | array   | false    | ['terra-default-theme'] | A list of themes for the test run.                                                            |
+| hostname                       |       | string  | false    | localhost               | Automation driver host address.                                                               |
+| port                           |       | number  | false    | 4444                    | Automation driver port.                                                                       |
+| baseUrl                        |       | string  | false    |                         | The base url.                                                                                 |
+| suite                          |       | array   | false    |                         | Overrides specs and runs only the defined suites.                                             |
+| spec                           |       | array   | false    |                         | A list of spec file paths.                                                                    |
+| updateScreenshots              | u     | boolean | false    | false                   | Updates all reference screenshots with the latest screenshots.                                |
 
 The following example will run the test suite a total of four times. Once for each permutation of the specified locales and form factors.
 

--- a/packages/terra-functional-testing/src/terra-dev-site/terra-functional-testing/wdio-testing/About.tool.mdx
+++ b/packages/terra-functional-testing/src/terra-dev-site/terra-functional-testing/wdio-testing/About.tool.mdx
@@ -32,6 +32,7 @@ A test runner is provided for local development and should be invoked using the 
 | baseUrl                        | string  | false    |                         | The base url.                                                                                 |
 | suite                          | array   | false    |                         | Overrides specs and runs only the defined suites.                                             |
 | spec                           | array   | false    |                         | A list of spec file paths.                                                                    |
+| updateScreenshots              | boolean | false    | false                   | Updates all reference screenshots with the latest screenshots.                                |
 
 The following example will run the test suite a total of four times. Once for each permutation of the specified locales and form factors.
 

--- a/packages/terra-functional-testing/tests/jest/commands/expect/toMatchReference.test.js
+++ b/packages/terra-functional-testing/tests/jest/commands/expect/toMatchReference.test.js
@@ -7,6 +7,7 @@ describe('toMatchReference', () => {
       isSameDimensions: true,
       isWithinMismatchTolerance: true,
       misMatchPercentage: 0.10,
+      screenshotWasUpdated: false,
     };
 
     const result = toMatchReference(receivedScreenshot);
@@ -24,12 +25,27 @@ describe('toMatchReference', () => {
     expect(result.pass).toBe(true);
   });
 
+  it('should pass if screenshot was auto updated even when mismatch and not same dimension', () => {
+    const receivedScreenshot = {
+      isNewScreenshot: false,
+      isSameDimensions: false,
+      isWithinMismatchTolerance: false,
+      misMatchPercentage: 0.50,
+      screenshotWasUpdated: true,
+    };
+
+    const result = toMatchReference(receivedScreenshot);
+
+    expect(result.pass).toBe(true);
+  });
+
   it('should not pass if not within mismatch tolerance', () => {
     const receivedScreenshot = {
       isNewScreenshot: false,
       isSameDimensions: true,
       isWithinMismatchTolerance: false,
       misMatchPercentage: 0.10,
+      screenshotWasUpdated: false,
     };
 
     const result = toMatchReference(receivedScreenshot);
@@ -43,6 +59,7 @@ describe('toMatchReference', () => {
       isSameDimensions: false,
       isWithinMismatchTolerance: true,
       misMatchPercentage: 0.10,
+      screenshotWasUpdated: false,
     };
 
     const result = toMatchReference(receivedScreenshot);

--- a/packages/terra-functional-testing/tests/jest/services/wdio-selenium-docker-service.test.js
+++ b/packages/terra-functional-testing/tests/jest/services/wdio-selenium-docker-service.test.js
@@ -18,9 +18,20 @@ describe('WDIO Selenium Docker Service', () => {
       jest.spyOn(service, 'initializeSwarm').mockImplementationOnce(() => Promise.resolve());
       jest.spyOn(service, 'deployStack').mockImplementationOnce(() => Promise.resolve());
 
-      await service.onPrepare({});
+      const config = {
+        hostname: 'mock-hostname',
+        port: 'mock-port',
+        launcherOptions: {
+          keepAliveSeleniumDockerService: true,
+        },
+      };
+
+      await service.onPrepare(config);
 
       expect(service.initializeSwarm).toHaveBeenCalled();
+      expect(service.host).toBe('mock-hostname');
+      expect(service.port).toBe('mock-port');
+      expect(service.keepAliveSeleniumDockerService).toBeTruthy();
     });
 
     it('should deploy the docker stack', async () => {

--- a/packages/terra-functional-testing/tests/jest/services/wdio-terra-service.test.js
+++ b/packages/terra-functional-testing/tests/jest/services/wdio-terra-service.test.js
@@ -124,7 +124,9 @@ describe('WDIO Terra Service', () => {
       serviceOptions: {
         selector: 'mock-selector',
       },
-      updateScreenshots: true,
+      launcherOptions: {
+        updateScreenshots: true,
+      },
     };
 
     const expectedServiceOptions = {

--- a/packages/terra-functional-testing/tests/jest/services/wdio-terra-service.test.js
+++ b/packages/terra-functional-testing/tests/jest/services/wdio-terra-service.test.js
@@ -109,6 +109,7 @@ describe('WDIO Terra Service', () => {
       formFactor: 'huge',
       selector: '[data-terra-test-content] *:first-child',
       theme: 'terra-default-theme',
+      updateScreenshots: false,
     };
 
     service.beforeSession({});
@@ -123,12 +124,14 @@ describe('WDIO Terra Service', () => {
       serviceOptions: {
         selector: 'mock-selector',
       },
+      updateScreenshots: true,
     };
 
     const expectedServiceOptions = {
       formFactor: 'huge',
       selector: 'mock-selector',
       theme: 'terra-default-theme',
+      updateScreenshots: true,
     };
 
     service.beforeSession(config);
@@ -144,6 +147,7 @@ describe('WDIO Terra Service', () => {
       formFactor: 'large',
       selector: '[data-terra-test-content] *:first-child',
       theme: 'terra-default-theme',
+      updateScreenshots: false,
     };
 
     service.beforeSession({});

--- a/packages/terra-functional-testing/tests/jest/services/wdio-visual-regression-service/methods/BaseCompare.test.js
+++ b/packages/terra-functional-testing/tests/jest/services/wdio-visual-regression-service/methods/BaseCompare.test.js
@@ -123,29 +123,42 @@ describe('BaseCompare', () => {
 
     describe('when referenceExists is true', () => {
       it('returns expected results when misMatchPercentage is 0 and isSameDimensions is true', () => {
-        const results = baseCompare.createResultReport(true, 0, true, true);
+        const results = baseCompare.createResultReport(true, 0, true, true, false);
         expect(results).toEqual(expect.objectContaining({
           misMatchPercentage: 0,
           isWithinMismatchTolerance: true,
           isSameDimensions: true,
+          screenshotWasUpdated: false,
         }));
       });
 
       it('returns expected results when misMatchPercentage is 0 and isSameDimensions is false', () => {
-        const results = baseCompare.createResultReport(true, 0, true, false);
+        const results = baseCompare.createResultReport(true, 0, true, false, false);
         expect(results).toEqual(expect.objectContaining({
           misMatchPercentage: 0,
           isWithinMismatchTolerance: true,
           isSameDimensions: false,
+          screenshotWasUpdated: false,
         }));
       });
 
       it('returns expected results when misMatchPercentage is greater than 0', () => {
-        const results = baseCompare.createResultReport(true, 30, true, false);
+        const results = baseCompare.createResultReport(true, 30, true, false, false);
         expect(results).toEqual(expect.objectContaining({
           misMatchPercentage: 30,
           isWithinMismatchTolerance: true,
           isSameDimensions: false,
+          screenshotWasUpdated: false,
+        }));
+      });
+
+      it('returns expected results when screenshotWasUpdated is true', () => {
+        const results = baseCompare.createResultReport(true, 30, true, false, true);
+        expect(results).toEqual(expect.objectContaining({
+          misMatchPercentage: 30,
+          isWithinMismatchTolerance: true,
+          isSameDimensions: false,
+          screenshotWasUpdated: true,
         }));
       });
     });

--- a/packages/terra-functional-testing/tests/jest/services/wdio-visual-regression-service/methods/LocalCompare.test.js
+++ b/packages/terra-functional-testing/tests/jest/services/wdio-visual-regression-service/methods/LocalCompare.test.js
@@ -33,6 +33,7 @@ const context = {
   },
   options: {
     name: 'displays a button',
+    updateScreenshots: false,
   },
 };
 
@@ -159,6 +160,7 @@ describe('LocalCompare', () => {
         misMatchPercentage: 0,
         isWithinMismatchTolerance: true,
         isSameDimensions: true,
+        screenshotWasUpdated: false,
       });
 
       const screenshotPathsSecond = getScreenshotPathsSpy.mock.results[1].value;
@@ -313,6 +315,75 @@ describe('LocalCompare', () => {
       const diffExistsSecond = fs.existsSync(screenshotPaths.diffPath);
       expect(diffExistsSecond).toBeFalsy();
     }, TIMEOUT * 3);
+
+    it('auto update the reference image when there is a mismatch', async () => {
+      const base64Screenshot = fs.readFileSync(path.join(dirFixture, 'image', '100x100-diff.png'), { encoding: 'base64' });
+      const base64ScreenshotNew = fs.readFileSync(path.join(dirFixture, 'image', '100x100.png'), { encoding: 'base64' });
+
+      const getScreenshotPathsSpy = jest.spyOn(localCompare, 'getScreenshotPaths');
+
+      // 1st run -> create reference
+      const resultFirst = await localCompare.processScreenshot(context, base64Screenshot);
+
+      // check screenshot getter
+      expect(getScreenshotPathsSpy).toHaveBeenCalledTimes(1);
+      expect(getScreenshotPathsSpy).toHaveBeenCalledWith(context);
+
+      // check image results
+      expect(resultFirst).toMatchObject({
+        isNewScreenshot: true,
+      });
+
+      const screenshotPathsFirst = getScreenshotPathsSpy.mock.results[0].value;
+
+      // check if reference image was created
+      const referenceExists = fs.existsSync(screenshotPathsFirst.referencePath);
+      expect(referenceExists).toBeTruthy();
+
+      // check if latest image was created
+      const latestExists = fs.existsSync(screenshotPathsFirst.latestPath);
+      expect(latestExists).toBeTruthy();
+
+      // check last modified
+      const referenceStatsFirst = fs.statSync(screenshotPathsFirst.referencePath);
+      expect(referenceStatsFirst.mtimeMs).toBeGreaterThan(0);
+
+      const latestStatsFirst = fs.statSync(screenshotPathsFirst.latestPath);
+      expect(latestStatsFirst.mtimeMs).toBeGreaterThan(0);
+
+      // create a second context with updateScreenshots set to true
+      const contextSecond = {
+        ...context,
+        options: {
+          name: 'displays a button',
+          updateScreenshots: true,
+        },
+      };
+
+      // 2nd run --> go against reference image
+      await pauseTest(); // pause to ensure time elapses between screenshot creation
+      const resultSecond = await localCompare.processScreenshot(contextSecond, base64ScreenshotNew);
+
+      // check reference getter
+      expect(getScreenshotPathsSpy).toHaveBeenCalledTimes(2);
+      expect(getScreenshotPathsSpy).toHaveBeenNthCalledWith(2, contextSecond);
+
+      // check if image is reported as different
+      expect(resultSecond.misMatchPercentage).toBeGreaterThan(0.01);
+      expect(resultSecond.isWithinMismatchTolerance).toBeFalsy();
+      expect(resultSecond.isSameDimensions).toBeTruthy();
+      expect(resultSecond.screenshotWasUpdated).toBeTruthy();
+
+      const screenshotPathsSecond = getScreenshotPathsSpy.mock.results[1].value;
+
+      // check that reference was updated
+      const referenceStatsSecond = fs.statSync(screenshotPathsSecond.referencePath);
+      expect(referenceStatsSecond.mtimeMs).toBeGreaterThan(referenceStatsFirst.mtimeMs);
+
+      // check that latest was updated
+      const latestStatsSecond = fs.statSync(screenshotPathsSecond.latestPath);
+      expect(latestStatsSecond.mtimeMs).toBeGreaterThan(latestStatsFirst.mtimeMs);
+    }, TIMEOUT);
   });
 
   describe('LocalCompare.processScreenshot-mismatchTolerance', () => {

--- a/packages/terra-functional-testing/tests/jest/terra-cli/wdio/__snapshots__/index.test.js.snap
+++ b/packages/terra-functional-testing/tests/jest/terra-cli/wdio/__snapshots__/index.test.js.snap
@@ -29,7 +29,7 @@ Options:
       --suite                           Overrides specs and runs only the
                                         defined suites.                  [array]
       --spec                            A list of spec file paths.       [array]
-      --updateScreenshots               Whether or not to automatically update
+  -u, --updateScreenshots               Whether or not to automatically update
                                         all reference screenshots with the
                                         latest screenshots.
                                                       [boolean] [default: false]"

--- a/packages/terra-functional-testing/tests/jest/terra-cli/wdio/__snapshots__/index.test.js.snap
+++ b/packages/terra-functional-testing/tests/jest/terra-cli/wdio/__snapshots__/index.test.js.snap
@@ -28,7 +28,11 @@ Options:
       --baseUrl                         The base url.                   [string]
       --suite                           Overrides specs and runs only the
                                         defined suites.                  [array]
-      --spec                            A list of spec file paths.       [array]"
+      --spec                            A list of spec file paths.       [array]
+      --updateScreenshots               Whether or not to automatically update
+                                        all reference screenshots with the
+                                        latest screenshots.
+                                                      [boolean] [default: false]"
 `;
 
 exports[`index declares the wdio terra-cli command with proper top level help 1`] = `

--- a/packages/terra-functional-testing/tests/jest/terra-cli/wdio/test-runner.test.js
+++ b/packages/terra-functional-testing/tests/jest/terra-cli/wdio/test-runner.test.js
@@ -75,10 +75,18 @@ describe('Test Runner', () => {
       await TestRunner.start({ config: '/path', locales: ['en', 'fr'], themes: ['terra-default-theme', 'terra-mock-theme'] });
 
       expect(TestRunner.run).toHaveBeenCalledTimes(4);
-      expect(TestRunner.run).toHaveBeenCalledWith({ config: '/path', theme: 'terra-default-theme', locale: 'en' });
-      expect(TestRunner.run).toHaveBeenCalledWith({ config: '/path', theme: 'terra-default-theme', locale: 'fr' });
-      expect(TestRunner.run).toHaveBeenCalledWith({ config: '/path', theme: 'terra-mock-theme', locale: 'en' });
-      expect(TestRunner.run).toHaveBeenCalledWith({ config: '/path', theme: 'terra-mock-theme', locale: 'fr' });
+      expect(TestRunner.run).toHaveBeenCalledWith({
+        config: '/path', theme: 'terra-default-theme', locale: 'en', launcherOptions: {},
+      });
+      expect(TestRunner.run).toHaveBeenCalledWith({
+        config: '/path', theme: 'terra-default-theme', locale: 'fr', launcherOptions: {},
+      });
+      expect(TestRunner.run).toHaveBeenCalledWith({
+        config: '/path', theme: 'terra-mock-theme', locale: 'en', launcherOptions: {},
+      });
+      expect(TestRunner.run).toHaveBeenCalledWith({
+        config: '/path', theme: 'terra-mock-theme', locale: 'fr', launcherOptions: {},
+      });
     });
 
     it('should initiate a test runner for each theme, locale, and form factor permutation', async () => {
@@ -93,28 +101,28 @@ describe('Test Runner', () => {
 
       expect(TestRunner.run).toHaveBeenCalledTimes(8);
       expect(TestRunner.run).toHaveBeenCalledWith({
-        config: '/path', theme: 'terra-default-theme', locale: 'en', formFactor: 'tiny',
+        config: '/path', theme: 'terra-default-theme', locale: 'en', formFactor: 'tiny', launcherOptions: {},
       });
       expect(TestRunner.run).toHaveBeenCalledWith({
-        config: '/path', theme: 'terra-default-theme', locale: 'en', formFactor: 'large',
+        config: '/path', theme: 'terra-default-theme', locale: 'en', formFactor: 'large', launcherOptions: {},
       });
       expect(TestRunner.run).toHaveBeenCalledWith({
-        config: '/path', theme: 'terra-default-theme', locale: 'fr', formFactor: 'tiny',
+        config: '/path', theme: 'terra-default-theme', locale: 'fr', formFactor: 'tiny', launcherOptions: {},
       });
       expect(TestRunner.run).toHaveBeenCalledWith({
-        config: '/path', theme: 'terra-default-theme', locale: 'fr', formFactor: 'large',
+        config: '/path', theme: 'terra-default-theme', locale: 'fr', formFactor: 'large', launcherOptions: {},
       });
       expect(TestRunner.run).toHaveBeenCalledWith({
-        config: '/path', theme: 'terra-mock-theme', locale: 'en', formFactor: 'tiny',
+        config: '/path', theme: 'terra-mock-theme', locale: 'en', formFactor: 'tiny', launcherOptions: {},
       });
       expect(TestRunner.run).toHaveBeenCalledWith({
-        config: '/path', theme: 'terra-mock-theme', locale: 'en', formFactor: 'large',
+        config: '/path', theme: 'terra-mock-theme', locale: 'en', formFactor: 'large', launcherOptions: {},
       });
       expect(TestRunner.run).toHaveBeenCalledWith({
-        config: '/path', theme: 'terra-mock-theme', locale: 'fr', formFactor: 'tiny',
+        config: '/path', theme: 'terra-mock-theme', locale: 'fr', formFactor: 'tiny', launcherOptions: {},
       });
       expect(TestRunner.run).toHaveBeenCalledWith({
-        config: '/path', theme: 'terra-mock-theme', locale: 'fr', formFactor: 'large',
+        config: '/path', theme: 'terra-mock-theme', locale: 'fr', formFactor: 'large', launcherOptions: {},
       });
     });
 
@@ -143,8 +151,10 @@ describe('Test Runner', () => {
         baseUrl: '/',
         suite: 'test-suite',
         spec: '/spec/',
-        keepAliveSeleniumDockerService: true,
-        updateScreenshots: true,
+        launcherOptions: {
+          keepAliveSeleniumDockerService: true,
+          updateScreenshots: true,
+        },
       });
     });
   });

--- a/packages/terra-functional-testing/tests/jest/terra-cli/wdio/test-runner.test.js
+++ b/packages/terra-functional-testing/tests/jest/terra-cli/wdio/test-runner.test.js
@@ -131,6 +131,7 @@ describe('Test Runner', () => {
         suite: 'test-suite',
         spec: '/spec/',
         keepAliveSeleniumDockerService: true,
+        updateScreenshots: true,
       });
 
       expect(TestRunner.run).toHaveBeenCalledWith({
@@ -143,6 +144,7 @@ describe('Test Runner', () => {
         suite: 'test-suite',
         spec: '/spec/',
         keepAliveSeleniumDockerService: true,
+        updateScreenshots: true,
       });
     });
   });


### PR DESCRIPTION
### Summary
Add the `updateScreenshots` CLI option to automatically update/replace the reference screenshot with latest screenshot if there is a mismatch.

Closes #530 

### Additional Details
- Example command: `npm run terra wdio --updateScreenshots`
- When this option is provided and the reference screenshot matches the latest screenshot, no replacement takes place and the test will pass as usual.
- When this option is provided and the reference screenshot does not matches the latest screenshot, the reference screenshot will be replaced with the latest screenshot and the test step _will_ pass.
- Many of the files are just for updated the case for primitive types on documentations.

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
