### PR TITLE
[terra-functional-testing] Invalid selector error message

### DIFF
--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Added
   * Added describeTests helper to filter tests by form factors, locales, or themes
 
+* Changed
+  * Throw error with a more meaningful message when an invalid selector is used to capture screenshot.
+
 ## 1.0.2 - (March 9, 2021)
 
 * Fixed

--- a/packages/terra-functional-testing/src/services/wdio-visual-regression-service/modules/makeElementScreenshot.js
+++ b/packages/terra-functional-testing/src/services/wdio-visual-regression-service/modules/makeElementScreenshot.js
@@ -28,6 +28,11 @@ async function makeElementScreenshot(browser, elementSelector, options = {}) {
 
   // get bounding rect of elements
   const boundingRects = await browser.execute(getBoundingRects, elementSelector);
+
+  if (boundingRects.length === 0) {
+    throw new Error(`[wdio-visual-regression-service:makeDocumentScreenshot] Failed to capture the element using the "${elementSelector}" selector. Either update the test document to include this selector or use a different selector that exists on the document.`);
+  }
+
   const boundingRect = groupBoundingRect(boundingRects);
 
   // make screenshot of area

--- a/packages/terra-functional-testing/tests/wdio/terra-validates-spec.js
+++ b/packages/terra-functional-testing/tests/wdio/terra-validates-spec.js
@@ -38,27 +38,15 @@ Terra.describeViewports('Terra.validates', ['small', 'large'], () => {
     });
 
     it('should require a screenshot name', () => {
-      let caughtError;
+      const errorMessage = '[terra-functional-testing:screenshot] Terra.validate.screenshot requires a unique test name as the first argument.';
 
-      try {
-        Terra.validates.screenshot();
-      } catch (error) {
-        caughtError = error;
-      }
-
-      expect(caughtError.message).toEqual('[terra-functional-testing:screenshot] Terra.validate.screenshot requires a unique test name as the first argument.');
+      expect(() => Terra.validates.screenshot()).toThrow(errorMessage);
     });
 
     it('should fail with invalid selector', () => {
-      let caughtError;
+      const errorMessage = '[wdio-visual-regression-service:makeDocumentScreenshot] Failed to capture the element using the "invalid-selector" selector. Either update the test document to include this selector or use a different selector that exists on the document.';
 
-      try {
-        Terra.validates.screenshot('invalid selector', { selector: 'invalid-selector' });
-      } catch (error) {
-        caughtError = error;
-      }
-
-      expect(caughtError.message).toEqual('[wdio-visual-regression-service:makeDocumentScreenshot] Failed to capture the element using the "invalid-selector" selector. Either update the test document to include this selector or use a different selector that exists on the document.');
+      expect(() => Terra.validates.screenshot('invalid selector', { selector: 'invalid-selector' })).toThrow(errorMessage);
     });
   });
 
@@ -80,27 +68,15 @@ Terra.describeViewports('Terra.validates', ['small', 'large'], () => {
     });
 
     it('should require a screenshot name', () => {
-      let caughtError;
+      const errorMessage = '[terra-functional-testing:element] Terra.validate.element requires a unique test name as the first argument.';
 
-      try {
-        Terra.validates.element();
-      } catch (error) {
-        caughtError = error;
-      }
-
-      expect(caughtError.message).toEqual('[terra-functional-testing:element] Terra.validate.element requires a unique test name as the first argument.');
+      expect(() => Terra.validates.element()).toThrow(errorMessage);
     });
 
     it('should fail with invalid selector', () => {
-      let caughtError;
+      const errorMessage = '[wdio-visual-regression-service:makeDocumentScreenshot] Failed to capture the element using the "invalid-selector" selector. Either update the test document to include this selector or use a different selector that exists on the document.';
 
-      try {
-        Terra.validates.element('invalid selector', { selector: 'invalid-selector' });
-      } catch (error) {
-        caughtError = error;
-      }
-
-      expect(caughtError.message).toEqual('[wdio-visual-regression-service:makeDocumentScreenshot] Failed to capture the element using the "invalid-selector" selector. Either update the test document to include this selector or use a different selector that exists on the document.');
+      expect(() => Terra.validates.element('invalid selector', { selector: 'invalid-selector' })).toThrow(errorMessage);
     });
   });
 });

--- a/packages/terra-functional-testing/tests/wdio/terra-validates-spec.js
+++ b/packages/terra-functional-testing/tests/wdio/terra-validates-spec.js
@@ -48,6 +48,18 @@ Terra.describeViewports('Terra.validates', ['small', 'large'], () => {
 
       expect(caughtError.message).toEqual('[terra-functional-testing:screenshot] Terra.validate.screenshot requires a unique test name as the first argument.');
     });
+
+    it('should fail with invalid selector', () => {
+      let caughtError;
+
+      try {
+        Terra.validates.screenshot('invalid selector', { selector: 'invalid-selector' });
+      } catch (error) {
+        caughtError = error;
+      }
+
+      expect(caughtError.message).toEqual('[wdio-visual-regression-service:makeDocumentScreenshot] Failed to capture the element using the "invalid-selector" selector. Either update the test document to include this selector or use a different selector that exists on the document.');
+    });
   });
 
   describe('element', () => {
@@ -77,6 +89,18 @@ Terra.describeViewports('Terra.validates', ['small', 'large'], () => {
       }
 
       expect(caughtError.message).toEqual('[terra-functional-testing:element] Terra.validate.element requires a unique test name as the first argument.');
+    });
+
+    it('should fail with invalid selector', () => {
+      let caughtError;
+
+      try {
+        Terra.validates.element('invalid selector', { selector: 'invalid-selector' });
+      } catch (error) {
+        caughtError = error;
+      }
+
+      expect(caughtError.message).toEqual('[wdio-visual-regression-service:makeDocumentScreenshot] Failed to capture the element using the "invalid-selector" selector. Either update the test document to include this selector or use a different selector that exists on the document.');
     });
   });
 });


### PR DESCRIPTION
### Summary
Log an error with a more meaningful message when an incorrect selector is used to capture screenshot.

### Additional Details
- Closes #475 
- The original issue shows this error when an incorrect selector is used. Perhaps this error message was logged when either on Node 8 or an older version of wdio-novus-visual-regression-service.
![Screen Shot 2021-03-17 at 1 27 15 PM](https://user-images.githubusercontent.com/22618655/111519003-a44cc880-8724-11eb-96ca-9ed913082bed.png)

This is the error when on Node 10:
![Screen Shot 2021-03-17 at 1 54 53 AM](https://user-images.githubusercontent.com/22618655/111519408-0d344080-8725-11eb-9191-4523238f6203.png)

This is the error when on Node 12:
![Screen Shot 2021-03-17 at 1 48 09 AM](https://user-images.githubusercontent.com/22618655/111519622-48cf0a80-8725-11eb-90a0-49332274e362.png)

The above error messages from jimp are slightly different because it depends on when the exception occurs based on the node version.

This is the new error message with this change:
![Screen Shot 2021-03-17 at 1 49 40 AM](https://user-images.githubusercontent.com/22618655/111520120-ca269d00-8725-11eb-88fa-4a75bff67aa8.png)


@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
