### PR TITLE
[terra-functional-testing] Updated specPath in BaseCompare.

### DIFF
--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Updated
-  * Update specPath in BaseCompare to replace `node_modules` with `test/wdio/__snapshot__`
+  * Update specPath in BaseCompare to replace `node_modules` with `tests/wdio/__snapshot__`
 
 ## 1.2.0 - (April 23, 2021)
 

--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Updated
+* Fixed
   * Update specPath in BaseCompare to replace `node_modules` with `tests/wdio/__snapshot__`
 
 ## 1.2.0 - (April 23, 2021)

--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated
+  * Update specPath in BaseCompare to replace `node_modules` with `test/wdio/__snapshot__`
+
 ## 1.2.0 - (April 23, 2021)
 
 * Added

--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Fixed
-  * Update specPath in BaseCompare to replace `node_modules` with `tests/wdio/__snapshot__`
+  * Update specPath in BaseCompare to replace `node_modules` with `tests/wdio`.
 
 ## 1.2.0 - (April 23, 2021)
 

--- a/packages/terra-functional-testing/src/services/wdio-visual-regression-service/methods/BaseCompare.js
+++ b/packages/terra-functional-testing/src/services/wdio-visual-regression-service/methods/BaseCompare.js
@@ -105,7 +105,7 @@ class BaseCompare {
 
     // Added to allow for test reusability from terra repositories
     if (specPath.includes('node_modules')) {
-      specPath = specPath.replace('node_modules', path.join('tests', 'wdio', '__snapshots__'));
+      specPath = specPath.replace('node_modules', path.join('tests', 'wdio'));
     }
 
     const baseScreenshotPath = path.join(this.baseScreenshotDir, specPath, '__snapshots__');

--- a/packages/terra-functional-testing/src/services/wdio-visual-regression-service/methods/BaseCompare.js
+++ b/packages/terra-functional-testing/src/services/wdio-visual-regression-service/methods/BaseCompare.js
@@ -105,7 +105,7 @@ class BaseCompare {
 
     // Added to allow for test reusability from terra repositories
     if (specPath.includes('node_modules')) {
-      specPath = specPath.replace('node_modules', 'tests/wdio/__snapshots__');
+      specPath = specPath.replace('node_modules', path.join('tests', 'wdio', '__snapshots__'));
     }
 
     const baseScreenshotPath = path.join(this.baseScreenshotDir, specPath, '__snapshots__');

--- a/packages/terra-functional-testing/src/services/wdio-visual-regression-service/methods/BaseCompare.js
+++ b/packages/terra-functional-testing/src/services/wdio-visual-regression-service/methods/BaseCompare.js
@@ -105,7 +105,7 @@ class BaseCompare {
 
     // Added to allow for test reusability from terra repositories
     if (specPath.includes('node_modules')) {
-      specPath = specPath.replace('node_modules', 'test/wdio/__snapshots__');
+      specPath = specPath.replace('node_modules', 'tests/wdio/__snapshots__');
     }
 
     const baseScreenshotPath = path.join(this.baseScreenshotDir, specPath, '__snapshots__');

--- a/packages/terra-functional-testing/src/services/wdio-visual-regression-service/methods/BaseCompare.js
+++ b/packages/terra-functional-testing/src/services/wdio-visual-regression-service/methods/BaseCompare.js
@@ -105,7 +105,7 @@ class BaseCompare {
 
     // Added to allow for test reusability from terra repositories
     if (specPath.includes('node_modules')) {
-      [, specPath] = specPath.split('node_modules');
+      specPath = specPath.replace('node_modules', 'test/wdio/__snapshots__');
     }
 
     const baseScreenshotPath = path.join(this.baseScreenshotDir, specPath, '__snapshots__');

--- a/packages/terra-functional-testing/tests/jest/services/wdio-visual-regression-service/methods/BaseCompare.test.js
+++ b/packages/terra-functional-testing/tests/jest/services/wdio-visual-regression-service/methods/BaseCompare.test.js
@@ -115,13 +115,13 @@ describe('BaseCompare', () => {
         ...context,
         test: {
           ...context.test,
-          file: path.join(process.cwd(), 'node_modules', 'test', 'wdio', 'test-spec.js'),
+          file: path.join(process.cwd(), 'node_modules', 'packageName', 'test', 'wdio', 'test-spec.js'),
         },
       };
       const result = baseCompare.getScreenshotPaths(updatedContext);
-      expect(result.referencePath).toEqual(path.join(process.cwd(), 'test', 'wdio', '__snapshots__', 'reference', 'screenshotDir', 'screenshotName.png'));
-      expect(result.latestPath).toEqual(path.join(process.cwd(), 'test', 'wdio', '__snapshots__', 'latest', 'screenshotDir', 'screenshotName.png'));
-      expect(result.diffPath).toEqual(path.join(process.cwd(), 'test', 'wdio', '__snapshots__', 'diff', 'screenshotDir', 'screenshotName.png'));
+      expect(result.referencePath).toEqual(path.join(process.cwd(), 'tests', 'wdio', '__snapshots__', 'packageName', 'test', 'wdio', '__snapshots__', 'reference', 'screenshotDir', 'screenshotName.png'));
+      expect(result.latestPath).toEqual(path.join(process.cwd(), 'tests', 'wdio', '__snapshots__', 'packageName', 'test', 'wdio', '__snapshots__', 'latest', 'screenshotDir', 'screenshotName.png'));
+      expect(result.diffPath).toEqual(path.join(process.cwd(), 'tests', 'wdio', '__snapshots__', 'packageName', 'test', 'wdio', '__snapshots__', 'diff', 'screenshotDir', 'screenshotName.png'));
     });
   });
 

--- a/packages/terra-functional-testing/tests/jest/services/wdio-visual-regression-service/methods/BaseCompare.test.js
+++ b/packages/terra-functional-testing/tests/jest/services/wdio-visual-regression-service/methods/BaseCompare.test.js
@@ -119,9 +119,9 @@ describe('BaseCompare', () => {
         },
       };
       const result = baseCompare.getScreenshotPaths(updatedContext);
-      expect(result.referencePath).toEqual(path.join(process.cwd(), 'tests', 'wdio', '__snapshots__', 'packageName', 'test', 'wdio', '__snapshots__', 'reference', 'screenshotDir', 'screenshotName.png'));
-      expect(result.latestPath).toEqual(path.join(process.cwd(), 'tests', 'wdio', '__snapshots__', 'packageName', 'test', 'wdio', '__snapshots__', 'latest', 'screenshotDir', 'screenshotName.png'));
-      expect(result.diffPath).toEqual(path.join(process.cwd(), 'tests', 'wdio', '__snapshots__', 'packageName', 'test', 'wdio', '__snapshots__', 'diff', 'screenshotDir', 'screenshotName.png'));
+      expect(result.referencePath).toEqual(path.join(process.cwd(), 'tests', 'wdio', 'packageName', 'test', 'wdio', '__snapshots__', 'reference', 'screenshotDir', 'screenshotName.png'));
+      expect(result.latestPath).toEqual(path.join(process.cwd(), 'tests', 'wdio', 'packageName', 'test', 'wdio', '__snapshots__', 'latest', 'screenshotDir', 'screenshotName.png'));
+      expect(result.diffPath).toEqual(path.join(process.cwd(), 'tests', 'wdio', 'packageName', 'test', 'wdio', '__snapshots__', 'diff', 'screenshotDir', 'screenshotName.png'));
     });
   });
 


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->
This PR replace `node_modules` in specPath in BaseCompare with `tests/wdio/__snapshots__`.

Closes #643 

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->
This is required as all the specs in clinical-theme are present in node_modules, And upgrading it to terra-functional-testing causes the snapshots to be created in the root directory.

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
