### PR TITLE
[terra-functional-testing] Default image tag in docker compose

### DIFF
--- a/packages/terra-functional-testing/src/docker/docker-compose.yml
+++ b/packages/terra-functional-testing/src/docker/docker-compose.yml
@@ -2,12 +2,12 @@ version: '3.7'
 
 services:
   hub:
-   image: selenium/hub:${TERRA_SELENIUM_DOCKER_VERSION}
+   image: selenium/hub:${TERRA_SELENIUM_DOCKER_VERSION:-3.14.0-helium}
    ports:
      - "4444:4444"
 
   chrome:
-    image: selenium/node-chrome:${TERRA_SELENIUM_DOCKER_VERSION}
+    image: selenium/node-chrome:${TERRA_SELENIUM_DOCKER_VERSION:-3.14.0-helium}
     # Volume mounting is necessary to ensure the browser does not crash inside the docker container.
     # For more details see: 
     #  https://github.com/SeleniumHQ/docker-selenium#running-the-images
@@ -23,7 +23,7 @@ services:
     entrypoint: bash -c 'SE_OPTS="-host $$HOSTNAME" /opt/bin/entry_point.sh'
 
   firefox:
-    image: selenium/node-firefox:${TERRA_SELENIUM_DOCKER_VERSION}
+    image: selenium/node-firefox:${TERRA_SELENIUM_DOCKER_VERSION:-3.141.59-titanium}
     # Volume mounting is necessary to ensure the browser does not crash inside the docker container.
     # For more details see: 
     #  https://github.com/SeleniumHQ/docker-selenium#running-the-images

--- a/packages/terra-functional-testing/src/services/wdio-selenium-docker-service.js
+++ b/packages/terra-functional-testing/src/services/wdio-selenium-docker-service.js
@@ -65,7 +65,7 @@ class SeleniumDockerService {
     const { stdout: stackInfo } = await exec('docker stack ls | grep wdio || true');
 
     if (!stackInfo) {
-      logger.info(`Deploying docker stack.`);
+      logger.info('Deploying docker stack.');
 
       const composeFilePath = path.resolve(__dirname, '../docker/docker-compose.yml');
       const envVars = this.version ? `TERRA_SELENIUM_DOCKER_VERSION=${this.version} ` : '';

--- a/packages/terra-functional-testing/src/services/wdio-selenium-docker-service.js
+++ b/packages/terra-functional-testing/src/services/wdio-selenium-docker-service.js
@@ -13,7 +13,7 @@ class SeleniumDockerService {
   constructor(options = {}) {
     const { version } = options;
 
-    this.version = version || '3.14.0-helium';
+    this.version = version;
   }
 
   /**
@@ -65,11 +65,12 @@ class SeleniumDockerService {
     const { stdout: stackInfo } = await exec('docker stack ls | grep wdio || true');
 
     if (!stackInfo) {
-      logger.info(`Deploying docker stack using selenium ${this.version}.`);
+      logger.info(`Deploying docker stack.`);
 
       const composeFilePath = path.resolve(__dirname, '../docker/docker-compose.yml');
+      const envVars = this.version ? `TERRA_SELENIUM_DOCKER_VERSION=${this.version} ` : '';
 
-      await exec(`TERRA_SELENIUM_DOCKER_VERSION=${this.version} docker stack deploy -c ${composeFilePath} wdio`);
+      await exec(`${envVars}docker stack deploy -c ${composeFilePath} wdio`);
 
       await this.waitForServiceCreation();
       await this.waitForNetworkCreation();

--- a/packages/terra-functional-testing/tests/jest/services/wdio-selenium-docker-service.test.js
+++ b/packages/terra-functional-testing/tests/jest/services/wdio-selenium-docker-service.test.js
@@ -149,7 +149,7 @@ describe('WDIO Selenium Docker Service', () => {
 
       const composeFilePath = path.resolve(__dirname, '../../../src/docker/docker-compose.yml');
 
-      expect(mockExec).toHaveBeenCalledWith(`TERRA_SELENIUM_DOCKER_VERSION=3.14.0-helium docker stack deploy -c ${composeFilePath} wdio`);
+      expect(mockExec).toHaveBeenCalledWith(`docker stack deploy -c ${composeFilePath} wdio`);
     });
 
     it('should deploy the stack with the specified selenium version', async () => {


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

This PR does two things:

- Defaults the docker tag in the docker compose file instead of inside of the docker service
- Changes the default firefox version to align with the [existing version used in terra-toolkit-boneyard](https://github.com/cerner/terra-toolkit-boneyard/blob/main/config/docker/local-docker-compose.yml#L30)

The chrome and firefox versions are not on the same tag. This change is necessary to ensure the firefox version gets defaulted correctly in the docker compose file.

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
