### PR TITLE
Add back "strict" to the CLI API but only for commands. Options aren't validated, but commands are.

### DIFF
--- a/packages/terra-cli/CHANGELOG.md
+++ b/packages/terra-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Add back "strict" to the CLI API but only for commands. Options aren't validated, but commands are.
+
 ## 1.6.0 - (February 25, 2021)
 
 * Changed

--- a/packages/terra-cli/index.js
+++ b/packages/terra-cli/index.js
@@ -15,6 +15,7 @@ const setupCLI = () => {
   const cli = yargs();
 
   return cli.usage('Usage: $0 <command> [options]')
+    .strictCommands()
     .demandCommand(1, 'A command is required. Pass --help to see all available commands and options.')
     .recommendCommands()
     .fail((msg, err) => {


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

Add back "strict" to the CLI API but only for commands. Options aren't validated, but commands are.

Fixes #630 