### PR TITLE
[terra-functional-testing] Clear Screenshots

### DIFF
--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * The `diff`, `error`, and `latest` folders in the `__snapshots__` directory will be deleted before each test run.  
+
 ## 1.1.0 - (April 13, 2021)
 
 * Added

--- a/packages/terra-functional-testing/package.json
+++ b/packages/terra-functional-testing/package.json
@@ -57,6 +57,7 @@
     "expect": "^26.4.2",
     "express": "^4.17.1",
     "fs-extra": "^9.0.1",
+    "glob": "^7.1.6",
     "gm": "^1.23.1",
     "image-size": "^0.8.3",
     "ip": "^1.1.5",
@@ -82,7 +83,6 @@
   "devDependencies": {
     "@cerner/terra-cli": "^1.6.0",
     "chai": "^4.2.0",
-    "glob": "^7.1.6",
     "lodash.groupby": "^4.6.0",
     "lodash.map": "^4.6.0",
     "lodash.mapkeys": "^4.6.0",

--- a/packages/terra-functional-testing/src/commands/utils/cleanScreenshots.js
+++ b/packages/terra-functional-testing/src/commands/utils/cleanScreenshots.js
@@ -13,6 +13,7 @@ async function cleanScreenshots() {
   const isMonoRepo = fs.existsSync(monoRepoPath);
   let patterns = [];
 
+  // Check whether or not it a monorepo and then get the paths to the snapshot directories.
   if (isMonoRepo) {
     const packageNames = fs.readdirSync(monoRepoPath);
 
@@ -29,11 +30,12 @@ async function cleanScreenshots() {
     ];
   }
 
-  let screenshotDirectories = [];
-  patterns.forEach((pattern) => {
-    screenshotDirectories = screenshotDirectories.concat(glob.sync(pattern));
-  });
+  // Determine the existing snapshot directories.
+  const screenshotDirectories = patterns.filter((pattern) => (
+    glob.sync(pattern).length > 0
+  ));
 
+  // Delete the existing snapshot directories.
   screenshotDirectories.forEach((dir) => {
     if (isDirectory(dir)) {
       fs.removeSync(dir);

--- a/packages/terra-functional-testing/src/commands/utils/cleanScreenshots.js
+++ b/packages/terra-functional-testing/src/commands/utils/cleanScreenshots.js
@@ -1,0 +1,46 @@
+const fs = require('fs-extra');
+const glob = require('glob');
+const path = require('path');
+const { Logger } = require('@cerner/terra-cli');
+
+const logger = new Logger({ prefix: '[terra-functional-testing:clean-snapshots]' });
+
+// eslint-disable-next-line global-require, import/no-dynamic-require
+const isDirectory = filePath => (fs.existsSync(filePath) && fs.lstatSync(filePath).isDirectory());
+
+async function cleanScreenshots() {
+  const monoRepoPath = path.resolve(process.cwd(), 'packages');
+  const isMonoRepo = fs.existsSync(monoRepoPath);
+  let patterns = [];
+
+  if (isMonoRepo) {
+    const packageNames = fs.readdirSync(monoRepoPath);
+
+    packageNames.forEach((packageName) => {
+      patterns.push(path.resolve(monoRepoPath, packageName, 'tests', 'wdio', '__snapshots__', 'diff'));
+      patterns.push(path.resolve(monoRepoPath, packageName, 'tests', 'wdio', '__snapshots__', 'error'));
+      patterns.push(path.resolve(monoRepoPath, packageName, 'tests', 'wdio', '__snapshots__', 'latest'));
+    });
+  } else {
+    patterns = [
+      `${process.cwd()}/tests/wdio/__snapshots__/diff`,
+      `${process.cwd()}/tests/wdio/__snapshots__/error`,
+      `${process.cwd()}/tests/wdio/__snapshots__/latest`,
+    ];
+  }
+
+  let screenshotDirectories = [];
+  patterns.forEach((pattern) => {
+    screenshotDirectories = screenshotDirectories.concat(glob.sync(pattern));
+  });
+
+  screenshotDirectories.forEach((dir) => {
+    if (isDirectory(dir)) {
+      fs.removeSync(dir);
+    }
+  });
+
+  logger.info('Cleaned wdio snapshots directories.');
+}
+
+module.exports = cleanScreenshots;

--- a/packages/terra-functional-testing/src/commands/utils/index.js
+++ b/packages/terra-functional-testing/src/commands/utils/index.js
@@ -1,13 +1,17 @@
+const cleanScreenshots = require('./cleanScreenshots');
 const describeTests = require('./describeTests');
 const describeViewports = require('./describeViewports');
+const dispatchCustomEvent = require('./dispatchCustomEvent');
 const getViewports = require('./getViewports');
 const hideInputCaret = require('./hideInputCaret');
 const setApplicationLocale = require('./setApplicationLocale');
 const setViewport = require('./setViewport');
 
 module.exports = {
+  cleanScreenshots,
   describeTests,
   describeViewports,
+  dispatchCustomEvent,
   getViewports,
   hideInputCaret,
   setApplicationLocale,

--- a/packages/terra-functional-testing/src/terra-cli/wdio/test-runner.js
+++ b/packages/terra-functional-testing/src/terra-cli/wdio/test-runner.js
@@ -3,7 +3,7 @@ const path = require('path');
 const Launcher = require('@wdio/cli').default;
 const { Logger } = require('@cerner/terra-cli');
 const getConfigurationOptions = require('../../config/utils/getConfigurationOptions');
-const cleanScreenshots = require('../../commands/utils/cleanScreenshots');
+const { cleanScreenshots } = require('../../commands/utils');
 
 const logger = new Logger({ prefix: '[terra-functional-testing:wdio]' });
 

--- a/packages/terra-functional-testing/src/terra-cli/wdio/test-runner.js
+++ b/packages/terra-functional-testing/src/terra-cli/wdio/test-runner.js
@@ -3,6 +3,7 @@ const path = require('path');
 const Launcher = require('@wdio/cli').default;
 const { Logger } = require('@cerner/terra-cli');
 const getConfigurationOptions = require('../../config/utils/getConfigurationOptions');
+const cleanScreenshots = require('../../commands/utils/cleanScreenshots');
 
 const logger = new Logger({ prefix: '[terra-functional-testing:wdio]' });
 
@@ -93,6 +94,9 @@ class TestRunner {
       themes,
       ...cliOptions
     } = options;
+
+    // Clean only the non reference screenshots.
+    cleanScreenshots();
 
     /**
      * The following code loops through each permutation of theme, locale, and form factor.

--- a/packages/terra-functional-testing/tests/jest/commands/utils/cleanScreenshots.test.js
+++ b/packages/terra-functional-testing/tests/jest/commands/utils/cleanScreenshots.test.js
@@ -1,7 +1,7 @@
 const fs = require('fs-extra');
 const glob = require('glob');
 const path = require('path');
-const cleanScreenshots = require('../../../../src/commands/utils/cleanScreenshots');
+const { cleanScreenshots } = require('../../../../src/commands/utils');
 
 jest.mock('@cerner/terra-cli/lib/utils/Logger');
 jest.mock('fs-extra');
@@ -22,39 +22,46 @@ describe('cleanScreenshots', () => {
   });
 
   it('should clean screenshots for monorepo project', () => {
-    jest.spyOn(path, 'resolve').mockImplementation(() => 'terra-toolkit/packages');
+    const mockPath = 'terra-toolkit/packages';
+    jest.spyOn(path, 'resolve').mockImplementation(() => mockPath);
     jest.spyOn(fs, 'existsSync').mockImplementation(() => true);
     jest.spyOn(fs, 'readdirSync').mockImplementationOnce(() => ['terra-functional-testing']);
-    jest.spyOn(glob, 'sync').mockImplementation(() => 'latest');
+    jest.spyOn(glob, 'sync').mockImplementation(() => ['latest']);
     jest.spyOn(fs, 'lstatSync').mockImplementation(() => ({ isDirectory: () => true }));
     jest.spyOn(fs, 'removeSync').mockImplementationOnce(() => { });
 
     cleanScreenshots();
 
     expect(path.resolve).toHaveBeenCalledWith(process.cwd(), 'packages');
-    expect(fs.existsSync).toHaveBeenCalledWith('terra-toolkit/packages');
-    expect(fs.readdirSync).toHaveBeenCalledWith('terra-toolkit/packages');
-    expect(fs.lstatSync).toHaveBeenCalledWith('latest');
-    expect(fs.removeSync).toHaveBeenCalledWith('latest');
-    expect(glob.sync).toHaveBeenCalledWith('terra-toolkit/packages');
+    expect(fs.existsSync).toHaveBeenCalledWith(mockPath);
+    expect(fs.readdirSync).toHaveBeenCalledWith(mockPath);
+    expect(glob.sync).toHaveBeenCalledWith(mockPath);
+    expect(fs.lstatSync).toHaveBeenCalledWith(mockPath);
+    expect(fs.removeSync).toHaveBeenCalledWith(mockPath);
   });
 
   it('should clean screenshots for non-monorepo project', () => {
-    jest.spyOn(path, 'resolve').mockImplementation(() => 'terra-toolkit/packages');
+    const mockPath = 'terra-toolkit/packages';
+    const cwd = process.cwd();
+    jest.spyOn(path, 'resolve').mockImplementation(() => mockPath);
     jest.spyOn(fs, 'existsSync').mockImplementationOnce(() => false);
-    jest.spyOn(fs, 'existsSync').mockImplementationOnce(() => true);
-    jest.spyOn(fs, 'readdirSync').mockImplementationOnce(() => {});
-    jest.spyOn(glob, 'sync').mockImplementation(() => 'latest');
+    jest.spyOn(fs, 'existsSync').mockImplementation(() => true);
+    jest.spyOn(glob, 'sync').mockImplementation(() => ['latest']);
     jest.spyOn(fs, 'lstatSync').mockImplementation(() => ({ isDirectory: () => true }));
-    jest.spyOn(fs, 'removeSync').mockImplementationOnce(() => { });
+    jest.spyOn(fs, 'removeSync').mockImplementation(() => { });
 
     cleanScreenshots();
 
-    expect(path.resolve).toHaveBeenCalledWith(process.cwd(), 'packages');
-    expect(fs.existsSync).toHaveBeenCalledWith('terra-toolkit/packages');
-    expect(fs.readdirSync).not.toHaveBeenCalledWith();
-    expect(glob.sync).toHaveBeenCalledWith(`${process.cwd()}/tests/wdio/__snapshots__/diff`);
-    expect(fs.lstatSync).toHaveBeenCalledWith('latest');
-    expect(fs.removeSync).toHaveBeenCalledWith('latest');
+    expect(path.resolve).toHaveBeenCalledWith(cwd, 'packages');
+    expect(fs.existsSync).toHaveBeenCalledWith(mockPath);
+    expect(glob.sync).toHaveBeenNthCalledWith(1, `${cwd}/tests/wdio/__snapshots__/diff`);
+    expect(glob.sync).toHaveBeenNthCalledWith(2, `${cwd}/tests/wdio/__snapshots__/error`);
+    expect(glob.sync).toHaveBeenNthCalledWith(3, `${cwd}/tests/wdio/__snapshots__/latest`);
+    expect(fs.lstatSync).toHaveBeenNthCalledWith(1, `${cwd}/tests/wdio/__snapshots__/diff`);
+    expect(fs.lstatSync).toHaveBeenNthCalledWith(2, `${cwd}/tests/wdio/__snapshots__/error`);
+    expect(fs.lstatSync).toHaveBeenNthCalledWith(3, `${cwd}/tests/wdio/__snapshots__/latest`);
+    expect(fs.removeSync).toHaveBeenNthCalledWith(1, `${cwd}/tests/wdio/__snapshots__/diff`);
+    expect(fs.removeSync).toHaveBeenNthCalledWith(2, `${cwd}/tests/wdio/__snapshots__/error`);
+    expect(fs.removeSync).toHaveBeenNthCalledWith(3, `${cwd}/tests/wdio/__snapshots__/latest`);
   });
 });

--- a/packages/terra-functional-testing/tests/jest/commands/utils/cleanScreenshots.test.js
+++ b/packages/terra-functional-testing/tests/jest/commands/utils/cleanScreenshots.test.js
@@ -1,0 +1,60 @@
+const fs = require('fs-extra');
+const glob = require('glob');
+const path = require('path');
+const cleanScreenshots = require('../../../../src/commands/utils/cleanScreenshots');
+
+jest.mock('@cerner/terra-cli/lib/utils/Logger');
+jest.mock('fs-extra');
+jest.mock('glob');
+jest.mock('path');
+
+describe('cleanScreenshots', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should not clean directories when they dont exist', () => {
+    jest.spyOn(fs, 'removeSync').mockImplementationOnce(() => { });
+
+    cleanScreenshots();
+
+    expect(fs.removeSync).not.toHaveBeenCalled();
+  });
+
+  it('should clean screenshots for monorepo project', () => {
+    jest.spyOn(path, 'resolve').mockImplementation(() => 'terra-toolkit/packages');
+    jest.spyOn(fs, 'existsSync').mockImplementation(() => true);
+    jest.spyOn(fs, 'readdirSync').mockImplementationOnce(() => ['terra-functional-testing']);
+    jest.spyOn(glob, 'sync').mockImplementation(() => 'latest');
+    jest.spyOn(fs, 'lstatSync').mockImplementation(() => ({ isDirectory: () => true }));
+    jest.spyOn(fs, 'removeSync').mockImplementationOnce(() => { });
+
+    cleanScreenshots();
+
+    expect(path.resolve).toHaveBeenCalledWith(process.cwd(), 'packages');
+    expect(fs.existsSync).toHaveBeenCalledWith('terra-toolkit/packages');
+    expect(fs.readdirSync).toHaveBeenCalledWith('terra-toolkit/packages');
+    expect(fs.lstatSync).toHaveBeenCalledWith('latest');
+    expect(fs.removeSync).toHaveBeenCalledWith('latest');
+    expect(glob.sync).toHaveBeenCalledWith('terra-toolkit/packages');
+  });
+
+  it('should clean screenshots for non-monorepo project', () => {
+    jest.spyOn(path, 'resolve').mockImplementation(() => 'terra-toolkit/packages');
+    jest.spyOn(fs, 'existsSync').mockImplementationOnce(() => false);
+    jest.spyOn(fs, 'existsSync').mockImplementationOnce(() => true);
+    jest.spyOn(fs, 'readdirSync').mockImplementationOnce(() => {});
+    jest.spyOn(glob, 'sync').mockImplementation(() => 'latest');
+    jest.spyOn(fs, 'lstatSync').mockImplementation(() => ({ isDirectory: () => true }));
+    jest.spyOn(fs, 'removeSync').mockImplementationOnce(() => { });
+
+    cleanScreenshots();
+
+    expect(path.resolve).toHaveBeenCalledWith(process.cwd(), 'packages');
+    expect(fs.existsSync).toHaveBeenCalledWith('terra-toolkit/packages');
+    expect(fs.readdirSync).not.toHaveBeenCalledWith();
+    expect(glob.sync).toHaveBeenCalledWith(`${process.cwd()}/tests/wdio/__snapshots__/diff`);
+    expect(fs.lstatSync).toHaveBeenCalledWith('latest');
+    expect(fs.removeSync).toHaveBeenCalledWith('latest');
+  });
+});

--- a/packages/terra-functional-testing/tests/jest/commands/utils/describeTests.test.js
+++ b/packages/terra-functional-testing/tests/jest/commands/utils/describeTests.test.js
@@ -1,5 +1,4 @@
-const describeViewports = require('../../../../src/commands/utils/describeViewports');
-const describeTests = require('../../../../src/commands/utils/describeTests');
+const { describeViewports, describeTests } = require('../../../../src/commands/utils');
 
 jest.mock('../../../../src/commands/utils/describeViewports');
 

--- a/packages/terra-functional-testing/tests/jest/commands/utils/describeViewports.test.js
+++ b/packages/terra-functional-testing/tests/jest/commands/utils/describeViewports.test.js
@@ -1,4 +1,4 @@
-const describeViewports = require('../../../../src/commands/utils/describeViewports');
+const { describeViewports } = require('../../../../src/commands/utils');
 
 describe('describeViewports', () => {
   it('should describe viewport', () => {

--- a/packages/terra-functional-testing/tests/jest/commands/utils/dispatchCustomEvent.test.js
+++ b/packages/terra-functional-testing/tests/jest/commands/utils/dispatchCustomEvent.test.js
@@ -1,4 +1,4 @@
-const dispatchCustomEvent = require('../../../../src/commands/utils/dispatchCustomEvent');
+const { dispatchCustomEvent } = require('../../../../src/commands/utils');
 
 describe('dispatchCustomEvent', () => {
   it('executes a specified function via browser.execute', () => {

--- a/packages/terra-functional-testing/tests/jest/commands/utils/getViewports.test.js
+++ b/packages/terra-functional-testing/tests/jest/commands/utils/getViewports.test.js
@@ -1,4 +1,4 @@
-const getViewports = require('../../../../src/commands/utils/getViewports');
+const { getViewports } = require('../../../../src/commands/utils');
 const { TERRA_VIEWPORTS } = require('../../../../src/constants');
 
 const {

--- a/packages/terra-functional-testing/tests/jest/commands/utils/hideInputCaret.test.js
+++ b/packages/terra-functional-testing/tests/jest/commands/utils/hideInputCaret.test.js
@@ -1,6 +1,6 @@
 jest.mock('@cerner/terra-cli/lib/utils/Logger');
 
-const hideInputCaret = require('../../../../src/commands/utils/hideInputCaret');
+const { hideInputCaret } = require('../../../../src/commands/utils');
 
 describe('hideInputCaret', () => {
   it('should hide caret on selector', () => {

--- a/packages/terra-functional-testing/tests/jest/commands/utils/index.test.js
+++ b/packages/terra-functional-testing/tests/jest/commands/utils/index.test.js
@@ -1,0 +1,23 @@
+const {
+  cleanScreenshots,
+  describeTests,
+  describeViewports,
+  dispatchCustomEvent,
+  getViewports,
+  hideInputCaret,
+  setApplicationLocale,
+  setViewport,
+} = require('../../../../src/commands/utils');
+
+describe('index', () => {
+  it('should export functions', () => {
+    expect(cleanScreenshots).toBeDefined();
+    expect(describeTests).toBeDefined();
+    expect(describeViewports).toBeDefined();
+    expect(dispatchCustomEvent).toBeDefined();
+    expect(getViewports).toBeDefined();
+    expect(hideInputCaret).toBeDefined();
+    expect(setApplicationLocale).toBeDefined();
+    expect(setViewport).toBeDefined();
+  });
+});

--- a/packages/terra-functional-testing/tests/jest/commands/utils/setLocale.test.js
+++ b/packages/terra-functional-testing/tests/jest/commands/utils/setLocale.test.js
@@ -1,5 +1,4 @@
-const setApplicationLocale = require('../../../../src/commands/utils/setApplicationLocale');
-const dispatchCustomEvent = require('../../../../src/commands/utils/dispatchCustomEvent');
+const { setApplicationLocale, dispatchCustomEvent } = require('../../../../src/commands/utils');
 
 jest.mock('../../../../src/commands/utils/dispatchCustomEvent');
 

--- a/packages/terra-functional-testing/tests/jest/commands/utils/setViewport.test.js
+++ b/packages/terra-functional-testing/tests/jest/commands/utils/setViewport.test.js
@@ -1,4 +1,4 @@
-const setViewport = require('../../../../src/commands/utils/setViewport');
+const { setViewport } = require('../../../../src/commands/utils');
 const { TERRA_VIEWPORTS } = require('../../../../src/constants');
 
 const mockSetWindowSize = jest.fn();

--- a/packages/terra-functional-testing/tests/jest/terra-cli/wdio/test-runner.test.js
+++ b/packages/terra-functional-testing/tests/jest/terra-cli/wdio/test-runner.test.js
@@ -1,10 +1,12 @@
 jest.mock('@cerner/terra-cli/lib/utils/Logger');
+jest.mock('../../../../src/commands/utils/cleanScreenshots');
 
 const fs = require('fs');
 const path = require('path');
 const Launcher = require('@wdio/cli').default;
 const TestRunner = require('../../../../src/terra-cli/wdio/test-runner');
 const getConfigurationOptions = require('../../../../src/config/utils/getConfigurationOptions');
+const cleanScreenshots = require('../../../../src/commands/utils/cleanScreenshots');
 
 jest.mock('@wdio/cli', () => ({
   default: jest.fn().mockImplementation(() => ({ run: () => Promise.resolve(0) })),
@@ -115,6 +117,7 @@ describe('Test Runner', () => {
       expect(TestRunner.run).toHaveBeenCalledWith({
         config: '/path', theme: 'terra-mock-theme', locale: 'fr',
       });
+      expect(cleanScreenshots).toHaveBeenCalled();
     });
 
     it('should initiate a test runner for each theme, locale, and form factor permutation', async () => {

--- a/packages/terra-functional-testing/tests/wdio/dispatch-custom-event-spec.js
+++ b/packages/terra-functional-testing/tests/wdio/dispatch-custom-event-spec.js
@@ -1,4 +1,4 @@
-const dispatchCustomEvent = require('../../src/commands/utils/dispatchCustomEvent');
+const { dispatchCustomEvent } = require('../../src/commands/utils');
 
 describe('dispatchCustomEvent', () => {
   it('sends a custom event that injects a string into a paragraph', () => {

--- a/packages/terra-functional-testing/tests/wdio/terra-describe-tests-spec.js
+++ b/packages/terra-functional-testing/tests/wdio/terra-describe-tests-spec.js
@@ -1,4 +1,4 @@
-Terra.describeTests('Terra.describeTests', { formFactors: ['small', 'large'], locales: ['en', 'fr'], themes: ['terra-default-theme', 'orion-fusion-theme'] }, () => {
+Terra.describeTests('Terra.describeTests', { formFactors: ['small', 'huge'], locales: ['en', 'fr'], themes: ['terra-default-theme', 'orion-fusion-theme'] }, () => {
   it('should filter test by formFactors, locales, and themes', () => {
     browser.url('/accessible.html');
     Terra.validates.accessibility();

--- a/packages/terra-toolkit-docs/CHANGELOG.md
+++ b/packages/terra-toolkit-docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Updated terra-functional-testing doc for cleaning snapshots
+
 ## 1.9.0 - (April 13, 2021)
 
 * Changed

--- a/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/About.1.tool.mdx
+++ b/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/About.1.tool.mdx
@@ -73,7 +73,9 @@ Chrome is enabled by default when running locally against the docker container.
 To target a list of browsers that are different than the default use the `browsers` cli option:
 
 <Notice variant="important" ariaLevel="3">
+
   Internet Explorer can only be enabled when running against a remote selenium grid. Internet Explorer is not available within the docker container.
+
 </Notice>
 
 ```json
@@ -85,7 +87,9 @@ To target a list of browsers that are different than the default use the `browse
 To run against a remote selenium grid:
 
 <Notice variant="important" ariaLevel="3">
+
   Chrome, Firefox, and Internet Explorer are all enabled by default when running against a remote selenium grid.
+
 </Notice>
 
 ```json
@@ -110,7 +114,9 @@ Tests can be executed in the following form factors:
 To specify a list of form factors use the cli option:
 
 <Notice variant="important" ariaLevel="3">
+
   If no form factor is specified all tests will be run against the huge form factor.
+
 </Notice>
 
 ```json
@@ -150,7 +156,9 @@ Required: `false`
 Default: `[data-terra-test-content] *:first-child`
 
 <Notice variant="important" ariaLevel="4">
+
   This selector is used as the default screenshot selector for Terra.validates.element and Terra.validates.screenshot.
+
 </Notice>
 
 ```js
@@ -174,7 +182,9 @@ Required: `false`
 Default: `3.14.0-helium`
 
 <Notice variant="caution" ariaLevel="4">
+
   The selenium version is only applied when running tests against a docker container. This option does not change the version on a remote selenium grid. Keep this in mind if your tests run against a remote selenium grid on a CI system.
+
 </Notice>
 
 ```js
@@ -198,7 +208,9 @@ The describe helpers are an alias for the top level `describe` block used within
 #### Terra.describeViewports
 
 <Notice variant="important" ariaLevel="5">
+
   We recommended using Terra.describeTests instead of Terra.describeViewports. The same features in Terra.describeViewports can be achieved with Terra.describeTests.
+
 </Notice>
 
 The `Terra.describeViewports` utility defines a list of form factors the tests are enabled for. By default, all tests will be run against each provided viewport. If a form factor is specified via the cli the describe viewpoint helper works as a filter and only allows the tests to execute if they match the current form factor.
@@ -214,7 +226,9 @@ Terra.describeViewports(title, [viewports], fn);
 ```
 
 <Notice variant="caution" ariaLevel="5">
+
   Describe helpers should not be nested within other describe helpers.
+
 </Notice>
 
 ```js
@@ -259,7 +273,9 @@ Terra.describeTests(title, options, fn);
 The following tests will only be ran for the locales, themes, and form factors provided:
 
 <Notice variant="caution" ariaLevel="5">
+
   The describe helper should not be nested inside of another describe helper.
+
 </Notice>
 
 ```js
@@ -284,7 +300,9 @@ The testing library integrates [axe-core](https://github.com/dequelabs/axe-core)
 Axe will analyze the entire document when run and report accessibility violations. The following [tags](https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#axe-core-tags) are enabled: `wcag2a`, `wcag2aa`, `wcag21aa`, and `section508`. Each tag has an associated list of [rules](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md) that will be checked against the document when axe is run.
 
 <Notice variant="important" ariaLevel="4">
+
   Please note that not all accessibility testing can be automated. Axe provides a lightweight static analysis of the entire document to catch common accessibility violations, but it is the responsibility of each team and application to do thorough accessibility and functional testing manually when necessary.
+
 </Notice>
 
 #### Terra.validates.accessibility

--- a/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/upgrade-guides.5/version-1-upgrade-guide.1.tool.md
+++ b/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/upgrade-guides.5/version-1-upgrade-guide.1.tool.md
@@ -277,12 +277,13 @@ Update any references to the old terra-aggregate-translations:
 + const aggregateTranslations = require('@cerner/terra-aggregate-translations');
 ```
 
-Update any scripts in the package.json to use webpack-dev-server. Use terra-cli for any static sites. Remove `terra-aggregate-translations` if installed:
+Update any scripts in the package.json to use webpack-dev-server. Use terra-cli for any static sites. Remove any reference to `tt-clean-screenshots` since cleaning the `diff`, `latest`, and `error` screenshot directories is now executed automaticatically for each test run. Remove `terra-aggregate-translations` if installed:
 
 ```diff
 // package.json
 {
   "scripts": {
+-    "clean:obsolete-wdio-snapshots": "tt-clean-screenshots",
 -    "start": "tt-serve",
 -    "start-prod": "tt-serve --env.disableHotReloading -p",
 -    "start-static": "npm run pack && tt-serve-static",

--- a/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/wdio-services.4/SeleniumDockerService.tool.mdx
+++ b/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/wdio-services.4/SeleniumDockerService.tool.mdx
@@ -23,7 +23,9 @@ Default: `false`
 Example:
 
 <Notice variant="important" ariaLevel="3">
+
   The selenium docker service is disabled automatically by the test runner if a remote selenium grid is specified.
+
 </Notice>
 
 ```js

--- a/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/wdio-services.4/VisualRegressionService.tool.mdx
+++ b/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/wdio-services.4/VisualRegressionService.tool.mdx
@@ -1,3 +1,5 @@
+import { Notice } from '@cerner/terra-docs';
+
 # Visual Regression Service
 
 Visual regression testing for WebdriverIO.
@@ -20,6 +22,16 @@ Latest screenshots are the screenshots generated on the most recent test run. La
 
 Diff screenshots are generated when the latest screenshot is different than the reference screenshot. The diff screenshots overlay the reference and latest screenshots to provide visual indication of the differences. Differences will be shaded with a pink color.
 
+## Error Screenshots
+
+Error screenshots are generated when an error occurs that results in a test failure. The error screenshot is captured immediately after the test step when the error occurred. The error screenshot is named using the title of the `describe` block concatenated with the title of the `it` block.
+
+<Notice variant="important" ariaLevel="3">
+
+  All screenshots in the `diff`, `error`, `latest` screenshot folders, if they exist, will be deleted before each test run. The `reference` screenshot folder will not be deleted.
+
+</Notice>
+
 ## Example Structure
 
 ```
@@ -33,6 +45,12 @@ Diff screenshots are generated when the latest screenshot is different than the 
 │   │           └── firefox_small
 │   │               └── terra-example-spec
 │   │                   └── example-screenshot.png
+│   ├── error
+│   │   └── terra-default-theme
+│   │       └── en
+│   │           └── chrome_small
+│   │               └── terra-example-spec
+│   │                   └── test-title.png
 │   ├── latest
 │   │   └── terra-default-theme
 │   │       ├── en


### PR DESCRIPTION
### Summary
Deletes the `diff`, `error`, and `latest` screenshot directories, if they exist, before each wdio test run.

Closes #620 

### Additional Details

- The [cleanScreenshots.js](https://github.com/cerner/terra-toolkit/blob/clear-snapshots/packages/terra-functional-testing/src/commands/utils/cleanScreenshots.js) is mostly copied from [clean-screenshots.js](https://github.com/cerner/terra-toolkit-boneyard/blob/main/scripts/wdio/clean-screenshots.js) in terra-toolkit-boneyard with a few tweaks added to look for the screenshots directories directly in the `tests/wdio` file path for both monorepo and non monorepo projects instead of searching in all directories including the node-modules folder.

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
