### PR TITLE
[terra-functional-testing] Fix selenium docker version service option

### DIFF
--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Fix docker version service option to be read from serviceOptions instead of launcherOptions
+
 ## 1.0.1 - (March 1, 2021)
 
 * Fixed

--- a/packages/terra-functional-testing/src/services/wdio-selenium-docker-service.js
+++ b/packages/terra-functional-testing/src/services/wdio-selenium-docker-service.js
@@ -17,8 +17,9 @@ class SeleniumDockerService {
    * @param {Object} config - The object containing the wdio configuration and options defined in the terra-cli test runner.
    */
   constructor(_options, _capabilities, config = {}) {
-    const { launcherOptions } = config;
-    const { disableSeleniumService, keepAliveSeleniumDockerService, version } = launcherOptions || {};
+    const { launcherOptions, serviceOptions } = config;
+    const { disableSeleniumService, keepAliveSeleniumDockerService } = launcherOptions || {};
+    const { version } = serviceOptions || {};
 
     this.disableSeleniumService = disableSeleniumService === true;
     this.keepAliveSeleniumDockerService = keepAliveSeleniumDockerService === true;
@@ -92,14 +93,14 @@ class SeleniumDockerService {
 
     await exec(`${envVars}docker-compose -f ${this.getDockerComposeFilePath()} up -d`);
     await this.waitForSeleniumHubReady();
+
+    logger.info('Successfully started the docker selenium hub.');
   }
 
   /**
    * Waits for the docker selenium hub to become healthy.
    */
   async waitForSeleniumHubReady() {
-    logger.info('Waiting for the docker selenium hub to become ready...');
-
     await this.pollCommand("docker inspect --format='{{json .State.Health.Status}}' selenium-hub", (result) => (
       new Promise((resolve, reject) => {
         const { stdout } = result;

--- a/packages/terra-functional-testing/tests/jest/services/wdio-selenium-docker-service.test.js
+++ b/packages/terra-functional-testing/tests/jest/services/wdio-selenium-docker-service.test.js
@@ -12,6 +12,8 @@ const config = {
   launcherOptions: {
     disableSeleniumService: true,
     keepAliveSeleniumDockerService: true,
+  },
+  serviceOptions: {
     version: '1234',
   },
 };
@@ -32,6 +34,7 @@ describe('WDIO Selenium Docker Service', () => {
 
       expect(service.disableSeleniumService).toBe(true);
       expect(service.keepAliveSeleniumDockerService).toBe(true);
+      expect(service.version).toEqual('1234');
     });
   });
 


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

This PR fixes the API for specifying the docker version option. `version` should be deconstructed from `serviceOptions` instead of `launcherOptions`.

Fixes #596.

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

Since this wasn't working as expected on the 1.0.0 release we could rename this option if we wanted to. 

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
