### PR TITLE
[terra-functional-testing] Pass theme as `defaultTheme` to webpack-config-terra

### DIFF
--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Correctly pass theme as `defaultTheme` to webpack-config-terra to run tests in the correct theme.
+
 ## 1.0.0 - (February 25, 2021)
 
 * Initial stable release

--- a/packages/terra-functional-testing/src/webpack-server/webpack-server.js
+++ b/packages/terra-functional-testing/src/webpack-server/webpack-server.js
@@ -25,7 +25,7 @@ class WebpackServer {
     const config = require(webpackConfig);
 
     if (typeof config === 'function') {
-      return config({ ...locale && { defaultLocale: locale }, theme }, { p: true });
+      return config({ ...locale && { defaultLocale: locale }, defaultTheme: theme }, { p: true });
     }
 
     return config;

--- a/packages/terra-functional-testing/tests/jest/webpack-server/webpack-server.test.js
+++ b/packages/terra-functional-testing/tests/jest/webpack-server/webpack-server.test.js
@@ -69,7 +69,7 @@ describe('Webpack Server', () => {
 
       const config = WebpackServer.config(options);
 
-      expect(config).toEqual({ defaultLocale: 'en', p: true, theme: 'lowlight' });
+      expect(config).toEqual({ defaultLocale: 'en', p: true, defaultTheme: 'lowlight' });
     });
   });
 

--- a/packages/terra-toolkit-docs/CHANGELOG.md
+++ b/packages/terra-toolkit-docs/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Changed
   * Add @cerner/terra-functional-testing to dependencies
+  * Update doc from `getCssProperty` to `getCSSProperty`
+  
 
 ## 1.8.0 - (February 25, 2021)
 

--- a/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/About.1.tool.mdx
+++ b/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/About.1.tool.mdx
@@ -196,7 +196,7 @@ it('should hide the caret', () => {
   Terra.hideInputCaret('#inputID');
   const element = browser.element('#inputID');
 
-  expect(element.getCSSProperty('caretColor').value).to.equal('rgba(0,0,0,0)');
+  expect(element.getCSSProperty('caretColor').value).toEqual('rgba(0,0,0,0)');
 });
 ```
 

--- a/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/About.1.tool.mdx
+++ b/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/About.1.tool.mdx
@@ -196,7 +196,7 @@ it('should hide the caret', () => {
   Terra.hideInputCaret('#inputID');
   const element = browser.element('#inputID');
 
-  expect(element.getCssProperty('caretColor').value).to.equal('rgba(0,0,0,0)');
+  expect(element.getCSSProperty('caretColor').value).to.equal('rgba(0,0,0,0)');
 });
 ```
 


### PR DESCRIPTION
### Summary
- webpack-config-terra reads the theme either from `process.env.THEME` or preferably [env.defaultTheme](https://github.com/cerner/terra-toolkit/blob/main/packages/webpack-config-terra/src/webpack.config.js#L50). terra-functional-testing recently removed setting all options in process.env. As a result, testing in other themes are failure and it uncovers that webpack-server should pass down theme as `defaultTheme` instead of `theme` which is not what webpack-config-terra expects. 

-  Updated doc from `getCssProperty` to `getCSSProperty`. It used to be in lowercase but is now upper case: https://v6.webdriver.io/docs/api/element/getCSSProperty.html


### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
