### PR TITLE
[terra-functional-testing] Add useSeleniumStandalonService option

### DIFF
--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Added useSeleniumStandalonService option for using the standalone-chrome host instead of the selenium docker service when building in Jenkins.
+
 ## 1.2.0 - (April 23, 2021)
 
 * Added

--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -6,7 +6,7 @@
   * Update specPath in BaseCompare to replace `node_modules` with `tests/wdio`.
 
 * Added
-  * Added useSeleniumStandalonService option for using the standalone-chrome host instead of the selenium docker service when building in Jenkins.
+  * Added useSeleniumStandaloneService option for using the standalone-chrome host instead of the selenium docker service when building in Jenkins.
 
 ## 1.2.0 - (April 23, 2021)
 

--- a/packages/terra-functional-testing/src/config/utils/getConfigurationOptions.js
+++ b/packages/terra-functional-testing/src/config/utils/getConfigurationOptions.js
@@ -22,15 +22,16 @@ const getConfigurationOptions = (options) => {
     suite,
     theme,
     updateScreenshots,
+    useSeleniumStandalonService,
   } = options;
 
   return {
     baseUrl: `http://${externalHost || getIpAddress()}:${externalPort || 8080}`,
     capabilities: getCapabilities(browsers, !!gridUrl),
-    hostname: gridUrl || 'localhost',
+    hostname: gridUrl || (useSeleniumStandalonService ? 'standalone-chrome' : 'localhost'),
     port: gridUrl ? 80 : 4444,
     launcherOptions: {
-      disableSeleniumService: disableSeleniumService || !!gridUrl,
+      disableSeleniumService: disableSeleniumService || useSeleniumStandalonService || !!gridUrl,
       formFactor,
       gridUrl,
       keepAliveSeleniumDockerService,

--- a/packages/terra-functional-testing/src/config/utils/getConfigurationOptions.js
+++ b/packages/terra-functional-testing/src/config/utils/getConfigurationOptions.js
@@ -22,16 +22,16 @@ const getConfigurationOptions = (options) => {
     suite,
     theme,
     updateScreenshots,
-    useSeleniumStandalonService,
+    useSeleniumStandaloneService,
   } = options;
 
   return {
     baseUrl: `http://${externalHost || getIpAddress()}:${externalPort || 8080}`,
     capabilities: getCapabilities(browsers, !!gridUrl),
-    hostname: gridUrl || (useSeleniumStandalonService ? 'standalone-chrome' : 'localhost'),
+    hostname: gridUrl || (useSeleniumStandaloneService ? 'standalone-chrome' : 'localhost'),
     port: gridUrl ? 80 : 4444,
     launcherOptions: {
-      disableSeleniumService: disableSeleniumService || useSeleniumStandalonService || !!gridUrl,
+      disableSeleniumService: disableSeleniumService || useSeleniumStandaloneService || !!gridUrl,
       formFactor,
       gridUrl,
       keepAliveSeleniumDockerService,

--- a/packages/terra-functional-testing/src/terra-cli/wdio/index.js
+++ b/packages/terra-functional-testing/src/terra-cli/wdio/index.js
@@ -146,7 +146,7 @@ const cli = {
       useSeleniumStandaloneService: {
         type: 'boolean',
         describe: 'A flag to use the selenium standalone service instead of the selenium docker service.',
-        default: () => process.env.USE_SELENIUM_STANDALONE_SERVICE === 'true',
+        default: process.env.USE_SELENIUM_STANDALONE_SERVICE === 'true',
       },
     })
   ),

--- a/packages/terra-functional-testing/src/terra-cli/wdio/index.js
+++ b/packages/terra-functional-testing/src/terra-cli/wdio/index.js
@@ -143,7 +143,7 @@ const cli = {
         describe: 'Whether or not to automatically update all reference screenshots with the latest screenshots.',
         default: false,
       },
-      useSeleniumStandalonService: {
+      useSeleniumStandaloneService: {
         type: 'boolean',
         describe: 'A flag to use the selenium standalone service instead of the selenium docker service.',
         default: () => process.env.USE_SELENIUM_STANDALONE_SERVICE === 'true',

--- a/packages/terra-functional-testing/src/terra-cli/wdio/index.js
+++ b/packages/terra-functional-testing/src/terra-cli/wdio/index.js
@@ -143,6 +143,11 @@ const cli = {
         describe: 'Whether or not to automatically update all reference screenshots with the latest screenshots.',
         default: false,
       },
+      useSeleniumStandalonService: {
+        type: 'boolean',
+        describe: 'A flag to use the selenium standalone service instead of the selenium docker service.',
+        default: () => process.env.USE_SELENIUM_STANDALONE_SERVICE === 'true',
+      },
     })
   ),
   handler: TestRunner.start,

--- a/packages/terra-functional-testing/src/terra-cli/wdio/test-runner.js
+++ b/packages/terra-functional-testing/src/terra-cli/wdio/test-runner.js
@@ -46,6 +46,7 @@ class TestRunner {
    * @param {array} options.suite - Overrides specs and runs only the defined suites.
    * @param {string} options.theme - A theme for the test run.
    * @param {boolean} options.updateScreenshots - Updates all reference screenshots with the latest screenshots.
+   * @param {boolean} options.useSeleniumStandalonService - A flag to use the selenium standalone service instead of the selenium docker service.
    * @returns {Promise} A promise that resolves with the test run exit code.
    */
   static async run(options) {
@@ -86,6 +87,7 @@ class TestRunner {
    * @param {array} options.suite - Overrides specs and runs only the defined suites.
    * @param {string} options.themes - A list of themes for the test run.
    * @param {boolean} options.updateScreenshots - Updates all reference screenshots with the latest screenshots.
+   * @param {boolean} options.useSeleniumStandalonService - A flag to use the selenium standalone service instead of the selenium docker service.
    */
   static async start(options) {
     const {

--- a/packages/terra-functional-testing/src/terra-cli/wdio/test-runner.js
+++ b/packages/terra-functional-testing/src/terra-cli/wdio/test-runner.js
@@ -46,7 +46,7 @@ class TestRunner {
    * @param {array} options.suite - Overrides specs and runs only the defined suites.
    * @param {string} options.theme - A theme for the test run.
    * @param {boolean} options.updateScreenshots - Updates all reference screenshots with the latest screenshots.
-   * @param {boolean} options.useSeleniumStandalonService - A flag to use the selenium standalone service instead of the selenium docker service.
+   * @param {boolean} options.useSeleniumStandaloneService - A flag to use the selenium standalone service instead of the selenium docker service.
    * @returns {Promise} A promise that resolves with the test run exit code.
    */
   static async run(options) {
@@ -87,7 +87,7 @@ class TestRunner {
    * @param {array} options.suite - Overrides specs and runs only the defined suites.
    * @param {string} options.themes - A list of themes for the test run.
    * @param {boolean} options.updateScreenshots - Updates all reference screenshots with the latest screenshots.
-   * @param {boolean} options.useSeleniumStandalonService - A flag to use the selenium standalone service instead of the selenium docker service.
+   * @param {boolean} options.useSeleniumStandaloneService - A flag to use the selenium standalone service instead of the selenium docker service.
    */
   static async start(options) {
     const {

--- a/packages/terra-functional-testing/tests/jest/config/utils/getConfigurationOptions.test.js
+++ b/packages/terra-functional-testing/tests/jest/config/utils/getConfigurationOptions.test.js
@@ -21,7 +21,7 @@ describe('getCapabilities', () => {
       suite: 'test-suite',
       theme: 'terra-default-theme',
       updateScreenshots: true,
-      useSeleniumStandalonService: false,
+      useSeleniumStandaloneService: false,
     };
 
     const defaultWebpackPath = path.resolve(process.cwd(), 'webpack.config.js');
@@ -54,7 +54,7 @@ describe('getCapabilities', () => {
     expect(config).toEqual(expectedConfig);
   });
 
-  it('should get configuration with useSeleniumStandalonService', async () => {
+  it('should get configuration with useSeleniumStandaloneService', async () => {
     const options = {
       assetServerPort: 8080,
       browsers: ['chrome'],
@@ -70,7 +70,7 @@ describe('getCapabilities', () => {
       suite: 'test-suite',
       theme: 'terra-default-theme',
       updateScreenshots: true,
-      useSeleniumStandalonService: true,
+      useSeleniumStandaloneService: true,
     };
 
     const defaultWebpackPath = path.resolve(process.cwd(), 'webpack.config.js');

--- a/packages/terra-functional-testing/tests/jest/config/utils/getConfigurationOptions.test.js
+++ b/packages/terra-functional-testing/tests/jest/config/utils/getConfigurationOptions.test.js
@@ -21,6 +21,7 @@ describe('getCapabilities', () => {
       suite: 'test-suite',
       theme: 'terra-default-theme',
       updateScreenshots: true,
+      useSeleniumStandalonService: false,
     };
 
     const defaultWebpackPath = path.resolve(process.cwd(), 'webpack.config.js');
@@ -37,6 +38,55 @@ describe('getCapabilities', () => {
         disableSeleniumService: true,
         formFactor: options.formFactor,
         gridUrl: options.gridUrl,
+        keepAliveSeleniumDockerService: true,
+        locale: options.locale,
+        port: options.assetServerPort,
+        site: options.site,
+        theme: options.theme,
+        overrideTheme: options.theme,
+        updateScreenshots: true,
+        webpackConfig: defaultWebpackPath,
+      },
+    };
+
+    const config = getConfigurationOptions(options);
+
+    expect(config).toEqual(expectedConfig);
+  });
+
+  it('should get configuration with useSeleniumStandalonService', async () => {
+    const options = {
+      assetServerPort: 8080,
+      browsers: ['chrome'],
+      config: '/path',
+      disableSeleniumService: false,
+      externalHost: 'externalHost',
+      externalPort: 3000,
+      formFactor: 'small',
+      keepAliveSeleniumDockerService: true,
+      locale: 'en',
+      site: 'build',
+      spec: '/spec/',
+      suite: 'test-suite',
+      theme: 'terra-default-theme',
+      updateScreenshots: true,
+      useSeleniumStandalonService: true,
+    };
+
+    const defaultWebpackPath = path.resolve(process.cwd(), 'webpack.config.js');
+    const capabilities = getCapabilities(options.browsers, !!options.gridUrl);
+
+    const expectedConfig = {
+      baseUrl: `http://${options.externalHost}:${options.externalPort}`,
+      capabilities,
+      hostname: 'standalone-chrome',
+      port: 4444,
+      spec: options.spec,
+      suite: options.suite,
+      launcherOptions: {
+        disableSeleniumService: true,
+        formFactor: options.formFactor,
+        gridUrl: undefined,
         keepAliveSeleniumDockerService: true,
         locale: options.locale,
         port: options.assetServerPort,

--- a/packages/terra-functional-testing/tests/jest/terra-cli/wdio/__snapshots__/index.test.js.snap
+++ b/packages/terra-functional-testing/tests/jest/terra-cli/wdio/__snapshots__/index.test.js.snap
@@ -45,7 +45,7 @@ Options:
                                         all reference screenshots with the
                                         latest screenshots.
                                                       [boolean] [default: false]
-      --useSeleniumStandalonService     A flag to use the selenium standalone
+      --useSeleniumStandaloneService    A flag to use the selenium standalone
                                         service instead of the selenium docker
                                         service. [boolean] [default: (_default)]"
 `;

--- a/packages/terra-functional-testing/tests/jest/terra-cli/wdio/__snapshots__/index.test.js.snap
+++ b/packages/terra-functional-testing/tests/jest/terra-cli/wdio/__snapshots__/index.test.js.snap
@@ -44,7 +44,10 @@ Options:
   -u, --updateScreenshots               Whether or not to automatically update
                                         all reference screenshots with the
                                         latest screenshots.
-                                                      [boolean] [default: false]"
+                                                      [boolean] [default: false]
+      --useSeleniumStandalonService     A flag to use the selenium standalone
+                                        service instead of the selenium docker
+                                        service. [boolean] [default: (_default)]"
 `;
 
 exports[`index declares the wdio terra-cli command with proper top level help 1`] = `

--- a/packages/terra-functional-testing/tests/jest/terra-cli/wdio/test-runner.test.js
+++ b/packages/terra-functional-testing/tests/jest/terra-cli/wdio/test-runner.test.js
@@ -52,7 +52,7 @@ describe('Test Runner', () => {
         suite: 'test-suite',
         theme: 'terra-default-theme',
         updateScreenshots: true,
-        useSeleniumStandalonService: true,
+        useSeleniumStandaloneService: true,
       };
 
       await TestRunner.run(options);
@@ -177,7 +177,7 @@ describe('Test Runner', () => {
         suite: 'test-suite',
         themes: ['terra-default-theme'],
         updateScreenshots: true,
-        useSeleniumStandalonService: true,
+        useSeleniumStandaloneService: true,
       });
 
       expect(TestRunner.run).toHaveBeenCalledWith({
@@ -196,7 +196,7 @@ describe('Test Runner', () => {
         suite: 'test-suite',
         theme: 'terra-default-theme',
         updateScreenshots: true,
-        useSeleniumStandalonService: true,
+        useSeleniumStandaloneService: true,
       });
     });
   });

--- a/packages/terra-functional-testing/tests/jest/terra-cli/wdio/test-runner.test.js
+++ b/packages/terra-functional-testing/tests/jest/terra-cli/wdio/test-runner.test.js
@@ -52,6 +52,7 @@ describe('Test Runner', () => {
         suite: 'test-suite',
         theme: 'terra-default-theme',
         updateScreenshots: true,
+        useSeleniumStandalonService: true,
       };
 
       await TestRunner.run(options);
@@ -176,6 +177,7 @@ describe('Test Runner', () => {
         suite: 'test-suite',
         themes: ['terra-default-theme'],
         updateScreenshots: true,
+        useSeleniumStandalonService: true,
       });
 
       expect(TestRunner.run).toHaveBeenCalledWith({
@@ -194,6 +196,7 @@ describe('Test Runner', () => {
         suite: 'test-suite',
         theme: 'terra-default-theme',
         updateScreenshots: true,
+        useSeleniumStandalonService: true,
       });
     });
   });


### PR DESCRIPTION
### Summary
Added `useSeleniumStandalonService` option to determine whether to use the standalone-chrome or the the selenium docker service when not using the selenium grid.

Closes #637 

### Additional Details

- When the Selenium Grid is not used (`gridUrl` is not provided) to run wdio tests, Jenkins will now set the `USE_SELENIUM_STANDALONE_SERVICE` env variable to allow us to determine whether to use standalone-chrome as the hostname or start the selenium docker service. This is similar to how the `CI` env is used in [terra-toolkit-boneyard](https://github.com/cerner/terra-toolkit-boneyard/blob/main/config/wdio/selenium.config.js#L74-L97).
- I didn't include `useSeleniumStandalonService` in the [CLI options documentation](https://engineering.cerner.com/terra-ui/dev_tools/cerner/terra-functional-testing/about#options) because consumers should not need to know about or set this locally since it should only be used by Jenkins.

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
