### PR TITLE
[terra-functional-testing] Update documentation and remove test* regex

### DIFF
--- a/packages/terra-functional-testing/src/config/wdio.conf.js
+++ b/packages/terra-functional-testing/src/config/wdio.conf.js
@@ -46,8 +46,8 @@ exports.config = {
   // directory is where your package.json resides, so `wdio` will be called from there.
   //
   specs: [
-    './test*/wdio/**/*-spec.js',
-    './packages/*/test*/wdio/**/*-spec.js',
+    './tests/wdio/**/*-spec.js',
+    './packages/*/tests/wdio/**/*-spec.js',
   ],
   //
   // ============

--- a/packages/terra-functional-testing/src/terra-dev-site/terra-functional-testing/wdio-testing/About.tool.mdx
+++ b/packages/terra-functional-testing/src/terra-dev-site/terra-functional-testing/wdio-testing/About.tool.mdx
@@ -27,11 +27,11 @@ A test runner is provided for local development and should be invoked using the 
 | --gridUrl                        | string  |                         | The remote selenium grid address.                                                             |
 | --hostname                       | string  | localhost               | Automation driver host address.                                                               |
 | --keepAliveSeleniumDockerService | boolean | false                   | Determines to keep the selenium docker service running upon test completion.                  |
-| --locales                        | array   | ['en']                  | A list of language locales for the test run.                                                  |
+| --locales                        | array   | en                      | A list of language locales for the test run.                                                  |
 | --port                           | number  | 4444                    | Automation driver port.                                                                       |
 | --spec                           | array   |                         | A list of spec file paths.                                                                    |
 | --suite                          | array   |                         | Overrides specs and runs only the defined suites.                                             |
-| --themes                         | array   | ['terra-default-theme'] | A list of themes for the test run.                                                            |
+| --themes                         | array   | terra-default-theme     | A list of themes for the test run.                                                            |
 | --updateScreenshots, -u          | boolean | false                   | Updates all reference screenshots with the latest screenshots.                                |
 
 The following example will run the test suite a total of four times. Once for each permutation of the specified locales and form factors.
@@ -57,24 +57,6 @@ Tests can be executed in any of the following supported form factors:
 | large    | 1000  | 768    |
 | huge     | 1300  | 768    |
 | enormous | 1500  | 768    |
-
-## Environment Variables
-
-The following environment variables are configurable for the test run. Variables marked as reserved will be overwritten by the test runner. To configure reserved variables use the test runner configuration options. If the test runner is not being used the variables are configurable by the user.
-
-| Variable Name                 | Type    | Reserved | Default             | Description                                                                                                                               |
-|-------------------------------|---------|----------|---------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
-| BROWSERS                      | string  | true     | chrome              | A list of browsers for the test run. Browsers are delimited by a comma. Example: chrome,firefox,ie                                        |
-| FORM_FACTOR                   | string  | true     | huge                | A form factor assigned to the test run.                                                                                                   |
-| LOCALE                        | string  | true     | en                  | A locale assigned to the test run.                                                                                                        |
-| SELENIUM_GRID_URL             | string  | true     |                     | The remote selenium grid address.                                                                                                         |
-| SITE                          | string  |          |                     | A file path to a static directory of assets. When defined, an express server will launch to serve the assets and disable running webpack. |
-| THEME                         | string  | true     | terra-default-theme | A theme name assigned to the test run.                                                                                                    |
-| WDIO_DISABLE_SELENIUM_SERVICE | boolean |          | false               | A flag to disable the selenium docker service.                                                                                            |
-| WDIO_EXTERNAL_HOST            | string  |          | localhost           | The host address the testing environment is connected to.                                                                                 |
-| WDIO_EXTERNAL_PORT            | number  |          | 8080                | The port mapping from the host to the container.                                                                                          |
-| WDIO_INTERNAL_PORT            | number  |          | 8080                | The port to run the webpack and express asset services on.                                                                                |
-| WDIO_HOSTNAME                 | string  |          | localhost           | The hostname of the driver server.                                                                                                        |
 
 ### Terra.describeViewports
 


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

This PR makes the following changes:

- Removes the environment variable documentation. Long term we want all consumers to use the test runner and plan to spike on removing environment variables all together, if possible.
- Removes the dynamic test/tests regex. All wdio tests are expected to be placed inside of /tests/.
- Updates the test runner defaults to not use array syntax. The options are not passed this way on the cli and might cause confusion.

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
