### PR TITLE
[terra-functional-testing] Fix locale and theme

### DIFF
--- a/packages/terra-functional-testing/src/webpack-server/webpack-server.js
+++ b/packages/terra-functional-testing/src/webpack-server/webpack-server.js
@@ -23,9 +23,11 @@ class WebpackServer {
 
     // eslint-disable-next-line global-require, import/no-dynamic-require
     const config = require(webpackConfig);
+    const defaultLocale = process.env.LOCALE || locale;
+    const defaultTheme = process.env.THEME || theme;
 
     if (typeof config === 'function') {
-      return config({ ...locale && { defaultLocale: locale }, theme }, { p: true });
+      return config({ ...defaultLocale && { defaultLocale }, theme: defaultTheme }, { p: true });
     }
 
     return config;

--- a/packages/terra-functional-testing/tests/jest/webpack-server/webpack-server.test.js
+++ b/packages/terra-functional-testing/tests/jest/webpack-server/webpack-server.test.js
@@ -38,6 +38,14 @@ describe('Webpack Server', () => {
   });
 
   describe('config', () => {
+    const OLD_ENV = process.env;
+    beforeEach(() => {
+      jest.resetModules();
+      process.env = { ...OLD_ENV };
+    });
+    afterEach(() => {
+      process.env = OLD_ENV;
+    });
     it('should return the webpack configuration', () => {
       jest.mock('./mock-webpack.config.js', () => 'mock-webpack');
 
@@ -70,6 +78,21 @@ describe('Webpack Server', () => {
       const config = WebpackServer.config(options);
 
       expect(config).toEqual({ defaultLocale: 'en', p: true, theme: 'lowlight' });
+    });
+
+    it('should run with env over options', () => {
+      jest.mock('./mock-webpack.config.js', () => (env, args) => ({ ...env, ...args }));
+      process.env.LOCALE = 'fr';
+      process.env.THEME = 'terra-default-theme';
+      const options = {
+        webpackConfig: path.resolve(__dirname, './mock-webpack.config.js'),
+        locale: 'en',
+        theme: 'lowlight',
+      };
+
+      const config = WebpackServer.config(options);
+
+      expect(config).toEqual({ defaultLocale: 'fr', p: true, theme: 'terra-default-theme' });
     });
   });
 


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->
While running tests with the cli, if passed an array of locales the tests were only being run against the first locale provided. This is because the `AssetServerService` defined in the `wdio.conf.js` is instantiated with it's options once at the start of the test run. Subsequent changes to the options do not get passed down. So the locale passed to the WebpackServer was only ever the first locale (this would be the same with themes). Updated to check for env first before the config

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
