### PR TITLE
[eslint-config-terra] Add `FullStack` to globals for usage in full stack testing

### DIFF
--- a/packages/eslint-config-terra/CHANGELOG.md
+++ b/packages/eslint-config-terra/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Added `FullStack` to globals for usage in full stack testing
+
 ## 5.0.0 - (February 16, 2021)
 
 * Breaking

--- a/packages/eslint-config-terra/eslint.config.js
+++ b/packages/eslint-config-terra/eslint.config.js
@@ -75,6 +75,7 @@ module.exports = {
         after: true,
         before: true,
         browser: true,
+        FullStack: true,
         Terra: true,
         $: true,
       },


### PR DESCRIPTION
### Summary
Add `FullStack` to globals for usage in full stack testing so developers do not get a lint warning when using it for full stack tests.

Closes #639 

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
