### PR TITLE
[terra-functional-testing] Remove lodash isArray dependency

### DIFF
--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Removed
+  * Removed lodash is array dependency in favor of Array.isArray.
+
 ## 1.4.0 - (May 7, 2021)
 
 * Added
@@ -19,7 +22,7 @@
 ## 1.2.0 - (April 23, 2021)
 
 * Added
-  * The `diff`, `error`, and `latest` folders in the `__snapshots__` directory will be deleted before each test run.  
+  * The `diff`, `error`, and `latest` folders in the `__snapshots__` directory will be deleted before each test run.
 
 ## 1.1.0 - (April 13, 2021)
 

--- a/packages/terra-functional-testing/package.json
+++ b/packages/terra-functional-testing/package.json
@@ -65,7 +65,6 @@
     "jimp": "^0.13.0",
     "lodash.get": "^4.4.2",
     "lodash.identity": "^3.0.0",
-    "lodash.isarray": "^4.0.0",
     "lodash.isplainobject": "^4.0.6",
     "lodash.isstring": "^4.0.1",
     "lodash.isundefined": "^3.0.1",

--- a/packages/terra-functional-testing/src/commands/axe/inject.js
+++ b/packages/terra-functional-testing/src/commands/axe/inject.js
@@ -6,7 +6,7 @@
  */
 const injectAxe = (options) => {
   // eslint-disable-next-line global-require
-  const { source } = require('axe-core/axe.min.js');
+  const { source } = require('axe-core/axe.min');
 
   browser.execute(`${source}\n ${options ? `axe.configure(${JSON.stringify(options)})` : ''}`);
 };

--- a/packages/terra-functional-testing/src/services/wdio-visual-regression-service/commands/saveElementScreenshot.js
+++ b/packages/terra-functional-testing/src/services/wdio-visual-regression-service/commands/saveElementScreenshot.js
@@ -1,4 +1,3 @@
-const lodashIsArray = require('lodash.isarray');
 const lodashIsPlainObject = require('lodash.isplainobject');
 const lodashIsString = require('lodash.isstring');
 const lodashIsUndefined = require('lodash.isundefined');
@@ -21,17 +20,17 @@ const saveBase64Image = require('../utils/saveBase64Image');
 // Note: function name must be async to signalize WebdriverIO that this function returns a promise
 async function async(fileName, elementSelector, options) {
   /* eslint-disable no-param-reassign */
-  if ((lodashIsString(fileName) || lodashIsArray(fileName)) && lodashIsPlainObject(elementSelector) && lodashIsUndefined(options)) {
+  if ((lodashIsString(fileName) || Array.isArray(fileName)) && lodashIsPlainObject(elementSelector) && lodashIsUndefined(options)) {
     options = elementSelector;
     elementSelector = fileName;
     fileName = undefined;
-  } else if ((lodashIsString(fileName) || lodashIsArray(fileName)) && lodashIsUndefined(elementSelector)) {
+  } else if ((lodashIsString(fileName) || Array.isArray(fileName)) && lodashIsUndefined(elementSelector)) {
     elementSelector = fileName;
     fileName = undefined;
   }
   /* eslint-enable no-param-reassign */
 
-  if (!(lodashIsString(elementSelector) || lodashIsArray(elementSelector))) {
+  if (!(lodashIsString(elementSelector) || Array.isArray(elementSelector))) {
     throw new Error('Please pass a valid selector value to parameter elementSelector');
   }
 

--- a/packages/terra-functional-testing/tests/jest/config/wdio.conf.test.js
+++ b/packages/terra-functional-testing/tests/jest/config/wdio.conf.test.js
@@ -1,4 +1,4 @@
-const config = require('../../../src/config/wdio.conf.js');
+const config = require('../../../src/config/wdio.conf');
 
 describe('WDIO Config', () => {
   it('should export the default WDIO configuration', () => {

--- a/packages/terra-functional-testing/tests/jest/reporters/spec-reporter/clean-results.test.js
+++ b/packages/terra-functional-testing/tests/jest/reporters/spec-reporter/clean-results.test.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const cleanResults = require('../../../../src/reporters/spec-reporter/clean-results.js');
+const cleanResults = require('../../../../src/reporters/spec-reporter/clean-results');
 const getOutputDir = require('../../../../src/reporters/spec-reporter/get-output-dir');
 
 jest.mock('../../../../src/reporters/spec-reporter/get-output-dir', () => (


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

Per the package deprecation warning:
> lodash.isarray@4.0.0: This package is deprecated. Use Array.isArray.

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
