### PR TITLE
[terra-functional-testing] Increase connectionRetryTimeout and mocha timeouts

### DIFF
--- a/packages/terra-functional-testing/src/config/wdio.conf.js
+++ b/packages/terra-functional-testing/src/config/wdio.conf.js
@@ -116,7 +116,7 @@ exports.config = {
   //
   // Default timeout in milliseconds for request
   // if browser driver or grid doesn't send response
-  connectionRetryTimeout: 120000,
+  connectionRetryTimeout: 1200000,
   //
   // Default request retries count
   connectionRetryCount: 3,
@@ -168,7 +168,7 @@ exports.config = {
   // See the full list at http://mochajs.org/
   mochaOpts: {
     ui: 'bdd',
-    timeout: 60000,
+    timeout: 1200000,
   },
   /**
    * Gets executed once before all workers get launched.


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

This PR increases the `connectionRetryTimeout` and mocha opts `timeout` to sync with the previous timeouts of terra-toolkit-boneyard.

- [connectionRetryTimeout](https://github.com/cerner/terra-toolkit-boneyard/blob/main/config/wdio/wdio.conf.js#L88)
- [mocha timeout](https://github.com/cerner/terra-toolkit-boneyard/blob/main/config/wdio/wdio.conf.js#L124)

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
