### PR TITLE
[terra-functional-testing] Rename version service option to seleniumVersion

### DIFF
--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Fixed
-  * Fix docker version service option to be read from serviceOptions instead of launcherOptions
+  * Fix seleniumVersion service option to be read from serviceOptions instead of launcherOptions
 
 ## 1.0.1 - (March 1, 2021)
 

--- a/packages/terra-functional-testing/src/services/wdio-selenium-docker-service.js
+++ b/packages/terra-functional-testing/src/services/wdio-selenium-docker-service.js
@@ -19,11 +19,11 @@ class SeleniumDockerService {
   constructor(_options, _capabilities, config = {}) {
     const { launcherOptions, serviceOptions } = config;
     const { disableSeleniumService, keepAliveSeleniumDockerService } = launcherOptions || {};
-    const { version } = serviceOptions || {};
+    const { seleniumVersion } = serviceOptions || {};
 
     this.disableSeleniumService = disableSeleniumService === true;
     this.keepAliveSeleniumDockerService = keepAliveSeleniumDockerService === true;
-    this.version = version;
+    this.seleniumVersion = seleniumVersion;
   }
 
   /**
@@ -89,7 +89,7 @@ class SeleniumDockerService {
   async startSeleniumHub() {
     logger.info('Starting the docker selenium hub...');
 
-    const envVars = this.version ? `TERRA_SELENIUM_DOCKER_VERSION=${this.version} ` : '';
+    const envVars = this.seleniumVersion ? `TERRA_SELENIUM_DOCKER_VERSION=${this.seleniumVersion} ` : '';
 
     await exec(`${envVars}docker-compose -f ${this.getDockerComposeFilePath()} up -d`);
     await this.waitForSeleniumHubReady();

--- a/packages/terra-functional-testing/tests/jest/services/wdio-selenium-docker-service.test.js
+++ b/packages/terra-functional-testing/tests/jest/services/wdio-selenium-docker-service.test.js
@@ -14,7 +14,7 @@ const config = {
     keepAliveSeleniumDockerService: true,
   },
   serviceOptions: {
-    version: '1234',
+    seleniumVersion: '1234',
   },
 };
 
@@ -34,7 +34,7 @@ describe('WDIO Selenium Docker Service', () => {
 
       expect(service.disableSeleniumService).toBe(true);
       expect(service.keepAliveSeleniumDockerService).toBe(true);
-      expect(service.version).toEqual('1234');
+      expect(service.seleniumVersion).toEqual('1234');
     });
   });
 

--- a/packages/terra-toolkit-docs/CHANGELOG.md
+++ b/packages/terra-toolkit-docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Update terra-functional-testing docker service documentation to rename version to seleniumVersion
+
 * Fixed
   * Add missing link to webpack-config-terra docs.
 

--- a/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/wdio-services.4/SeleniumDockerService.tool.mdx
+++ b/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/wdio-services.4/SeleniumDockerService.tool.mdx
@@ -23,10 +23,7 @@ const SeleniumDockerService = require('@cerner/terra-functional-testing/lib/serv
 export.config = {
     // ...
     services: [
-        [SeleniumDockerService, {
-            // Selenium service options here
-            // ...
-        }]
+        [SeleniumDockerService]
     ],
     // ...
 };
@@ -34,7 +31,7 @@ export.config = {
 
 ## Options
 
-### version
+### seleniumVersion
 
 The docker selenium image version to run tests against.
 
@@ -52,11 +49,10 @@ const SeleniumDockerService = require('@cerner/terra-functional-testing/lib/serv
 
 export.config = {
     // ...
-    services: [
-        [SeleniumDockerService, {
-          version: '3.14.0-helium'
-        }]
-    ],
+    services: [[SeleniumDockerService]],
+    serviceOptions: {
+        seleniumVersion: '3.14.0-helium',
+    }
     // ...
 };
 ```


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

This PR renames the docker service `version` option to `seleniumVersion`. This change is passive because it was not exposed correctly on the 1.0.0 release so no consumers could have been using it.

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

Example usage:

```js
// wdio.conf.js

const { config } = require('@cerner/terra-functional-testing/lib/config/wdio.conf');

config.serviceOptions = {
  seleniumVersion: '3.141.59-20210128',
};

exports.config = config;
```

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
