### PR TITLE
[terra-functional-testing] Update documentation and default export

### DIFF
--- a/packages/terra-enzyme-intl/CHANGELOG.md
+++ b/packages/terra-enzyme-intl/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Changed
-  * Updated enzyme-intl jest snapshots again?
+  * Updated enzyme-intl jest snapshots again? And Again?
 
 ## 4.2.0 - (February 25, 2021)
 

--- a/packages/terra-enzyme-intl/tests/jest/__snapshots__/enzyme-intl.test.jsx.snap
+++ b/packages/terra-enzyme-intl/tests/jest/__snapshots__/enzyme-intl.test.jsx.snap
@@ -5,12 +5,12 @@ exports[`mountWithIntl using FormattedMessage should match the snapshot 1`] = `
   foo="bar"
 >
   <div>
-    <Component
+    <FormattedMessage
       id="TerraEnzymeIntl.helloWorld"
     >
       TerraEnzymeIntl.helloWorld
-    </Component>
-    <Component
+    </FormattedMessage>
+    <FormattedMessage
       id="TerraEnzymeIntl.buttonText"
     >
       <button
@@ -18,7 +18,7 @@ exports[`mountWithIntl using FormattedMessage should match the snapshot 1`] = `
       >
         TerraEnzymeIntl.buttonText
       </button>
-    </Component>
+    </FormattedMessage>
     {
   "foo": "bar"
 }
@@ -88,12 +88,12 @@ exports[`mountWithIntl with a wrapping component should match the snapshot 1`] =
   foo="bar"
 >
   <div>
-    <Component
+    <FormattedMessage
       id="TerraEnzymeIntl.helloWorld"
     >
       TerraEnzymeIntl.helloWorld
-    </Component>
-    <Component
+    </FormattedMessage>
+    <FormattedMessage
       id="TerraEnzymeIntl.buttonText"
     >
       <button
@@ -101,7 +101,7 @@ exports[`mountWithIntl with a wrapping component should match the snapshot 1`] =
       >
         TerraEnzymeIntl.buttonText
       </button>
-    </Component>
+    </FormattedMessage>
     {
   "foo": "bar"
 }
@@ -139,14 +139,14 @@ exports[`renderWithIntl using injectIntl should match the snapshot 1`] = `
 
 exports[`renderWithIntl with a wrapping component should match the snapshot 1`] = `
 <div>
-  <FormattedMessage
+  <MemoizedFormattedMessage
     id="TerraEnzymeIntl.helloWorld"
   />
-  <FormattedMessage
+  <MemoizedFormattedMessage
     id="TerraEnzymeIntl.buttonText"
   >
     <Component />
-  </FormattedMessage>
+  </MemoizedFormattedMessage>
   {
   "foo": "bar"
 }
@@ -155,14 +155,14 @@ exports[`renderWithIntl with a wrapping component should match the snapshot 1`] 
 
 exports[`shallowWithIntl using FormattedMessage should match the snapshot 1`] = `
 <div>
-  <FormattedMessage
+  <MemoizedFormattedMessage
     id="TerraEnzymeIntl.helloWorld"
   />
-  <FormattedMessage
+  <MemoizedFormattedMessage
     id="TerraEnzymeIntl.buttonText"
   >
     <Component />
-  </FormattedMessage>
+  </MemoizedFormattedMessage>
   {
   "foo": "bar"
 }

--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Added a main index file to export the wdio.conf.js configuration file
+
 * Removed
   * Removed log message for out of range elements in screenshot because there are valid cases to have out of range elements.
 

--- a/packages/terra-functional-testing/package.json
+++ b/packages/terra-functional-testing/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@cerner/terra-functional-testing",
   "version": "1.0.3",
+  "main": "lib/index.js",
   "description": "A functional testing utility for applications built using Terra.",
   "publishConfig": {
     "access": "public"

--- a/packages/terra-functional-testing/src/index.js
+++ b/packages/terra-functional-testing/src/index.js
@@ -1,0 +1,3 @@
+const { config } = require('./config/wdio.conf');
+
+module.exports = { config };

--- a/packages/terra-toolkit-docs/CHANGELOG.md
+++ b/packages/terra-toolkit-docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Updated terra-functional-testing documentation to add additional information to the about page and individual services
+
 * Added
   * Added documentation in terra-functional-testing to describe how visual regression determines screenshot dimensions.
 

--- a/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/About.1.tool.mdx
+++ b/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/About.1.tool.mdx
@@ -114,7 +114,7 @@ To specify a list of form factors use the cli option:
 
 ## Configuration
 
-The test runner ships with a default [wdio.conf.js](https://github.com/cerner/terra-toolkit/blob/main/packages/terra-functional-testing/src/config/wdio.conf.js). Webdriver and service options can be configured by extending the default configuration file.
+The test runner ships with a default [wdio.conf.js](https://github.com/cerner/terra-toolkit/blob/main/packages/terra-functional-testing/src/config/wdio.conf.js). Options can be configured by extending the default configuration file.
 
 To extend the default configuration create a `wdio.conf.js` file at the root of your project and apply the desired options.
 
@@ -130,7 +130,7 @@ exports.config = config;
 
 ## Service Options
 
-A few service options are configurable by extending the wdio.conf.js file. These options are applied for every test run.
+Service options are configurable by extending the wdio.conf.js file. These options are applied for every test run.
 
 ### selector
 
@@ -186,11 +186,7 @@ Test utilities are available to help write tests. These utilities are accessed u
 
 ## Describe Helpers
 
-The describe helpers are an alias for the top level `describe` block used within spec files. The describe helpers provide useful features for limit a set of tests to specific form factors, locales, and themes.
-
-<Notice variant="caution" ariaLevel="3">
-  The describe helpers should not be nested. Multiple describe helpers can be used sequentially in the same spec file.
-</Notice>
+The describe helpers are an alias for the top level `describe` block used within spec files. The describe helpers provide useful features for limiting a set of tests to specific form factors, locales, and themes.
 
 ### Terra.describeViewports
 
@@ -208,10 +204,24 @@ Terra.describeViewports(title, [viewports], fn);
 
 The following example will scope the tests to run only for the `tiny` and `huge` form factors. The tests will not run for any other form factor.
 
+<Notice variant="caution" ariaLevel="3">
+  Do not nest describe helpers.
+</Notice>
+
 ```js
 Terra.describeViewports('Describe viewports title', ['tiny', 'huge'], () => {
   it('should test tiny and huge screens', () => {
     browser.url('/testing/route/');
+
+    Terra.validates.screenshot('describe viewports');
+  });
+});
+
+// Multiple describe helpers can be used sequentially in the same spec file as long as they are not nested.
+
+Terra.describeViewports('Describe viewports title', ['small'], () => {
+  it('should test small screens', () => {
+    browser.url('/testing/route/small/');
 
     Terra.validates.screenshot('describe viewports');
   });
@@ -287,7 +297,11 @@ Axe will analyze the entire document when run and report accessibility violation
 
 ### Terra.validates.accessibility
 
-The accessibility assertion should only be invoked inside an `it` block. Invoking the assertion will run accessibility checks on the entire document. If accessibility violations are found the test step will fail. It is recommended to run accessibility checks at various steps in a functional workflow to check for violations at different stages of the application.
+The validates accessibility command will run accessibility checks on the entire document. If accessibility violations are found the test step will fail. It is recommended to run accessibility checks at various steps in a functional workflow to check for violations at different stages of the application.
+
+<Notice variant="caution" ariaLevel="3">
+  The accessibility assertion must be used within an `it` block.
+</Notice>
 
 ```js
 it('should report no accessibility violations', () => {
@@ -316,9 +330,11 @@ A screenshot can be captured at any given point inside an `it` block in a test. 
 
 ### Terra.validates.screenshot
 
-The screenshot assertion should only be invoked inside an `it` block. Invoking the assertion will capture a screenshot at the time it is invoked. If no reference screenshot exists, one will be created in the `reference` folder with the given screenshot name. If such reference screenshot already exists, the new screenshot will be compared with the reference screenshot to validate visually that they are within the mismatch tolerance. If the mismatch exceeds the tolerance, the test step will fail and a screenshot showing the difference will be generated.
+Invoking the assertion will capture a screenshot at the time it is invoked. If no reference screenshot exists, one will be created in the `reference` folder with the given screenshot name. If such reference screenshot already exists, the new screenshot will be compared with the reference screenshot to validate visually that they are within the mismatch tolerance. If the mismatch exceeds the tolerance, the test step will fail and a screenshot showing the difference will be generated.
 
-A name must be provided to be used as the screenshot name.
+<Notice variant="caution" ariaLevel="3">
+  The screenshot assertion must be used within an `it` block and a screenshot name must be provided.
+</Notice>
 
 ```js
 it('should validate the screenshot', () => {
@@ -354,6 +370,10 @@ it('should validate the screenshot with options', () => {
 ### Terra.validates.element
 
 The validates element assertion performs both accessibility and screenshot assertions.
+
+<Notice variant="caution" ariaLevel="3">
+  The validates element assertion must be used within an `it` block.
+</Notice>
 
 ```js
 it('should validate the element', () => {

--- a/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/About.1.tool.mdx
+++ b/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/About.1.tool.mdx
@@ -111,7 +111,7 @@ Tests can be executed in the following form factors:
 To specify a list of form factors use the cli option:
 
 <Notice variant="important" ariaLevel="3">
-  If no form factor is specified all tests will be run against the `huge` form factor. 
+  If no form factor is specified all tests will be run against the huge form factor.
 </Notice>
 
 ```json
@@ -192,11 +192,11 @@ exports.config = config;
 
 Test utilities are available to help write tests. These utilities are accessed using the `Terra` global object.
 
-## Describe Helpers
+### Describe Helpers
 
 The describe helpers are an alias for the top level `describe` block used within spec files. The describe helpers provide useful features for limiting a set of tests to specific form factors, locales, and themes.
 
-### Terra.describeViewports
+#### Terra.describeViewports
 
 <Notice variant="important" ariaLevel="3">
   We recommended using Terra.describeTests instead of Terra.describeViewports. The same features in Terra.describeViewports can be achieved with Terra.describeTests.
@@ -215,7 +215,7 @@ Terra.describeViewports(title, [viewports], fn);
 ```
 
 <Notice variant="caution" ariaLevel="3">
-  Describe helpers should not be nested.
+  Describe helpers should not be nested within other describe helpers.
 </Notice>
 
 ```js
@@ -240,7 +240,7 @@ Terra.describeViewports('Describe viewports title', ['small'], () => {
 });
 ```
 
-### Terra.describeTests
+#### Terra.describeTests
 
 The `Terra.describeTests` helper extends the `Terra.describeViewports` helper by additionally filtering tests by locale and theme. Tests within this helper will only be executed if each of the form factors, locales, and themes listed in the options match those defined in the configurations for the current test run. If no form factors, locales, or themes are provided as options, then all tests under this helper will qualify to run in any form factor, locale, or theme.
 
@@ -259,6 +259,10 @@ Terra.describeTests(title, options, fn);
 
 The following tests will only be ran for the locales, themes, and form factors provided:
 
+<Notice variant="caution" ariaLevel="3">
+  The describe helper should not be nested inside of another describe helper.
+</Notice>
+
 ```js
 const testOptions = {
   formFactors: ['tiny', 'huge'],
@@ -274,7 +278,7 @@ Terra.describeTests('Describe tests', testOptions, () => {
 });
 ```
 
-## Accessibility Testing
+### Accessibility Testing
 
 The testing library integrates [axe-core](https://github.com/dequelabs/axe-core) into the testing framework to help automate accessibility testing along side functional testing.
 
@@ -284,12 +288,14 @@ Axe will analyze the entire document when run and report accessibility violation
   Please note that not all accessibility testing can be automated. Axe provides a lightweight static analysis of the entire document to catch common accessibility violations, but it is the responsibility of each team and application to do thorough accessibility and functional testing manually when necessary.
 </Notice>
 
-### Terra.validates.accessibility
+#### Terra.validates.accessibility
 
 The validates accessibility command will run accessibility checks on the entire document. If accessibility violations are found the test step will fail. It is recommended to run accessibility checks at various steps in a functional workflow to check for violations at different stages of the application.
 
 <Notice variant="caution" ariaLevel="3">
+
   The accessibility assertion must be used within an `it` block.
+
 </Notice>
 
 ```js
@@ -313,16 +319,18 @@ it('should override a rule configuration', () => {
 });
 ```
 
-## Screenshot Testing
+### Screenshot Testing
 
 A screenshot can be captured at any given point inside an `it` block in a test. The element(s) being captured in the screenshot is determined by the provided selector option or the default `[data-terra-test-content]` selector if one is not provided. If part or all of the selector or any of its children are rendered outside the bounds of the current viewport, only what is within the viewport will be captured and what is outside the viewport will be clipped. The captured screenshot will be used as a reference artifact. Element validation is done by comparing the reference screenshot against the screenshot captured in future test runs at the same point in the test.
 
-### Terra.validates.screenshot
+#### Terra.validates.screenshot
 
 Invoking the assertion will capture a screenshot at the time it is invoked. If no reference screenshot exists, one will be created in the `reference` folder with the given screenshot name. If such reference screenshot already exists, the new screenshot will be compared with the reference screenshot to validate visually that they are within the mismatch tolerance. If the mismatch exceeds the tolerance, the test step will fail and a screenshot showing the difference will be generated.
 
 <Notice variant="caution" ariaLevel="3">
+
   The screenshot assertion must be used within an `it` block and a screenshot name must be provided.
+
 </Notice>
 
 ```js
@@ -340,8 +348,8 @@ base_directory/test_spec_directory/test_spec_name/__snapshots__/(reference|lates
 ```
 
 The screenshot assertion accepts an optional second argument with the following keys.
-  * `selector` - the element selector to use to capture the element for screenshot comparison. The default selector is `data-terra-test-content`.
-  * `mismatchTolerance` - the number between 0 and 100 that defines the degree of mismatch to consider two images as identical. Increasing this value will decrease level of test coverage.
+  * `selector` - The element selector to use to capture the element for screenshot comparison. The default selector is `data-terra-test-content`.
+  * `mismatchTolerance` - The number between 0 and 100 that defines the degree of mismatch to consider two images as identical. Increasing this value will decrease level of test coverage. The default mismatch tolerance is 0.01.
 
 ```js
 it('should validate the screenshot with options', () => {
@@ -356,12 +364,14 @@ it('should validate the screenshot with options', () => {
 });
 ```
 
-### Terra.validates.element
+#### Terra.validates.element
 
 The validates element assertion performs both accessibility and screenshot assertions.
 
 <Notice variant="caution" ariaLevel="3">
-  The validates element assertion must be used within an `it` block.
+
+  The validates element assertion must be used within an `it` block and a screenshot name must be provided.
+
 </Notice>
 
 ```js
@@ -373,9 +383,9 @@ it('should validate the element', () => {
 ```
 
 The element assertion accepts an optional second argument with the following keys.
-  * `rules` - the accessibility [rules](https://github.com/dequelabs/axe-core/blob/master/doc/rule-descriptions.md) to use as overrides if necessary.
-  * `selector` - the element selector to use to capture the element for screenshot comparison. The default selector is `data-terra-test-content`.
-  * `mismatchTolerance` - the number between 0 and 100 that defines the degree of mismatch to consider two images as identical. Increasing this value will decrease level of test coverage.
+  * `rules` - The accessibility [rules](https://github.com/dequelabs/axe-core/blob/master/doc/rule-descriptions.md) to use as overrides if necessary.
+  * `selector` - The element selector to use to capture the element for screenshot comparison. The default selector is `data-terra-test-content`.
+  * `mismatchTolerance` - The number between 0 and 100 that defines the degree of mismatch to consider two images as identical. Increasing this value will decrease level of test coverage. The default mismatch tolerance is 0.01.
 
 ```js
 it('should validate the element with options', () => {
@@ -391,9 +401,9 @@ it('should validate the element with options', () => {
 });
 ```
 
-## Additional Utilities
+### Additional Utilities
 
-### Terra.hideInputCaret
+#### Terra.hideInputCaret
 
 An editable text field in focus will have a blinking caret. Often times this blinking caret causes inconsistent test failures due to the blinking of the caret during screenshot capture. This situation can be avoided by using `Terra.hideInputCaret` to set the CSS caret color to of the element to be transparent. This method must be placed in a `before`, `beforeEach`, or `it` block or it will not be ran. This method accepts a selector string as an argument and will only apply to the first selector if multiple are found. The caret will automatically be hidden for body every time the page loads or refreshes.
 
@@ -406,7 +416,7 @@ it('should hide the caret', () => {
 });
 ```
 
-### Terra.setApplicationLocale
+#### Terra.setApplicationLocale
 
 Use `Terra.setApplicationLocale` to update a terra application's locale on a case by case basis; particularly useful for testing locale changes on a deployed application. This method accepts a string containing the `locale` to update to.
 

--- a/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/About.1.tool.mdx
+++ b/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/About.1.tool.mdx
@@ -63,19 +63,19 @@ The following example will run the test suite a total of four times. Once for ea
 
 ## Browser Capabilities
 
-<Notice variant="important" ariaLevel="3">
-  Internet Explorer can only be enabled when running against a remote selenium grid. Internet Explorer is not available locally within docker.
-</Notice>
-
 The following browsers are supported:
 
 - Chrome
 - Firefox
 - Internet Explorer
 
-By default, Chrome is the only browser enabled when running locally against a containerized docker environment. If a selenium grid is specified all three browsers will be enabled by default.
+Chrome is enabled by default when running locally against the docker container.
 
 To target a list of browsers that are different than the default use the `browsers` cli option:
+
+<Notice variant="important" ariaLevel="3">
+  Internet Explorer can only be enabled when running against a remote selenium grid. Internet Explorer is not available within the docker container.
+</Notice>
 
 ```json
 "scripts": {
@@ -85,6 +85,10 @@ To target a list of browsers that are different than the default use the `browse
 
 To run against a remote selenium grid:
 
+<Notice variant="important" ariaLevel="3">
+  Chrome, Firefox, and Internet Explorer are all enabled by default when running against a remove selenium grid.
+</Notice>
+
 ```json
 "scripts": {
   "test:wdio": "terra wdio --gridUrl grid.test.example.com"
@@ -93,7 +97,7 @@ To run against a remote selenium grid:
 
 ## Form Factors
 
-By default, all tests will be run against the `huge` form factor. Tests can be executed in the following form factors:
+Tests can be executed in the following form factors:
 
 | Size     | Width | Height |
 |----------|-------|--------|
@@ -105,6 +109,10 @@ By default, all tests will be run against the `huge` form factor. Tests can be e
 | enormous | 1500  | 768    |
 
 To specify a list of form factors use the cli option:
+
+<Notice variant="important" ariaLevel="3">
+  If no form factor is specified all tests will be run against the `huge` form factor. 
+</Notice>
 
 ```json
 "scripts": {
@@ -134,10 +142,6 @@ Service options are configurable by extending the wdio.conf.js file. These optio
 
 ### selector
 
-<Notice variant="important" ariaLevel="3">
-  This selector is used as the default screenshot selector for Terra.validates.element and Terra.validates.screenshot.
-</Notice>
-
 Specifies the default element to be captured when taking a screenshot.
 
 Type: `string`
@@ -145,6 +149,10 @@ Type: `string`
 Required: `false`
 
 Default: `[data-terra-test-content] *:first-child`
+
+<Notice variant="important" ariaLevel="3">
+  This selector is used as the default screenshot selector for Terra.validates.element and Terra.validates.screenshot.
+</Notice>
 
 ```js
 const { config } = require('@cerner/terra-functional-testing');
@@ -158,10 +166,6 @@ exports.config = config;
 
 ### seleniumVersion
 
-<Notice variant="caution" ariaLevel="3">
-  The selenium version is only applied when running tests against a docker container. This option does not change the version on a remote selenium grid. Keep this in mind if your tests run against a remote selenium grid on a CI system.
-</Notice>
-
 Specifies the [docker selenium](https://github.com/SeleniumHQ/docker-selenium/tree/selenium-3) version used within the docker container.
 
 Type: `string`
@@ -169,6 +173,10 @@ Type: `string`
 Required: `false`
 
 Default: `3.14.0-helium`
+
+<Notice variant="caution" ariaLevel="3">
+  The selenium version is only applied when running tests against a docker container. This option does not change the version on a remote selenium grid. Keep this in mind if your tests run against a remote selenium grid on a CI system.
+</Notice>
 
 ```js
 const { config } = require('@cerner/terra-functional-testing');

--- a/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/About.1.tool.mdx
+++ b/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/About.1.tool.mdx
@@ -79,14 +79,14 @@ To target a list of browsers that are different than the default use the `browse
 
 ```json
 "scripts": {
-  "test:wdio": "terra wdio --browser firefox"
+  "test:wdio": "terra wdio --browsers firefox"
 }
 ```
 
 To run against a remote selenium grid:
 
 <Notice variant="important" ariaLevel="3">
-  Chrome, Firefox, and Internet Explorer are all enabled by default when running against a remove selenium grid.
+  Chrome, Firefox, and Internet Explorer are all enabled by default when running against a remote selenium grid.
 </Notice>
 
 ```json

--- a/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/About.1.tool.mdx
+++ b/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/About.1.tool.mdx
@@ -45,7 +45,6 @@ package.json
 | --externalPort                   | number  |                         | The port mapping from the host to the container.                                                                                          |
 | --formFactors                    | array   |                         | A list of form factors for the test run. One of tiny, small, medium, large, huge, or enormous                                             |
 | --gridUrl                        | string  |                         | The remote selenium grid address.                                                                                                         |
-| --keepAliveSeleniumDockerService | boolean | false                   | Determines to keep the selenium docker service running upon test completion.                                                              |
 | --locales                        | array   | en                      | A list of language locales for the test run.                                                                                              |
 | --site                           | string  |                         | A file path to a static directory of assets. When defined, an express server will launch to serve the assets and disable running webpack. |
 | --spec                           | array   |                         | A list of spec file paths.                                                                                                                |
@@ -150,7 +149,7 @@ Required: `false`
 
 Default: `[data-terra-test-content] *:first-child`
 
-<Notice variant="important" ariaLevel="3">
+<Notice variant="important" ariaLevel="4">
   This selector is used as the default screenshot selector for Terra.validates.element and Terra.validates.screenshot.
 </Notice>
 
@@ -174,7 +173,7 @@ Required: `false`
 
 Default: `3.14.0-helium`
 
-<Notice variant="caution" ariaLevel="3">
+<Notice variant="caution" ariaLevel="4">
   The selenium version is only applied when running tests against a docker container. This option does not change the version on a remote selenium grid. Keep this in mind if your tests run against a remote selenium grid on a CI system.
 </Notice>
 
@@ -198,7 +197,7 @@ The describe helpers are an alias for the top level `describe` block used within
 
 #### Terra.describeViewports
 
-<Notice variant="important" ariaLevel="3">
+<Notice variant="important" ariaLevel="5">
   We recommended using Terra.describeTests instead of Terra.describeViewports. The same features in Terra.describeViewports can be achieved with Terra.describeTests.
 </Notice>
 
@@ -214,7 +213,7 @@ The `Terra.describeViewports` utility defines a list of form factors the tests a
 Terra.describeViewports(title, [viewports], fn);
 ```
 
-<Notice variant="caution" ariaLevel="3">
+<Notice variant="caution" ariaLevel="5">
   Describe helpers should not be nested within other describe helpers.
 </Notice>
 
@@ -259,7 +258,7 @@ Terra.describeTests(title, options, fn);
 
 The following tests will only be ran for the locales, themes, and form factors provided:
 
-<Notice variant="caution" ariaLevel="3">
+<Notice variant="caution" ariaLevel="5">
   The describe helper should not be nested inside of another describe helper.
 </Notice>
 
@@ -284,7 +283,7 @@ The testing library integrates [axe-core](https://github.com/dequelabs/axe-core)
 
 Axe will analyze the entire document when run and report accessibility violations. The following [tags](https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#axe-core-tags) are enabled: `wcag2a`, `wcag2aa`, `wcag21aa`, and `section508`. Each tag has an associated list of [rules](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md) that will be checked against the document when axe is run.
 
-<Notice variant="important" ariaLevel="3">
+<Notice variant="important" ariaLevel="4">
   Please note that not all accessibility testing can be automated. Axe provides a lightweight static analysis of the entire document to catch common accessibility violations, but it is the responsibility of each team and application to do thorough accessibility and functional testing manually when necessary.
 </Notice>
 
@@ -292,7 +291,7 @@ Axe will analyze the entire document when run and report accessibility violation
 
 The validates accessibility command will run accessibility checks on the entire document. If accessibility violations are found the test step will fail. It is recommended to run accessibility checks at various steps in a functional workflow to check for violations at different stages of the application.
 
-<Notice variant="caution" ariaLevel="3">
+<Notice variant="caution" ariaLevel="4">
 
   The accessibility assertion must be used within an `it` block.
 
@@ -327,7 +326,7 @@ A screenshot can be captured at any given point inside an `it` block in a test. 
 
 Invoking the assertion will capture a screenshot at the time it is invoked. If no reference screenshot exists, one will be created in the `reference` folder with the given screenshot name. If such reference screenshot already exists, the new screenshot will be compared with the reference screenshot to validate visually that they are within the mismatch tolerance. If the mismatch exceeds the tolerance, the test step will fail and a screenshot showing the difference will be generated.
 
-<Notice variant="caution" ariaLevel="3">
+<Notice variant="caution" ariaLevel="5">
 
   The screenshot assertion must be used within an `it` block and a screenshot name must be provided.
 
@@ -368,7 +367,7 @@ it('should validate the screenshot with options', () => {
 
 The validates element assertion performs both accessibility and screenshot assertions.
 
-<Notice variant="caution" ariaLevel="3">
+<Notice variant="caution" ariaLevel="5">
 
   The validates element assertion must be used within an `it` block and a screenshot name must be provided.
 

--- a/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/About.1.tool.mdx
+++ b/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/About.1.tool.mdx
@@ -198,6 +198,10 @@ The describe helpers are an alias for the top level `describe` block used within
 
 ### Terra.describeViewports
 
+<Notice variant="important" ariaLevel="3">
+  We recommended using Terra.describeTests instead of Terra.describeViewports. The same features in Terra.describeViewports can be achieved with Terra.describeTests.
+</Notice>
+
 The `Terra.describeViewports` utility defines a list of form factors the tests are enabled for. By default, all tests will be run against each provided viewport. If a form factor is specified via the cli the describe viewpoint helper works as a filter and only allows the tests to execute if they match the current form factor.
 
 ```js
@@ -210,13 +214,13 @@ The `Terra.describeViewports` utility defines a list of form factors the tests a
 Terra.describeViewports(title, [viewports], fn);
 ```
 
-The following example will scope the tests to run only for the `tiny` and `huge` form factors. The tests will not run for any other form factor.
-
 <Notice variant="caution" ariaLevel="3">
-  Do not nest describe helpers.
+  Describe helpers should not be nested.
 </Notice>
 
 ```js
+// The following example will scope the tests to run only for the `tiny` and `huge` form factors. The tests will not run for any other form factor.
+
 Terra.describeViewports('Describe viewports title', ['tiny', 'huge'], () => {
   it('should test tiny and huge screens', () => {
     browser.url('/testing/route/');
@@ -238,7 +242,7 @@ Terra.describeViewports('Describe viewports title', ['small'], () => {
 
 ### Terra.describeTests
 
-The `Terra.describeTests` helper extends the `Terra.describeViewports` helper by additionally filter tests by locales and themes. All tests within this helper will be executed only if each of the form factors, locales, and themes listed in the options match those defined in the configurations for the current test run. If no form factors, locales, or themes are provided as options, then all tests under this helper will qualify to run in any form factor, locale, or theme. It is recommended to use `Terra.describeTests` over `Terra.describeViewports` because the same features in `Terra.describeViewports` can be achieved with `Terra.describeTests` by eliminating locales and themes and only specify the form factors. This helper accepts these arguments in the following order:
+The `Terra.describeTests` helper extends the `Terra.describeViewports` helper by additionally filtering tests by locale and theme. Tests within this helper will only be executed if each of the form factors, locales, and themes listed in the options match those defined in the configurations for the current test run. If no form factors, locales, or themes are provided as options, then all tests under this helper will qualify to run in any form factor, locale, or theme.
 
 ```js
 /**
@@ -253,30 +257,7 @@ The `Terra.describeTests` helper extends the `Terra.describeViewports` helper by
 Terra.describeTests(title, options, fn);
 ```
 
-The below describe block qualifies to run because each of the form factors, locales, and themes provided to `describeTests` match the CLI options specified in the test runner.
-```sh
-terra wdio --formFactors tiny --locales en --themes terra-default-theme
-```
-
-```js
-const testOptions = {
-  formFactors: ['tiny', 'huge'],
-  locales: ['en', 'fr'],
-  themes: ['terra-default-theme', 'orion-fusion-theme']
-}
-
-Terra.describeTests('Describe tests', testOptions, () => {
-  it('should execute only if form factor is tiny or huge, locale is en or fr, and theme is terra-default-theme or orion-fusion-theme', () => {
-    browser.url('/testing/route/');
-    Terra.validates.element('describe tests');
-  });
-});
-```
-
-The below describe block is not qualified to run because at least one of the form factors, locales, or themes provided to `describeTests` does not match the CLI options specified in the test runner.
-```sh
-terra wdio --formFactors small --locales en --themes terra-default-theme
-```
+The following tests will only be ran for the locales, themes, and form factors provided:
 
 ```js
 const testOptions = {

--- a/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/About.1.tool.mdx
+++ b/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/About.1.tool.mdx
@@ -1,24 +1,37 @@
+import { Notice } from '@cerner/terra-docs';
 import { Badge } from '@cerner/terra-functional-testing/package.json?dev-site-package';
 
 <Badge />
 
 # Terra Functional Testing
 
-The terra-functional-testing library is a utility for developing automation tests. The library extends the [WebdriverIO Framework](https://webdriver.io/) to facilitate automating accessibility and functional testing for Terra projects.
+The terra-functional-testing library is a utility for developing automation tests. The library extends [WebdriverIO](https://v6.webdriver.io/) to facilitate automating accessibility and functional testing for Terra projects.
 
-## Getting Started
+## System Requirements
 
-To get started ensure [docker](https://www.docker.com/) has been installed. The terra-functional-testing library uses docker to setup and run tests in a containerized environment.
+- [Node.js](http://nodejs.org/) Install at least v10.24.0. Due to requirements of fibers used within the project install no greater than lts/erbium (v12).
+- [Docker](https://www.docker.com/) Install docker. Docker is used to setup and run tests in a containerized environment.
 
-Install with npm:
+We strongly recommend using [nvm](https://github.com/nvm-sh/nvm) for installing node versions.
+
+## Installation
+
+Install @cerner/terra-functional-testing and @cerner/terra-cli as development dependencies with npm:
 
 ```
-npm install --save-dev @cerner/terra-functional-testing
+npm install --save-dev @cerner/terra-functional-testing @cerner/terra-cli
 ```
 
-## Test Runner
+## Usage
 
-A test runner is provided for local development and should be invoked using the [terra-cli](https://engineering.cerner.com/terra-ui/dev_tools/cerner/terra-cli/about).
+A test runner is provided for local development. The test runner is invoked via the [terra-cli](https://engineering.cerner.com/terra-ui/dev_tools/cerner/terra-cli/about).
+
+package.json
+```json
+"scripts": {
+  "test:wdio": "terra wdio"
+}
+```
 
 ### Options
 
@@ -42,18 +55,45 @@ A test runner is provided for local development and should be invoked using the 
 
 The following example will run the test suite a total of four times. Once for each permutation of the specified locales and form factors.
 
-package.json
 ```json
-{
-  "scripts": {
-    "wdio": "npm run terra wdio --locales en fr --formFactors tiny huge"
-  }
+"scripts": {
+  "test:wdio": "terra wdio --locales en fr --formFactors tiny huge"
+}
+```
+
+## Browser Capabilities
+
+<Notice variant="important" ariaLevel="3">
+  Internet Explorer can only be enabled when running against a remote selenium grid. Internet Explorer is not available locally within docker.
+</Notice>
+
+The following browsers are supported:
+
+- Chrome
+- Firefox
+- Internet Explorer
+
+By default, Chrome is the only browser enabled when running locally against a containerized docker environment. If a selenium grid is specified all three browsers will be enabled by default.
+
+To target a list of browsers that are different than the default use the `browsers` cli option:
+
+```json
+"scripts": {
+  "test:wdio": "terra wdio --browser firefox"
+}
+```
+
+To run against a remote selenium grid:
+
+```json
+"scripts": {
+  "test:wdio": "terra wdio --gridUrl grid.test.example.com"
 }
 ```
 
 ## Form Factors
 
-Tests can be executed in any of the following supported form factors:
+By default, all tests will be run against the `huge` form factor. Tests can be executed in the following form factors:
 
 | Size     | Width | Height |
 |----------|-------|--------|
@@ -64,21 +104,115 @@ Tests can be executed in any of the following supported form factors:
 | huge     | 1300  | 768    |
 | enormous | 1500  | 768    |
 
+To specify a list of form factors use the cli option:
+
+```json
+"scripts": {
+  "test:wdio": "terra wdio --formFactors tiny small enormous"
+}
+```
+
+## Configuration
+
+The test runner ships with a default [wdio.conf.js](https://github.com/cerner/terra-toolkit/blob/main/packages/terra-functional-testing/src/config/wdio.conf.js). Webdriver and service options can be configured by extending the default configuration file.
+
+To extend the default configuration create a `wdio.conf.js` file at the root of your project and apply the desired options.
+
+wdio.conf.js
+```js
+const { config } = require('@cerner/terra-functional-testing');
+
+// Stop the test run if there is a test failure.
+config.bail = 1;
+
+exports.config = config;
+```
+
+## Service Options
+
+A few service options are configurable by extending the wdio.conf.js file. These options are applied for every test run.
+
+### selector
+
+<Notice variant="important" ariaLevel="3">
+  This selector is used as the default screenshot selector for Terra.validates.element and Terra.validates.screenshot.
+</Notice>
+
+Specifies the default element to be captured when taking a screenshot.
+
+Type: `string`
+
+Required: `false`
+
+Default: `[data-terra-test-content] *:first-child`
+
+```js
+const { config } = require('@cerner/terra-functional-testing');
+
+config.serviceOptions = {
+  selector: '#root',
+};
+
+exports.config = config;
+```
+
+### seleniumVersion
+
+<Notice variant="caution" ariaLevel="3">
+  The selenium version is only applied when running tests against a docker container. This option does not change the version on a remote selenium grid. Keep this in mind if your tests run against a remote selenium grid on a CI system.
+</Notice>
+
+Specifies the [docker selenium](https://github.com/SeleniumHQ/docker-selenium/tree/selenium-3) version used within the docker container.
+
+Type: `string`
+
+Required: `false`
+
+Default: `3.14.0-helium`
+
+```js
+const { config } = require('@cerner/terra-functional-testing');
+
+config.serviceOptions = {
+  seleniumVersion: '3.141.59-20210311',
+};
+
+exports.config = config;
+```
+
+## Test Utilities
+
+Test utilities are available to help write tests. These utilities are accessed using the `Terra` global object.
+
 ## Describe Helpers
 
-These helpers are used as the top level `describe` block for the spec file. These helpers should not be nested within itself. If a block of tests needs to run against different form factors, locales, or themes, they should be created under a separate top level describe block or spec file.
+The describe helpers are an alias for the top level `describe` block used within spec files. The describe helpers provide useful features for limit a set of tests to specific form factors, locales, and themes.
+
+<Notice variant="caution" ariaLevel="3">
+  The describe helpers should not be nested. Multiple describe helpers can be used sequentially in the same spec file.
+</Notice>
 
 ### Terra.describeViewports
 
-All tests within this helper will be executed for each given viewport(s). Only the above defined viewports are supported. The default viewport is 'huge'. If a form factor is passed as a CLI option to the `test wdio` test runner, this form factor will supersede the viewports defined in this helper. This helper accepts these arguments in the following order:
-- {string} title - The `describe` block title.
-- {string[]} viewports - The list of Terra viewports to test.
-- {function} - the test function to execute for each viewport.
+The `Terra.describeViewports` utility defines a list of form factors the tests are enabled for. By default, all tests will be run against each provided viewport. If a form factor is specified via the cli the describe viewpoint helper works as a filter and only allows the tests to execute if they match the current form factor.
 
 ```js
-Terra.describeViewports('Describe viewports', ['tiny', 'huge'], () => {
+/**
+ * Executes all tests for each defined viewport.
+ * @param {string} title - The describe block title.
+ * @param {string[]} viewports - A list of viewports. [tiny, small, medium, large, huge, enormous]
+ * @param {function} fn - The block of tests to execute against each viewport.
+ */
+Terra.describeViewports(title, [viewports], fn);
+```
+
+The following example will scope the tests to run only for the `tiny` and `huge` form factors. The tests will not run for any other form factor.
+
+```js
+Terra.describeViewports('Describe viewports title', ['tiny', 'huge'], () => {
   it('should test tiny and huge screens', () => {
     browser.url('/testing/route/');
+
     Terra.validates.screenshot('describe viewports');
   });
 });
@@ -87,10 +221,19 @@ Terra.describeViewports('Describe viewports', ['tiny', 'huge'], () => {
 ### Terra.describeTests
 
 The `Terra.describeTests` helper extends the `Terra.describeViewports` helper by additionally filter tests by locales and themes. All tests within this helper will be executed only if each of the form factors, locales, and themes listed in the options match those defined in the configurations for the current test run. If no form factors, locales, or themes are provided as options, then all tests under this helper will qualify to run in any form factor, locale, or theme. It is recommended to use `Terra.describeTests` over `Terra.describeViewports` because the same features in `Terra.describeViewports` can be achieved with `Terra.describeTests` by eliminating locales and themes and only specify the form factors. This helper accepts these arguments in the following order:
-- {string} title - The describe block title.
-- {Object} options - An object containing arrays of formFactors, locales, and themes that the block of tests will only qualify to execute in.
-- {function} - The block of tests to execute against each viewport.
 
+```js
+/**
+ * Executes all tests for each defined set of form factors, locales, and themes.
+ * @param {string} title - The describe block title.
+ * @param {Object} options - An object containing arrays of formFactors, locales, and themes that the block of tests will only qualify to execute in.
+ * @param {string} options.formFactors - The form factors that the block of tests only execute in.
+ * @param {string} options.locales -  The language locales that the block of tests only execute in.
+ * @param {string} options.themes - The themes that the block of tests only execute in.
+ * @param {function} fn - The block of tests to execute based on the defined form factor, locale, and theme.
+ */
+Terra.describeTests(title, options, fn);
+```
 
 The below describe block qualifies to run because each of the form factors, locales, and themes provided to `describeTests` match the CLI options specified in the test runner.
 ```sh
@@ -136,9 +279,11 @@ Terra.describeTests('Describe tests', testOptions, () => {
 
 The testing library integrates [axe-core](https://github.com/dequelabs/axe-core) into the testing framework to help automate accessibility testing along side functional testing.
 
-Axe will analyze the entire document when run and report accessibility violations. The following [tags](https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#axe-core-tags) are enabled `wcag2a`, `wcag2aa`, `wcag21aa`, and `section508`. Each tag has an associated list of [rules](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md) that will be checked against the document when axe is run.
+Axe will analyze the entire document when run and report accessibility violations. The following [tags](https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#axe-core-tags) are enabled: `wcag2a`, `wcag2aa`, `wcag21aa`, and `section508`. Each tag has an associated list of [rules](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md) that will be checked against the document when axe is run.
 
-Please note that not all accessibility testing can be automated. Axe provides a lightweight static analysis of the entire document to catch common accessibility violations, but it is the responsibility of each team and application to do thorough accessibility and functional testing manually when necessary.
+<Notice variant="important" ariaLevel="3">
+  Please note that not all accessibility testing can be automated. Axe provides a lightweight static analysis of the entire document to catch common accessibility violations, but it is the responsibility of each team and application to do thorough accessibility and functional testing manually when necessary.
+</Notice>
 
 ### Terra.validates.accessibility
 
@@ -165,7 +310,7 @@ it('should override a rule configuration', () => {
 });
 ```
 
-## Validating element
+## Screenshot Testing
 
 A screenshot can be captured at any given point inside an `it` block in a test. The element(s) being captured in the screenshot is determined by the provided selector option or the default `[data-terra-test-content]` selector if one is not provided. If part or all of the selector or any of its children are rendered outside the bounds of the current viewport, only what is within the viewport will be captured and what is outside the viewport will be clipped. The captured screenshot will be used as a reference artifact. Element validation is done by comparing the reference screenshot against the screenshot captured in future test runs at the same point in the test.
 
@@ -208,7 +353,7 @@ it('should validate the screenshot with options', () => {
 
 ### Terra.validates.element
 
-The element assertion basically performs both `Terra.validates.accessibility` and `Terra.validates.screenshot` assertions. Like these two assertions the element assertion should also only be invoked inside an `it` block.
+The validates element assertion performs both accessibility and screenshot assertions.
 
 ```js
 it('should validate the element', () => {
@@ -237,7 +382,7 @@ it('should validate the element with options', () => {
 });
 ```
 
-## Input Caret
+## Additional Utilities
 
 ### Terra.hideInputCaret
 
@@ -252,9 +397,8 @@ it('should hide the caret', () => {
 });
 ```
 
-## Locale Update (Case by Case)
-
 ### Terra.setApplicationLocale
+
 Use `Terra.setApplicationLocale` to update a terra application's locale on a case by case basis; particularly useful for testing locale changes on a deployed application. This method accepts a string containing the `locale` to update to.
 
 ```js

--- a/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/upgrade-guides.5/version-1-upgrade-guide.1.tool.md
+++ b/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/upgrade-guides.5/version-1-upgrade-guide.1.tool.md
@@ -395,7 +395,7 @@ Update any references to the previous `wdio.conf.js`:
 ```diff
 // wdio.conf.js
 - const wdioConfig = require('terra-toolkit/config/wdio/wdio.conf');
-+ const { config } = require('@cerner/terra-functional-testing/lib/config/wdio.conf');
++ const { config } = require('@cerner/terra-functional-testing');
 
 - module.exports = wdioConfig;
 + exports.config = config;
@@ -433,7 +433,7 @@ Choose a spec file to uplift and limit the test run to only that file.
 
 ```js
 // wdio.conf.js
-const { config } = require('@cerner/terra-functional-testing/lib/config/wdio.conf');
+const { config } = require('@cerner/terra-functional-testing');
 
 config.specs = [
   '/tests/wdio/path/example-spec',

--- a/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/wdio-reporters.3/SpecReporter.tool.mdx
+++ b/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/wdio-reporters.3/SpecReporter.tool.mdx
@@ -1,3 +1,47 @@
 # Spec Reporter
 
-The Spec Reporter writes test results to file in JSON format and is enabled by default in the `terra-functional-testing` wdio configuration.
+The spec reporter is a custom reporter plugin that aggregates test data and writes the results to file. The generated results file will contain all relevant metadata for the test run in JSON format.
+
+Example Output:
+
+```json
+{
+  "packageName": "terra-example-project",
+  "theme": "terra-default-theme",
+  "locale": "en",
+  "formFactor": "large",
+  "capabilities": {
+    "browserName": "chrome",
+    "platform": "Linux",
+    "version": "69.0.3497.100"
+  },
+  "specs": [
+    {
+      "spec": "terra-example-project/tests/wdio/terra-example-spec.js",
+      "start": "2021-03-25T15:35:27.650Z",
+      "end": "2021-03-25T15:35:27.723Z",
+      "suites": [
+        {
+          "title": "Example Describe",
+          "fullTitle": "Example Describe",
+          "duration": 3,
+          "start": "2021-03-25T15:35:27.653Z",
+          "end": "2021-03-25T15:35:27.656Z",
+          "tests": [
+            {
+              "title": "should pass the assertion",
+              "fullTitle": "Example Describe should pass the assertion",
+              "duration": 3,
+              "start": "2021-03-25T15:35:27.653Z",
+              "end": "2021-03-25T15:35:27.656Z",
+              "state": "passed"
+            }
+          ],
+          "suites": []
+        }
+      ],
+      "tests": []
+    }
+  ]
+}
+```

--- a/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/wdio-services.4/AssetServerService.tool.mdx
+++ b/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/wdio-services.4/AssetServerService.tool.mdx
@@ -1,96 +1,12 @@
 # Asset Server Service
 
-The asset server service initializes a server to serve compiled assets to the testing environment.
-
-## Installation
-
-The asset server service should be installed as a development dependency.
-
-```bash
-npm install --save-dev @cerner/terra-functional-testing
-```
-
-## Configuration
-
-To use the service it must be added to the services array in the `wdio.conf.js` file.
-
-```js
-// wdio.conf.js
-const AssetServerService = require('@cerner/terra-functional-testing/lib/services/wdio-asset-server-service');
-
-export.config = {
-    // ...
-    services: [
-        [AssetServerService, {
-            // Asset server service options here.
-            // ...
-        }]
-    ],
-    // ...
-};
-```
+The asset server service initializes an asset server to serve compiled assets to the testing environment. An express server will be launched for static sites. For all non-static sites a webpack-dev-server will be launched.
 
 ## Options
 
-### webpackConfig
+The assert server options are configured via the [test runner CLI options](../about#options). The webpack-dev-server will be provided the locale and theme options via the test runner and will pass those through to webpack.
 
-A path to a webpack configuration file.
-
-Note: The `site` configuration option will take precedence over `webpackConfig` if both are provided.
-
-Type: `string`
-
-Required: `false`
-
-Default: The asset server service will check the current working directory for a `webpack.config.js` file.
-
-Example:
-
-```js
-// wdio.conf.js
-const AssetServerService = require('@cerner/terra-functional-testing/lib/services/wdio-asset-server-service');
-
-export.config = {
-    // ...
-    services: [
-        [AssetServerService, {
-          webpackConfig: './path/webpack.config.js'
-        }]
-    ],
-    // ...
-};
-```
-
-### locale
-
-Note: The locale will only be applied when providing a webpack configuration. The locale will not be used for `site` configuration.
-
-An optional locale that will be passed into the webpack configuration as an environment variable.
-
-Type: `string`
-
-Required: `false`
-
-Default: `undefined`
-
-Example:
-
-```js
-// wdio.conf.js
-const AssetServerService = require('@cerner/terra-functional-testing/lib/services/wdio-asset-server-service');
-
-export.config = {
-    // ...
-    services: [
-        [AssetServerService, {
-          locale: 'en-US',
-        }]
-    ],
-    // ...
-};
-```
-
-### port
+### assetServerPort
 
 The port the service will be hosted on.
 
@@ -103,18 +19,9 @@ Default: `8080`
 Example:
 
 ```js
-// wdio.conf.js
-const AssetServerService = require('@cerner/terra-functional-testing/lib/services/wdio-asset-server-service');
-
-export.config = {
-    // ...
-    services: [
-        [AssetServerService, {
-          port: 8080,
-        }]
-    ],
-    // ...
-};
+"scripts": {
+  "test:wdio": "terra wdio --assetServerPort 8081"
+}
 ```
 
 ### site
@@ -132,45 +39,7 @@ Default: `undefined`
 Example:
 
 ```js
-// wdio.conf.js
-const AssetServerService = require('@cerner/terra-functional-testing/lib/services/wdio-asset-server-service');
-
-export.config = {
-    // ...
-    services: [
-        [AssetServerService, {
-          site: './build',
-        }]
-    ],
-    // ...
-};
-```
-
-### theme
-
-Note: The theme will only be applied when providing a webpack configuration. The theme will not be used for `site` configuration.
-
-An optional theme that will be passed into the webpack configuration as an environment variable.
-
-Type: `string`
-
-Required: `false`
-
-Default: `terra-default-theme`
-
-Example:
-
-```js
-// wdio.conf.js
-const AssetServerService = require('@cerner/terra-functional-testing/lib/services/wdio-asset-server-service');
-
-export.config = {
-    // ...
-    services: [
-        [AssetServerService, {
-          theme: 'terra-theme-name',
-        }]
-    ],
-    // ...
-};
+"scripts": {
+  "test:wdio": "terra wdio --site ./build"
+}
 ```

--- a/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/wdio-services.4/SeleniumDockerService.tool.mdx
+++ b/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/wdio-services.4/SeleniumDockerService.tool.mdx
@@ -6,10 +6,6 @@ The selenium docker service initializes a docker-compose for running functional 
 
 By default, the selenium grid will be deployed locally on the host machine running on port 4444. Google Chrome and Firefox are available on the docker container. Internet Explorer can be enable when using a remote selenium grid that has it available.
 
-<Notice variant="important" ariaLevel="3">
-  The selenium docker service is disabled automatically by the test runner if a remote selenium grid is specified.
-</Notice>
-
 ## Options
 
 The selenium docker service options are configured via the [test runner CLI options](../about#options).
@@ -25,6 +21,10 @@ Required: `false`
 Default: `false`
 
 Example:
+
+<Notice variant="important" ariaLevel="3">
+  The selenium docker service is disabled automatically by the test runner if a remote selenium grid is specified.
+</Notice>
 
 ```js
 "scripts": {

--- a/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/wdio-services.4/SeleniumDockerService.tool.mdx
+++ b/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/wdio-services.4/SeleniumDockerService.tool.mdx
@@ -2,7 +2,7 @@ import { Notice } from '@cerner/terra-docs';
 
 # Selenium Docker Service
 
-The selenium docker service initializes a docker-compose for running functional [WebDriverIO](https://webdriver.io/) tests against a containerized [selenium docker](https://github.com/SeleniumHQ/docker-selenium) environment.
+The selenium docker service initializes a containerized [selenium docker](https://github.com/SeleniumHQ/docker-selenium) environment for running functional [WebDriverIO](https://webdriver.io/) tests.
 
 By default, the selenium grid will be deployed locally on the host machine running on port 4444. Google Chrome and Firefox are available on the docker container. Internet Explorer can be enable when using a remote selenium grid that has it available.
 
@@ -29,24 +29,6 @@ Example:
 ```js
 "scripts": {
   "test:wdio": "terra wdio --disableSeleniumService"
-}
-```
-
-### keepAliveSeleniumDockerService
-
-A flag to keep the selenium docker service running upon test completion.
-
-Type: `bool`
-
-Required: `false`
-
-Default: `false`
-
-Example:
-
-```js
-"scripts": {
-  "test:wdio": "terra wdio --keepAliveSeleniumDockerService"
 }
 ```
 

--- a/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/wdio-services.4/SeleniumDockerService.tool.mdx
+++ b/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/wdio-services.4/SeleniumDockerService.tool.mdx
@@ -1,39 +1,58 @@
+import { Notice } from '@cerner/terra-docs';
+
 # Selenium Docker Service
 
-The selenium docker service initializes a docker swarm for running functional [WebDriverIO](https://webdriver.io/) tests against a containerized [selenium docker](https://github.com/SeleniumHQ/docker-selenium) environment.
+The selenium docker service initializes a docker-compose for running functional [WebDriverIO](https://webdriver.io/) tests against a containerized [selenium docker](https://github.com/SeleniumHQ/docker-selenium) environment.
 
-By default, the selenium grid will be deployed locally on the host machine running on port 4444. Google Chrome and Firefox browsers are available on the grid.
+By default, the selenium grid will be deployed locally on the host machine running on port 4444. Google Chrome and Firefox are available on the docker container. Internet Explorer can be enable when using a remote selenium grid that has it available.
 
-## Installation
-
-The selenium docker service should be installed as a development dependency.
-
-```bash
-npm install --save-dev @cerner/terra-functional-testing
-```
-
-## Configuration
-
-To use the service it must be added to the services array in the `wdio.conf.js` file.
-
-```js
-// wdio.conf.js
-const SeleniumDockerService = require('@cerner/terra-functional-testing/lib/services/wdio-selenium-docker-service');
-
-export.config = {
-    // ...
-    services: [
-        [SeleniumDockerService]
-    ],
-    // ...
-};
-```
+<Notice variant="important" ariaLevel="3">
+  The selenium docker service is disabled automatically by the test runner if a remote selenium grid is specified.
+</Notice>
 
 ## Options
 
+The selenium docker service options are configured via the [test runner CLI options](../about#options).
+
+### disableSeleniumService
+
+A flag to disable the selenium docker service for the test run.
+
+Type: `bool`
+
+Required: `false`
+
+Default: `false`
+
+Example:
+
+```js
+"scripts": {
+  "test:wdio": "terra wdio --disableSeleniumService"
+}
+```
+
+### keepAliveSeleniumDockerService
+
+A flag to keep the selenium docker service running upon test completion.
+
+Type: `bool`
+
+Required: `false`
+
+Default: `false`
+
+Example:
+
+```js
+"scripts": {
+  "test:wdio": "terra wdio --keepAliveSeleniumDockerService"
+}
+```
+
 ### seleniumVersion
 
-The docker selenium image version to run tests against.
+The docker selenium image version to run tests against. This option is configured via the `wdio.conf.js`.
 
 Type: `string`
 
@@ -45,14 +64,11 @@ Example:
 
 ```js
 // wdio.conf.js
-const SeleniumDockerService = require('@cerner/terra-functional-testing/lib/services/wdio-selenium-docker-service');
+const { config } = require('@cerner/terra-functional-testing');
 
-export.config = {
-    // ...
-    services: [[SeleniumDockerService]],
-    serviceOptions: {
-        seleniumVersion: '3.14.0-helium',
-    }
-    // ...
+config.serviceOptions = {
+  seleniumVersion: '3.141.59-20210311',
 };
+
+exports.config = config;
 ```

--- a/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/wdio-services.4/TerraService.tool.mdx
+++ b/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/wdio-services.4/TerraService.tool.mdx
@@ -1,12 +1,14 @@
 # Terra Service
 
-The Terra service integrates [axe accessibility](https://github.com/dequelabs/axe-core) and screenshot comparison testing into the test environment. Invoking the axe engine will perform a static analysis of the entire document and dom structure. The axe analysis runs accessibility checks against `wcag2a`, `wcag2aa`, `wcag21aa`, and `section508` standards.
+The Terra service integrates [axe accessibility](https://github.com/dequelabs/axe-core) and screenshot comparison testing commands into the test environment. Invoking the axe engine will perform a static analysis of the entire document and dom structure.
+
+A list of available commands can be viewed [here](../about#test-utilities).
 
 ## Options
 
 ### selector
 
-An optional selector can be configured in the `serviceOptions` to specify the element to be captured when taking a screenshot. Accessibility testing ignores this option and always tests the entire document.
+An optional selector can be configured in the `serviceOptions` to specify the default element to be captured when taking a screenshot. Accessibility testing ignores this option and always tests the entire document.
 
 Type: `string`
 

--- a/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/wdio-services.4/TerraService.tool.mdx
+++ b/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/wdio-services.4/TerraService.tool.mdx
@@ -1,6 +1,6 @@
 # Terra Service
 
-The Terra service integrates [axe accessibility](https://github.com/dequelabs/axe-core) testing into the test environment. Invoking the axe engine will perform a static analysis of the entire document and dom structure. The axe analysis runs accessibility checks against `wcag2a`, `wcag2aa`, `wcag21aa`, and `section508` standards.
+The Terra service integrates [axe accessibility](https://github.com/dequelabs/axe-core) and screenshot comparison testing into the test environment. Invoking the axe engine will perform a static analysis of the entire document and dom structure. The axe analysis runs accessibility checks against `wcag2a`, `wcag2aa`, `wcag21aa`, and `section508` standards.
 
 ## Options
 

--- a/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/wdio-services.4/TerraService.tool.mdx
+++ b/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/wdio-services.4/TerraService.tool.mdx
@@ -1,70 +1,12 @@
 # Terra Service
 
-The Terra service integrates [axe accessibility](https://github.com/dequelabs/axe-core) testing into the test environment. Invoking the axe engine will perform a static analysis of the current document and dom structure. The axe analysis runs accessibility checks against `wcag2a`, `wcag2aa`, `wcag21aa`, and `section508` standards.
-
-## Installation
-
-The Terra service should be installed as a development dependency.
-
-```bash
-npm install --save-dev @cerner/terra-functional-testing
-```
-## Configuration
-
-To use the service it must be added to the services array in the `wdio.conf.js` file.
-
-```js
-// wdio.conf.js
-const TerraService = require('@cerner/terra-functional-testing/lib/services/wdio-terra-service');
-
-export.config = {
-    // ...
-    services: [
-        [TerraService, {
-            // Terra service options here
-            // ...
-        }]
-    ],
-    // ...
-};
-```
+The Terra service integrates [axe accessibility](https://github.com/dequelabs/axe-core) testing into the test environment. Invoking the axe engine will perform a static analysis of the entire document and dom structure. The axe analysis runs accessibility checks against `wcag2a`, `wcag2aa`, `wcag21aa`, and `section508` standards.
 
 ## Options
 
-### formFactor
-
-Tests can be executed in a specific form factor by setting the `formFactor` configuration option or the `FORM_FACTOR` environment variable . The form factors can be any of the following supported viewports: `tiny`; `small`; `medium`; `large`; `huge`; `enormous`. In order for the tests to run in this form factor, it must be one that is already specified in the `Terra.describeViewport` block. 
-
-Type: `String`
-
-Required: `false`
-
-Default: `undefined`
-
-Examples:
-
-```js
-"FORM_FACTOR=huge npm run test:wdio"
-```
-
-```js
-// wdio.conf.js
-const TerraService = require('@cerner/terra-functional-testing/lib/services/wdio-terra-service');
-
-export.config = {
-    // ...
-    services: [
-        [TerraService, {
-          formFactor: 'huge',
-        }]
-    ],
-    // ...
-};
-```
-
 ### selector
 
-An optional selector can be configured in the `serviceOptions` option to specify the element to be captured in the screenshot. The default selector is `data-terra-test-content`. Accessibility testing ignores this option and always tests the entire document.
+An optional selector can be configured in the `serviceOptions` to specify the element to be captured when taking a screenshot. Accessibility testing ignores this option and always tests the entire document.
 
 Type: `string`
 
@@ -76,38 +18,12 @@ Example:
 
 ```js
 // wdio.conf.js
-export.config = {
-    // ...
-    serviceOptions: {
-        selector: 'selector-name',
-    },
-    // ...
+const { config } = require('@cerner/terra-functional-testing');
+
+config.serviceOptions = {
+  selector: '#root',
 };
+
+exports.config = config;
 ```
 
-### theme
-
-An optional theme name that will be used to configure the testing environment. This option will flex the axe-core rules used during testing to account for the current theme.
-
-Type: `string`
-
-Required: `false`
-
-Default: `terra-default-theme`
-
-Example:
-
-```js
-// wdio.conf.js
-const TerraService = require('@cerner/terra-functional-testing/lib/services/wdio-terra-service');
-
-export.config = {
-    // ...
-    services: [
-        [TerraService, {
-          theme: 'terra-theme-name',
-        }]
-    ],
-    // ...
-};
-```

--- a/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/wdio-services.4/VisualRegressionService.tool.mdx
+++ b/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/wdio-services.4/VisualRegressionService.tool.mdx
@@ -1,95 +1,92 @@
 # Visual Regression Service
 
-> Visual regression testing for WebdriverIO
+Visual regression testing for WebdriverIO.
 
-Based on the work of Jan-André Zinser on [wdio-visual-regression-service](https://github.com/zinserjan/wdio-visual-regression-service) and [wdio-screenshot](https://github.com/zinserjan/wdio-screenshot)
+Based on the work of Jan-André Zinser on [wdio-visual-regression-service](https://github.com/zinserjan/wdio-visual-regression-service) and [wdio-screenshot](https://github.com/zinserjan/wdio-screenshot). The visual regression service performs image comparison evaluations to determine mismatch tolerances. Screenshots exceeding the mismatch tolerance will fail the test run.
 
-## Installation
+Screenshots are saved to a `__snapshot__` directory at the same level as the spec file. Screenshots are organized by theme, locale, browser, and form factor.
 
-The wdio-visual-regression-service should be installed as a dev-dependency:
+To generate screenshots use the [Terra.validates.screenshot](../about#terravalidatesscreenshot) and [Terra.validates.element](../about#terravalidateselement) utility commands.
 
-```sh
-$ npm install @cerner/terra-functional-testing --save-dev
+## Reference Screenshots
+
+Reference screenshots are stable screenshots that will be used to compare future screenshots. If a reference screenshot doesn't exist a new one will be generated on the next test run.
+
+## Latest Screenshots
+
+Latest screenshots are the screenshots generated on the most recent test run. Latest screenshots are not checked into source control, but can be used to troubleshoot differences between latest and reference.
+
+## Diff Screenshots
+
+Diff screenshots are generated when the latest screenshot is different than the reference screenshot. The diff screenshots overlay the reference and latest screenshots to provide visual indication of the differences. Differences will be shaded with a pink color.
+
+## Example Structure
+
 ```
-
-## Configuration
-Setup wdio-visual-regression-service by adding `visual-regression` to the service section of your WebdriverIO config and define your desired comparison strategy in the service options.
-
-```js
-// wdio.conf.js
-
-var path = require('path');
-var VisualRegressionCompare = require('@cerner/terra-functional-testing/lib/services/wdio-visual-regression-service/compare');
-
-exports.config = {
-  // ...
-  services: [
-    [
-      'visual-regression',
-      {
-        locale: 'en',
-        theme: 'terra-default-theme',
-      }
-    ]
-  ],
-  // ...
-};
+├── __snapshots__
+│   ├── diff
+│   │   └── terra-default-theme
+│   │       └── en
+│   │           ├── chrome_small
+│   │           │   └── terra-example-spec
+│   │           │       └── example-screenshot.png
+│   │           └── firefox_small
+│   │               └── terra-example-spec
+│   │                   └── example-screenshot.png
+│   ├── latest
+│   │   └── terra-default-theme
+│   │       ├── en
+│   │       │   ├── chrome_large
+│   │       │   │   └── terra-example-spec
+│   │       │   │       └── example-screenshot.png
+│   │       │   ├── chrome_small
+│   │       │   │   └── terra-example-spec
+│   │       │   │       └── example-screenshot.png
+│   │       │   ├── firefox_large
+│   │       │   │   └── terra-example-spec
+│   │       │   │       └── example-screenshot.png
+│   │       │   └── firefox_small
+│   │       │       └── terra-example-spec
+│   │       │           └── example-screenshot.png
+│   │       └── fr
+│   │           ├── chrome_large
+│   │           │   └── terra-example-spec
+│   │           │       └── example-screenshot.png
+│   │           ├── chrome_small
+│   │           │   └── terra-example-spec
+│   │           │       └── example-screenshot.png
+│   │           ├── firefox_large
+│   │           │   └── terra-example-spec
+│   │           │       └── example-screenshot.png
+│   │           └── firefox_small
+│   │               └── terra-example-spec
+│   │                   └── example-screenshot.png
+│   └── reference
+│       └── terra-default-theme
+│           ├── en
+│           │   ├── chrome_large
+│           │   │   └── terra-example-spec
+│           │   │       └── example-screenshot.png
+│           │   ├── chrome_small
+│           │   │   └── terra-example-spec
+│           │   │       └── example-screenshot.png
+│           │   ├── firefox_large
+│           │   │   └── terra-example-spec
+│           │   │       └── example-screenshot.png
+│           │   └── firefox_small
+│           │       └── terra-example-spec
+│           │           └── example-screenshot.png
+│           └── fr
+│               ├── chrome_large
+│               │   └── terra-example-spec
+│               │       └── example-screenshot.png
+│               ├── chrome_small
+│               │   └── terra-example-spec
+│               │       └── example-screenshot.png
+│               ├── firefox_large
+│               │   └── terra-example-spec
+│               │       └── example-screenshot.png
+│               └── firefox_small
+│                   └── terra-example-spec
+│                       └── example-screenshot.png
 ```
-
-### Options
-Under the key `visualRegression` in your wdio.config.js you can pass a configuration object with the following structure:
-
-* **locale** `String` ( default: 'en' ) <br />
-the locale the test runner is testing against. This is used to categorizes screenshots by locale.
-
-* **theme** `String` ( default: 'terra-default-theme' ) <br />
-the theme the test runner is testing against. This is used to categorizes screenshots by theme.
-
-### Compare Methods
-wdio-visual-regression-service allows the usage of different screenshot comparison methods.
-
-#### VisualRegressionCompare.LocalCompare
-The *LocalCompare* method captures screenshots on your computer and compares a reference screenshot against the latest (current) screenshots captured in the test run. If a mismatch occurs, a diff screenshot will be outputed. This is the compare method used by the VisualRegressionService.
-
-The screenshot naming pattern is as follows:
-
-```js
-base_directory/test_spec_directory/test_spec_name/__snapshots__/(reference|latest|diff)/theme/locale/browserName_terraViewportName/screenshot.png
-```
-
-You can pass the following options to it's constructor as object:
-
-* **locale** `String` ( default: 'en' ) <br />
-the locale the test runner is testing against. This is used to categorize screenshots by locale.
-
-* **theme** `String` ( default: 'terra-default-theme' ) <br />
-the theme the test runner is testing against. This is used to categorize screenshots by theme.
-
-For an example of generating screenshot filenames dependent on the current test name, have a look at the sample code of [Configuration](#configuration).
-
-#### VisualRegressionCompare.SaveScreenshot
-This method is a stripped variant of `VisualRegressionCompare.LocalCompare` to capture only screenshots. This is quite useful when you just want to create reference screenshots and overwrite the previous one without diffing.
-
-You can pass the following options to it's constructor as object:
-
-* **screenshotName** `Function` <br />
-pass in a function that returns the filename for the current screenshot. Function receives a *context* object as first parameter with all relevant information about the command.
-
-## Usage
-wdio-visual-regression-service enhances a WebdriverIO instance with the following commands:
-* `browser.checkElement(elementSelector, {options});`
-
-All of these provide options that will help you to capture screenshots in different dimensions or to exclude irrelevant parts (e.g. content). The following options are
-available:
-
-* **hide** `Object[]`<br />
-  hides all elements queried by all kinds of different [WebdriverIO selector strategies](https://v6.webdriver.io/docs/selectors.html) (via `visibility: hidden`)
-
-* **remove** `Object[]`<br />
-  removes all elements queried by all kinds of different [WebdriverIO selector strategies](https://v6.webdriver.io/docs/selectors.html) (via `display: none`)
-
-* **mismatchTolerance** `Number` <br />
-    Overrides the global *mismatchTolerance* value for this command. Pass in a number between 0 and 100 that defines the degree of mismatch to consider two images as identical.
-
-* **ignoreComparison** `String` <br />
-    Overrides the global *ignoreComparison* value for this command. Pass in a string with value of `nothing` , `colors` or `antialiasing` to adjust the comparison method.


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

This PR updates the terra-functional-testing documentation by cleaning documentation, adding missing documentation, and removing non-modifiable implementation details.

This PR also adds a default export for terra-functional-testing to create a shorter import for overriding the wdio config.

The new import looks like this:

```js
const { config } = require('@cerner/terra-functional-testing');
```

To see the rendered documentation in the dev site the deployment link is here:

https://terra-toolki-issue-595--jc4iyb.herokuapp.com/dev_tools/terra-toolkit-docs/terra-functional-testing/about

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

Resolves #595 

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
