### PR TITLE
[package-json-lint] Add a flag to mark a project as application, module, or devModule.

### DIFF
--- a/packages/package-json-lint/CHANGELOG.md
+++ b/packages/package-json-lint/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Added
-  * Added `type` to allow users to flag project as `application`, `module` or `devModule`.
+  * Added `projectType` to allow users to flag project as `application`, `module` or `devModule`.
 
 ## 1.0.0 - (August 13, 2021)
 

--- a/packages/package-json-lint/CHANGELOG.md
+++ b/packages/package-json-lint/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Added `type` to allow users to flag project as `application`, `module` or `devModule`.
+
 ## 1.0.0 - (August 13, 2021)
 
 * Initial stable release

--- a/packages/package-json-lint/src/lint.js
+++ b/packages/package-json-lint/src/lint.js
@@ -21,7 +21,7 @@ const lint = ({ packageJsonData, config }) => {
     const rule = rules[ruleId];
     const ruleConfig = getRuleConfig({ rule, ruleInformation });
     if (ruleConfig.severity !== 'off') {
-      return rule.create({ ruleConfig, report: issue => issues.push(issue) });
+      return rule.create({ ruleConfig, type: config.type, report: issue => issues.push(issue) });
     }
     return undefined;
   }).filter(rule => !!rule);

--- a/packages/package-json-lint/src/lint.js
+++ b/packages/package-json-lint/src/lint.js
@@ -20,8 +20,9 @@ const lint = ({ packageJsonData, config }) => {
   const rulesToRun = Object.entries(config.rules).map(([ruleId, ruleInformation]) => {
     const rule = rules[ruleId];
     const ruleConfig = getRuleConfig({ rule, ruleInformation });
+    const projectType = config.projectType || 'module';
     if (ruleConfig.severity !== 'off') {
-      return rule.create({ ruleConfig, type: config.type, report: issue => issues.push(issue) });
+      return rule.create({ ruleConfig, projectType, report: issue => issues.push(issue) });
     }
     return undefined;
   }).filter(rule => !!rule);

--- a/packages/package-json-lint/src/lint.js
+++ b/packages/package-json-lint/src/lint.js
@@ -17,10 +17,10 @@ const lint = ({ packageJsonData, config }) => {
   }
 
   const issues = [];
+  const projectType = config.projectType || 'module';
   const rulesToRun = Object.entries(config.rules).map(([ruleId, ruleInformation]) => {
     const rule = rules[ruleId];
     const ruleConfig = getRuleConfig({ rule, ruleInformation });
-    const projectType = config.projectType || 'module';
     if (ruleConfig.severity !== 'off') {
       return rule.create({ ruleConfig, projectType, report: issue => issues.push(issue) });
     }

--- a/packages/package-json-lint/src/rules/require-no-terra-base-peer-dependency-versions.js
+++ b/packages/package-json-lint/src/rules/require-no-terra-base-peer-dependency-versions.js
@@ -77,9 +77,9 @@ const versionSet = [
 ];
 
 module.exports = {
-  create: ({ ruleConfig, type, report }) => ({
+  create: ({ ruleConfig, projectType, report }) => ({
     dependencies: (dependencies) => requireVersionSet({
-      versionSet, dependencies, ruleConfig, type: type || 'module', report, lintId: 'require-no-terra-base-peer-dependency-versions', messageString: 'no terra base peer dependencies',
+      versionSet, dependencies, ruleConfig, projectType, report, lintId: 'require-no-terra-base-peer-dependency-versions', messageString: 'no terra base peer dependencies',
     }),
   }),
 };

--- a/packages/package-json-lint/src/rules/require-no-terra-base-peer-dependency-versions.js
+++ b/packages/package-json-lint/src/rules/require-no-terra-base-peer-dependency-versions.js
@@ -79,7 +79,7 @@ const versionSet = [
 module.exports = {
   create: ({ ruleConfig, type, report }) => ({
     dependencies: (dependencies) => requireVersionSet({
-      versionSet, dependencies, ruleConfig, type: type || 'devModule', report, lintId: 'require-no-terra-base-peer-dependency-versions', messageString: 'no terra base peer dependencies',
+      versionSet, dependencies, ruleConfig, type: type || 'module', report, lintId: 'require-no-terra-base-peer-dependency-versions', messageString: 'no terra base peer dependencies',
     }),
   }),
 };

--- a/packages/package-json-lint/src/rules/require-no-terra-base-peer-dependency-versions.js
+++ b/packages/package-json-lint/src/rules/require-no-terra-base-peer-dependency-versions.js
@@ -77,9 +77,9 @@ const versionSet = [
 ];
 
 module.exports = {
-  create: ({ ruleConfig, report }) => ({
+  create: ({ ruleConfig, type, report }) => ({
     dependencies: (dependencies) => requireVersionSet({
-      versionSet, dependencies, ruleConfig, report, lintId: 'require-no-terra-base-peer-dependency-versions', messageString: 'no terra base peer dependencies',
+      versionSet, dependencies, ruleConfig, type: type || 'devModule', report, lintId: 'require-no-terra-base-peer-dependency-versions', messageString: 'no terra base peer dependencies',
     }),
   }),
 };

--- a/packages/package-json-lint/src/rules/require-theme-context-versions.js
+++ b/packages/package-json-lint/src/rules/require-theme-context-versions.js
@@ -76,9 +76,9 @@ const versionSet = [
 ];
 
 module.exports = {
-  create: ({ ruleConfig, type, report }) => ({
+  create: ({ ruleConfig, projectType, report }) => ({
     dependencies: (dependencies) => requireVersionSet({
-      versionSet, dependencies, ruleConfig, type: type || 'module', report, lintId: 'require-theme-context-versions', messageString: 'theming context',
+      versionSet, dependencies, ruleConfig, projectType, report, lintId: 'require-theme-context-versions', messageString: 'theming context',
     }),
   }),
 };

--- a/packages/package-json-lint/src/rules/require-theme-context-versions.js
+++ b/packages/package-json-lint/src/rules/require-theme-context-versions.js
@@ -76,9 +76,9 @@ const versionSet = [
 ];
 
 module.exports = {
-  create: ({ ruleConfig, report }) => ({
+  create: ({ ruleConfig, type, report }) => ({
     dependencies: (dependencies) => requireVersionSet({
-      versionSet, dependencies, ruleConfig, report, lintId: 'require-theme-context-versions', messageString: 'theming context',
+      versionSet, dependencies, ruleConfig, type: type || 'devModule', report, lintId: 'require-theme-context-versions', messageString: 'theming context',
     }),
   }),
 };

--- a/packages/package-json-lint/src/rules/require-theme-context-versions.js
+++ b/packages/package-json-lint/src/rules/require-theme-context-versions.js
@@ -78,7 +78,7 @@ const versionSet = [
 module.exports = {
   create: ({ ruleConfig, type, report }) => ({
     dependencies: (dependencies) => requireVersionSet({
-      versionSet, dependencies, ruleConfig, type: type || 'devModule', report, lintId: 'require-theme-context-versions', messageString: 'theming context',
+      versionSet, dependencies, ruleConfig, type: type || 'module', report, lintId: 'require-theme-context-versions', messageString: 'theming context',
     }),
   }),
 };

--- a/packages/package-json-lint/src/rules/requireVersionSet.js
+++ b/packages/package-json-lint/src/rules/requireVersionSet.js
@@ -1,7 +1,7 @@
 const semver = require('semver');
 
 module.exports = ({
-  versionSet, dependencies, ruleConfig, type, report, lintId, messageString,
+  versionSet, dependencies, ruleConfig, projectType, report, lintId, messageString,
 }) => {
   const currentProblems = versionSet.map(({ name, versionRange }) => {
     const dependencyVersion = dependencies[name];
@@ -14,7 +14,7 @@ module.exports = ({
   if (currentProblems.length) {
     const lintMessage = `The dependencies for this project do not have the minimum versions required for ${messageString}:\n  ${currentProblems.join('\n  ')}`;
     report({
-      lintId, severity: ruleConfig.severity, lintMessage, type,
+      lintId, severity: ruleConfig.severity, lintMessage, projectType,
     });
   }
 };

--- a/packages/package-json-lint/src/rules/requireVersionSet.js
+++ b/packages/package-json-lint/src/rules/requireVersionSet.js
@@ -1,7 +1,7 @@
 const semver = require('semver');
 
 module.exports = ({
-  versionSet, dependencies, ruleConfig, report, lintId, messageString,
+  versionSet, dependencies, ruleConfig, type, report, lintId, messageString,
 }) => {
   const currentProblems = versionSet.map(({ name, versionRange }) => {
     const dependencyVersion = dependencies[name];
@@ -14,7 +14,7 @@ module.exports = ({
   if (currentProblems.length) {
     const lintMessage = `The dependencies for this project do not have the minimum versions required for ${messageString}:\n  ${currentProblems.join('\n  ')}`;
     report({
-      lintId, severity: ruleConfig.severity, lintMessage,
+      lintId, severity: ruleConfig.severity, lintMessage, type,
     });
   }
 };

--- a/packages/package-json-lint/tests/jest/lint.test.js
+++ b/packages/package-json-lint/tests/jest/lint.test.js
@@ -29,14 +29,13 @@ describe('lint', () => {
         'require-no-terra-base-peer-dependency-versions': 'error',
         'require-theme-context-versions': 'error',
       },
-      type: 'module',
+      projectType: 'module',
     });
     getConfigForFile.mockResolvedValueOnce({
       rules: {
         'require-no-terra-base-peer-dependency-versions': 'warn',
         'require-theme-context-versions': 'warn',
       },
-      type: 'module',
     });
     getPathsForPackages.mockResolvedValueOnce([
       'path1',
@@ -106,10 +105,10 @@ describe('lint', () => {
     expect(getRuleConfig).toHaveBeenNthCalledWith(3, { rule: rules['require-no-terra-base-peer-dependency-versions'], ruleInformation: 'warn' });
     expect(getRuleConfig).toHaveBeenNthCalledWith(4, { rule: rules['require-theme-context-versions'], ruleInformation: 'warn' });
     expect(rules['require-no-terra-base-peer-dependency-versions'].create).toHaveBeenCalledTimes(1);
-    expect(rules['require-no-terra-base-peer-dependency-versions'].create).toHaveBeenCalledWith({ ruleConfig: package2RuleConfig1, type: 'module', report: expect.anything() });
+    expect(rules['require-no-terra-base-peer-dependency-versions'].create).toHaveBeenCalledWith({ ruleConfig: package2RuleConfig1, projectType: 'module', report: expect.anything() });
     expect(rules['require-theme-context-versions'].create).toHaveBeenCalledTimes(2);
-    expect(rules['require-theme-context-versions'].create).toHaveBeenCalledWith({ ruleConfig: package1RuleConfig2, type: 'module', report: expect.anything() });
-    expect(rules['require-theme-context-versions'].create).toHaveBeenCalledWith({ ruleConfig: package2RuleConfig2, type: 'module', report: expect.anything() });
+    expect(rules['require-theme-context-versions'].create).toHaveBeenCalledWith({ ruleConfig: package1RuleConfig2, projectType: 'module', report: expect.anything() });
+    expect(rules['require-theme-context-versions'].create).toHaveBeenCalledWith({ ruleConfig: package2RuleConfig2, projectType: 'module', report: expect.anything() });
     expect(mockRule1.dependencies).toHaveBeenCalledTimes(1);
     expect(mockRule1.dependencies).toHaveBeenCalledWith({ b: '1.1.1' });
     expect(mockRule2.dependencies).toHaveBeenCalledTimes(1);

--- a/packages/package-json-lint/tests/jest/lint.test.js
+++ b/packages/package-json-lint/tests/jest/lint.test.js
@@ -29,12 +29,14 @@ describe('lint', () => {
         'require-no-terra-base-peer-dependency-versions': 'error',
         'require-theme-context-versions': 'error',
       },
+      type: 'module',
     });
     getConfigForFile.mockResolvedValueOnce({
       rules: {
         'require-no-terra-base-peer-dependency-versions': 'warn',
         'require-theme-context-versions': 'warn',
       },
+      type: 'module',
     });
     getPathsForPackages.mockResolvedValueOnce([
       'path1',
@@ -104,10 +106,10 @@ describe('lint', () => {
     expect(getRuleConfig).toHaveBeenNthCalledWith(3, { rule: rules['require-no-terra-base-peer-dependency-versions'], ruleInformation: 'warn' });
     expect(getRuleConfig).toHaveBeenNthCalledWith(4, { rule: rules['require-theme-context-versions'], ruleInformation: 'warn' });
     expect(rules['require-no-terra-base-peer-dependency-versions'].create).toHaveBeenCalledTimes(1);
-    expect(rules['require-no-terra-base-peer-dependency-versions'].create).toHaveBeenCalledWith({ ruleConfig: package2RuleConfig1, report: expect.anything() });
+    expect(rules['require-no-terra-base-peer-dependency-versions'].create).toHaveBeenCalledWith({ ruleConfig: package2RuleConfig1, type: 'module', report: expect.anything() });
     expect(rules['require-theme-context-versions'].create).toHaveBeenCalledTimes(2);
-    expect(rules['require-theme-context-versions'].create).toHaveBeenCalledWith({ ruleConfig: package1RuleConfig2, report: expect.anything() });
-    expect(rules['require-theme-context-versions'].create).toHaveBeenCalledWith({ ruleConfig: package2RuleConfig2, report: expect.anything() });
+    expect(rules['require-theme-context-versions'].create).toHaveBeenCalledWith({ ruleConfig: package1RuleConfig2, type: 'module', report: expect.anything() });
+    expect(rules['require-theme-context-versions'].create).toHaveBeenCalledWith({ ruleConfig: package2RuleConfig2, type: 'module', report: expect.anything() });
     expect(mockRule1.dependencies).toHaveBeenCalledTimes(1);
     expect(mockRule1.dependencies).toHaveBeenCalledWith({ b: '1.1.1' });
     expect(mockRule2.dependencies).toHaveBeenCalledTimes(1);

--- a/packages/package-json-lint/tests/jest/rules/__snapshots__/require-no-terra-base-peer-dependency-versions.test.js.snap
+++ b/packages/package-json-lint/tests/jest/rules/__snapshots__/require-no-terra-base-peer-dependency-versions.test.js.snap
@@ -5,7 +5,7 @@ Object {
   "lintId": "require-no-terra-base-peer-dependency-versions",
   "lintMessage": "The dependencies for this project do not have the minimum versions required for no terra base peer dependencies:
   terra-action-footer@^1.0.0 does not satisfy range requirement for no terra base peer dependencies: terra-action-footer@>2.5.0",
-  "projectType": undefined,
+  "projectType": "module",
   "severity": "warning",
 }
 `;
@@ -87,7 +87,7 @@ Object {
   terra-toggle-section-header@2.5.0 does not satisfy range requirement for no terra base peer dependencies: terra-toggle-section-header@>2.5.0
   terra-toggle@3.5.0 does not satisfy range requirement for no terra base peer dependencies: terra-toggle@>3.5.0
   terra-visually-hidden-text@2.4.0 does not satisfy range requirement for no terra base peer dependencies: terra-visually-hidden-text@>2.4.0",
-  "projectType": undefined,
+  "projectType": "devModule",
   "severity": "error",
 }
 `;

--- a/packages/package-json-lint/tests/jest/rules/__snapshots__/require-no-terra-base-peer-dependency-versions.test.js.snap
+++ b/packages/package-json-lint/tests/jest/rules/__snapshots__/require-no-terra-base-peer-dependency-versions.test.js.snap
@@ -5,8 +5,8 @@ Object {
   "lintId": "require-no-terra-base-peer-dependency-versions",
   "lintMessage": "The dependencies for this project do not have the minimum versions required for no terra base peer dependencies:
   terra-action-footer@^1.0.0 does not satisfy range requirement for no terra base peer dependencies: terra-action-footer@>2.5.0",
+  "projectType": undefined,
   "severity": "warning",
-  "type": "module",
 }
 `;
 
@@ -87,8 +87,8 @@ Object {
   terra-toggle-section-header@2.5.0 does not satisfy range requirement for no terra base peer dependencies: terra-toggle-section-header@>2.5.0
   terra-toggle@3.5.0 does not satisfy range requirement for no terra base peer dependencies: terra-toggle@>3.5.0
   terra-visually-hidden-text@2.4.0 does not satisfy range requirement for no terra base peer dependencies: terra-visually-hidden-text@>2.4.0",
+  "projectType": undefined,
   "severity": "error",
-  "type": "devModule",
 }
 `;
 

--- a/packages/package-json-lint/tests/jest/rules/__snapshots__/require-no-terra-base-peer-dependency-versions.test.js.snap
+++ b/packages/package-json-lint/tests/jest/rules/__snapshots__/require-no-terra-base-peer-dependency-versions.test.js.snap
@@ -6,6 +6,7 @@ Object {
   "lintMessage": "The dependencies for this project do not have the minimum versions required for no terra base peer dependencies:
   terra-action-footer@^1.0.0 does not satisfy range requirement for no terra base peer dependencies: terra-action-footer@>2.5.0",
   "severity": "warning",
+  "type": "devModule",
 }
 `;
 
@@ -87,6 +88,7 @@ Object {
   terra-toggle@3.5.0 does not satisfy range requirement for no terra base peer dependencies: terra-toggle@>3.5.0
   terra-visually-hidden-text@2.4.0 does not satisfy range requirement for no terra base peer dependencies: terra-visually-hidden-text@>2.4.0",
   "severity": "error",
+  "type": "module",
 }
 `;
 

--- a/packages/package-json-lint/tests/jest/rules/__snapshots__/require-no-terra-base-peer-dependency-versions.test.js.snap
+++ b/packages/package-json-lint/tests/jest/rules/__snapshots__/require-no-terra-base-peer-dependency-versions.test.js.snap
@@ -6,7 +6,7 @@ Object {
   "lintMessage": "The dependencies for this project do not have the minimum versions required for no terra base peer dependencies:
   terra-action-footer@^1.0.0 does not satisfy range requirement for no terra base peer dependencies: terra-action-footer@>2.5.0",
   "severity": "warning",
-  "type": "devModule",
+  "type": "module",
 }
 `;
 
@@ -88,7 +88,7 @@ Object {
   terra-toggle@3.5.0 does not satisfy range requirement for no terra base peer dependencies: terra-toggle@>3.5.0
   terra-visually-hidden-text@2.4.0 does not satisfy range requirement for no terra base peer dependencies: terra-visually-hidden-text@>2.4.0",
   "severity": "error",
-  "type": "module",
+  "type": "devModule",
 }
 `;
 

--- a/packages/package-json-lint/tests/jest/rules/__snapshots__/require-theme-context-versions.test.js.snap
+++ b/packages/package-json-lint/tests/jest/rules/__snapshots__/require-theme-context-versions.test.js.snap
@@ -6,6 +6,7 @@ Object {
   "lintMessage": "The dependencies for this project do not have the minimum versions required for theming context:
   terra-action-footer@^1.0.0 does not satisfy range requirement for theming context: terra-action-footer@>=2.42.0",
   "severity": "warning",
+  "type": "module",
 }
 `;
 
@@ -86,6 +87,7 @@ Object {
   terra-time-input@<4.29.0 does not satisfy range requirement for theming context: terra-time-input@>=4.29.0
   terra-toolbar@<1.8.0 does not satisfy range requirement for theming context: terra-toolbar@>=1.8.0",
   "severity": "error",
+  "type": "module",
 }
 `;
 

--- a/packages/package-json-lint/tests/jest/rules/__snapshots__/require-theme-context-versions.test.js.snap
+++ b/packages/package-json-lint/tests/jest/rules/__snapshots__/require-theme-context-versions.test.js.snap
@@ -5,8 +5,8 @@ Object {
   "lintId": "require-theme-context-versions",
   "lintMessage": "The dependencies for this project do not have the minimum versions required for theming context:
   terra-action-footer@^1.0.0 does not satisfy range requirement for theming context: terra-action-footer@>=2.42.0",
+  "projectType": undefined,
   "severity": "warning",
-  "type": "module",
 }
 `;
 
@@ -86,8 +86,8 @@ Object {
   terra-text@<4.31.0 does not satisfy range requirement for theming context: terra-text@>=4.31.0
   terra-time-input@<4.29.0 does not satisfy range requirement for theming context: terra-time-input@>=4.29.0
   terra-toolbar@<1.8.0 does not satisfy range requirement for theming context: terra-toolbar@>=1.8.0",
+  "projectType": undefined,
   "severity": "error",
-  "type": "module",
 }
 `;
 

--- a/packages/package-json-lint/tests/jest/rules/__snapshots__/require-theme-context-versions.test.js.snap
+++ b/packages/package-json-lint/tests/jest/rules/__snapshots__/require-theme-context-versions.test.js.snap
@@ -5,7 +5,7 @@ Object {
   "lintId": "require-theme-context-versions",
   "lintMessage": "The dependencies for this project do not have the minimum versions required for theming context:
   terra-action-footer@^1.0.0 does not satisfy range requirement for theming context: terra-action-footer@>=2.42.0",
-  "projectType": undefined,
+  "projectType": "module",
   "severity": "warning",
 }
 `;
@@ -86,7 +86,7 @@ Object {
   terra-text@<4.31.0 does not satisfy range requirement for theming context: terra-text@>=4.31.0
   terra-time-input@<4.29.0 does not satisfy range requirement for theming context: terra-time-input@>=4.29.0
   terra-toolbar@<1.8.0 does not satisfy range requirement for theming context: terra-toolbar@>=1.8.0",
-  "projectType": undefined,
+  "projectType": "module",
   "severity": "error",
 }
 `;

--- a/packages/package-json-lint/tests/jest/rules/require-no-terra-base-peer-dependency-versions.test.js
+++ b/packages/package-json-lint/tests/jest/rules/require-no-terra-base-peer-dependency-versions.test.js
@@ -28,7 +28,8 @@ describe('require-no-terra-base-peer-dependency-versions', () => {
     requireNoTerraBasePeerDependencyVersions.create({
       ruleConfig: {
         severity: 'warning',
-      }, // Not sending a type in this test. The type in snapshot should be `module`.
+      },
+      type: 'module',
       report: (issues) => {
         results = issues;
       },

--- a/packages/package-json-lint/tests/jest/rules/require-no-terra-base-peer-dependency-versions.test.js
+++ b/packages/package-json-lint/tests/jest/rules/require-no-terra-base-peer-dependency-versions.test.js
@@ -6,7 +6,7 @@ describe('require-no-terra-base-peer-dependency-versions', () => {
       ruleConfig: {
         severity: 'error',
       },
-      type: 'module',
+      projectType: 'module',
     }).dependencies({});
     expect(results).toMatchSnapshot();
   });
@@ -16,7 +16,7 @@ describe('require-no-terra-base-peer-dependency-versions', () => {
       ruleConfig: {
         severity: 'error',
       },
-      type: 'module',
+      projectType: 'module',
     }).dependencies({
       a: '^1.0.0',
     });
@@ -29,7 +29,7 @@ describe('require-no-terra-base-peer-dependency-versions', () => {
       ruleConfig: {
         severity: 'warning',
       },
-      type: 'module',
+      projectType: 'module',
       report: (issues) => {
         results = issues;
       },
@@ -45,7 +45,7 @@ describe('require-no-terra-base-peer-dependency-versions', () => {
       ruleConfig: {
         severity: 'error',
       },
-      type: 'devModule',
+      projectType: 'devModule',
       report: (issues) => {
         results = issues;
       },
@@ -132,7 +132,7 @@ describe('require-no-terra-base-peer-dependency-versions', () => {
       ruleConfig: {
         severity: 'error',
       },
-      type: 'module',
+      projectType: 'module',
     }).dependencies({
       'terra-action-footer': '^2.6.0',
       'terra-action-header': '^2.9.0',

--- a/packages/package-json-lint/tests/jest/rules/require-no-terra-base-peer-dependency-versions.test.js
+++ b/packages/package-json-lint/tests/jest/rules/require-no-terra-base-peer-dependency-versions.test.js
@@ -28,7 +28,7 @@ describe('require-no-terra-base-peer-dependency-versions', () => {
     requireNoTerraBasePeerDependencyVersions.create({
       ruleConfig: {
         severity: 'warning',
-      },
+      }, // Not sending a type in this test. The type in snapshot should be `module`.
       report: (issues) => {
         results = issues;
       },
@@ -44,7 +44,7 @@ describe('require-no-terra-base-peer-dependency-versions', () => {
       ruleConfig: {
         severity: 'error',
       },
-      type: 'module',
+      type: 'devModule',
       report: (issues) => {
         results = issues;
       },

--- a/packages/package-json-lint/tests/jest/rules/require-no-terra-base-peer-dependency-versions.test.js
+++ b/packages/package-json-lint/tests/jest/rules/require-no-terra-base-peer-dependency-versions.test.js
@@ -6,6 +6,7 @@ describe('require-no-terra-base-peer-dependency-versions', () => {
       ruleConfig: {
         severity: 'error',
       },
+      type: 'module',
     }).dependencies({});
     expect(results).toMatchSnapshot();
   });
@@ -15,6 +16,7 @@ describe('require-no-terra-base-peer-dependency-versions', () => {
       ruleConfig: {
         severity: 'error',
       },
+      type: 'module',
     }).dependencies({
       a: '^1.0.0',
     });
@@ -42,6 +44,7 @@ describe('require-no-terra-base-peer-dependency-versions', () => {
       ruleConfig: {
         severity: 'error',
       },
+      type: 'module',
       report: (issues) => {
         results = issues;
       },
@@ -128,6 +131,7 @@ describe('require-no-terra-base-peer-dependency-versions', () => {
       ruleConfig: {
         severity: 'error',
       },
+      type: 'module',
     }).dependencies({
       'terra-action-footer': '^2.6.0',
       'terra-action-header': '^2.9.0',

--- a/packages/package-json-lint/tests/jest/rules/require-theme-context-versions.test.js
+++ b/packages/package-json-lint/tests/jest/rules/require-theme-context-versions.test.js
@@ -6,6 +6,7 @@ describe('require-theme-context-versions', () => {
       ruleConfig: {
         severity: 'error',
       },
+      type: 'module',
     }).dependencies({});
     expect(results).toMatchSnapshot();
   });
@@ -15,6 +16,7 @@ describe('require-theme-context-versions', () => {
       ruleConfig: {
         severity: 'error',
       },
+      type: 'module',
     }).dependencies({
       a: '^1.0.0',
     });
@@ -27,6 +29,7 @@ describe('require-theme-context-versions', () => {
       ruleConfig: {
         severity: 'warning',
       },
+      type: 'module',
       report: (issues) => {
         results = issues;
       },
@@ -42,6 +45,7 @@ describe('require-theme-context-versions', () => {
       ruleConfig: {
         severity: 'error',
       },
+      type: 'module',
       report: (issues) => {
         results = issues;
       },
@@ -127,6 +131,7 @@ describe('require-theme-context-versions', () => {
       ruleConfig: {
         severity: 'error',
       },
+      type: 'module',
     }).dependencies({
       '@cerner/terra-docs': '^1.0.0',
       'terra-abstract-modal': '^3.25.0',

--- a/packages/package-json-lint/tests/jest/rules/require-theme-context-versions.test.js
+++ b/packages/package-json-lint/tests/jest/rules/require-theme-context-versions.test.js
@@ -6,7 +6,7 @@ describe('require-theme-context-versions', () => {
       ruleConfig: {
         severity: 'error',
       },
-      type: 'module',
+      projectType: 'module',
     }).dependencies({});
     expect(results).toMatchSnapshot();
   });
@@ -16,7 +16,7 @@ describe('require-theme-context-versions', () => {
       ruleConfig: {
         severity: 'error',
       },
-      type: 'module',
+      projectType: 'module',
     }).dependencies({
       a: '^1.0.0',
     });
@@ -29,7 +29,7 @@ describe('require-theme-context-versions', () => {
       ruleConfig: {
         severity: 'warning',
       },
-      type: 'module',
+      projectType: 'module',
       report: (issues) => {
         results = issues;
       },
@@ -45,7 +45,7 @@ describe('require-theme-context-versions', () => {
       ruleConfig: {
         severity: 'error',
       },
-      type: 'module',
+      projectType: 'module',
       report: (issues) => {
         results = issues;
       },
@@ -131,7 +131,7 @@ describe('require-theme-context-versions', () => {
       ruleConfig: {
         severity: 'error',
       },
-      type: 'module',
+      projectType: 'module',
     }).dependencies({
       '@cerner/terra-docs': '^1.0.0',
       'terra-abstract-modal': '^3.25.0',


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->
This PR adds a variable `projectType` to flag a project as application, module, or devModule.
The fallback value for `projectType` is `module`. Currently seems a most common scenario.

Closes #696 

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
