### PR TITLE
Update aggregate-messages.js to only warn on JSON parser errors not when the file isn't there

### DIFF
--- a/packages/terra-aggregate-translations/CHANGELOG.md
+++ b/packages/terra-aggregate-translations/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * When parsing translation files, only warn when the JSON is invalid or the base file isn't there.
+
 ## 2.1.0 - (August 25, 2021)
 
 * Fixed

--- a/packages/terra-aggregate-translations/src/aggregate-messages.js
+++ b/packages/terra-aggregate-translations/src/aggregate-messages.js
@@ -13,8 +13,10 @@ const aggregateTranslationMessages = (translationDirectories, locales, fileSyste
     try {
       Object.assign(translations[language], JSON.parse(fileSystem.readFileSync(translationFile, 'utf8')));
     } catch (e) {
-      /* eslint-disable-next-line no-console */
-      console.warn(chalk.yellow(`There was an error reading your translations file ${translationFile}.\n Exception Message: ${e.message} \n`));
+      if (e instanceof SyntaxError) {
+        /* eslint-disable-next-line no-console */
+        console.warn(chalk.yellow(`There was an error reading your translations file ${translationFile}.\n Exception Message: ${e.message} \n`));
+      }
     }
   }));
 

--- a/packages/terra-aggregate-translations/src/aggregate-messages.js
+++ b/packages/terra-aggregate-translations/src/aggregate-messages.js
@@ -13,9 +13,13 @@ const aggregateTranslationMessages = (translationDirectories, locales, fileSyste
     try {
       Object.assign(translations[language], JSON.parse(fileSystem.readFileSync(translationFile, 'utf8')));
     } catch (e) {
+      // Only warn if the JSON is invalid or if the base language is missing
       if (e instanceof SyntaxError) {
         /* eslint-disable-next-line no-console */
         console.warn(chalk.yellow(`There was an error reading your translations file ${translationFile}.\n Exception Message: ${e.message} \n`));
+      } else if (language.split('-').length === 1) {
+        /* eslint-disable-next-line no-console */
+        console.warn(chalk.yellow(`The base translation file for ${language} is missing at ${translationFile}.\n`));
       }
     }
   }));


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

Update aggregate-messages.js to only warn on JSON parser errors not when the file isn't there