### PR TITLE
[terra-functional-testing] Remove out-of-bound log message.

### DIFF
--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Removed
+  * Removed log message for out of range elements in screenshot because there are valid cases to have out of range elements.
+
 ## 1.0.3 - (March 23, 2021)
 
 * Added

--- a/packages/terra-functional-testing/src/services/wdio-visual-regression-service/utils/strategies/BaseStrategy.js
+++ b/packages/terra-functional-testing/src/services/wdio-visual-regression-service/utils/strategies/BaseStrategy.js
@@ -1,7 +1,4 @@
-const { Logger } = require('@cerner/terra-cli');
 const CropDimension = require('../CropDimension');
-
-const logger = new Logger({ prefix: '[wdio-visual-regression-service:BaseStrategy]' });
 
 class BaseStrategy {
   constructor(screenDimensions) {
@@ -25,21 +22,6 @@ class BaseStrategy {
     const adjustedStartY = startY > documentHeight || startY < 0 ? 0 : startY;
     const adjustedEndX = endX > documentWidth || endX < 0 ? documentWidth : endX;
     const adjustedEndY = endY > documentHeight || endY < 0 ? documentHeight : endY;
-
-    if (adjustedStartX !== startX || adjustedStartY !== startY || adjustedEndX !== endX || adjustedEndY !== endY) {
-      const dimensions = {
-        startX,
-        startY,
-        endX,
-        endY,
-        adjustedStartX,
-        adjustedStartY,
-        adjustedEndX,
-        adjustedEndY,
-      };
-
-      logger.info(`The element being captured is off the viewable screen and will be clipped using the adjusted dimensions: ${JSON.stringify(dimensions, null, 2)}`);
-    }
 
     this.area = {
       startX: adjustedStartX,

--- a/packages/terra-toolkit-docs/CHANGELOG.md
+++ b/packages/terra-toolkit-docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Added documentation in terra-functional-testing to describe how visual regression determines screenshot dimensions.
+
 ## 1.8.3 - (March 23, 2021)
 
 * Added

--- a/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/About.1.tool.mdx
+++ b/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/About.1.tool.mdx
@@ -167,7 +167,7 @@ it('should override a rule configuration', () => {
 
 ## Validating element
 
-A screenshot can be captured at any given point inside an `it` block in a test. The captured screenshot will be used as a reference artifact. Element validation is done by comparing the reference screenshot against the screenshot captured in future test runs at the same point in the test.
+A screenshot can be captured at any given point inside an `it` block in a test. The element(s) being captured in the screenshot is determined by the provided selector option or the default `[data-terra-test-content]` selector if one is not provided. If part or all of the selector or any of its children are rendered outside the bounds of the current viewport, only what is within the viewport will be captured and what is outside the viewport will be clipped. The captured screenshot will be used as a reference artifact. Element validation is done by comparing the reference screenshot against the screenshot captured in future test runs at the same point in the test.
 
 ### Terra.validates.screenshot
 

--- a/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/wdio-services.4/VisualRegressionService.tool.mdx
+++ b/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/wdio-services.4/VisualRegressionService.tool.mdx
@@ -83,10 +83,10 @@ All of these provide options that will help you to capture screenshots in differ
 available:
 
 * **hide** `Object[]`<br />
-  hides all elements queried by all kinds of different [WebdriverIO selector strategies](http://webdriver.io/guide/usage/selectors.html) (via `visibility: hidden`)
+  hides all elements queried by all kinds of different [WebdriverIO selector strategies](https://v6.webdriver.io/docs/selectors.html) (via `visibility: hidden`)
 
 * **remove** `Object[]`<br />
-  removes all elements queried by all kinds of different [WebdriverIO selector strategies](http://webdriver.io/guide/usage/selectors.html) (via `display: none`)
+  removes all elements queried by all kinds of different [WebdriverIO selector strategies](https://v6.webdriver.io/docs/selectors.html) (via `display: none`)
 
 * **mismatchTolerance** `Number` <br />
     Overrides the global *mismatchTolerance* value for this command. Pass in a number between 0 and 100 that defines the degree of mismatch to consider two images as identical.


### PR DESCRIPTION
### Summary

- Removed log message for out of range elements in screenshot because there are valid cases to have out of range elements.
- Added documentation to describe how visual regression determines screenshot dimensions.

### Additional Details
There are valid scenarios to have elements rendered outside the viewport and we do not want the log message to display for every test with these valid scenarios.

Examples include:
- Any component using the VisuallyHiddenText component that is rendered with a negative margins
- Components using negative values for the `left` style
- Components using negative values in `translate3d` such as `transform: translate3d(-100%, 0, 0)`.

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
