### PR TITLE
Updates webpack-dev-server to latest version v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,6 @@
     "utf-8-validate": "^5.0.2",
     "webpack": "^5.28.0",
     "webpack-cli": "^4.6.0",
-    "webpack-dev-server": "^3.11.0"
+    "webpack-dev-server": "^4.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -130,6 +130,6 @@
     "utf-8-validate": "^5.0.2",
     "webpack": "^5.28.0",
     "webpack-cli": "^4.6.0",
-    "webpack-dev-server": "^4.6.0"
+    "webpack-dev-server": "^4.7.2"
   }
 }

--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+* Added
+  * Added devMiddleWare to support webpack-dev-server v4
 
 ## 2.5.0 - (September 28, 2021)
 

--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Added
+  * Added authentication for accessing screenshots from the remote site.
   * Added `useRemoteReferenceScreenshots` cli option for downloading reference screenshots from a remote site for screenshot comparisons.
 
 ## 2.7.0 - (February 11, 2022)

--- a/packages/terra-functional-testing/package.json
+++ b/packages/terra-functional-testing/package.json
@@ -74,7 +74,7 @@
     "strip-ansi": "^6.0.0",
     "uuid": "^3.0.0",
     "webdriverio": "^7.7.3",
-    "webpack-dev-server": "^3.11.0",
+    "webpack-dev-server": "^4.6.0",
     "which": "^2.0.2"
   },
   "peerDependencies": {

--- a/packages/terra-functional-testing/package.json
+++ b/packages/terra-functional-testing/package.json
@@ -74,7 +74,7 @@
     "strip-ansi": "^6.0.0",
     "uuid": "^3.0.0",
     "webdriverio": "^7.7.3",
-    "webpack-dev-server": "^4.6.0",
+    "webpack-dev-server": "^4.7.2",
     "which": "^2.0.2"
   },
   "peerDependencies": {

--- a/packages/terra-functional-testing/package.json
+++ b/packages/terra-functional-testing/package.json
@@ -65,6 +65,7 @@
     "inquirer": "8.1.3",
     "ip": "^1.1.5",
     "jimp": "^0.13.0",
+    "js-yaml": "^3.14.0",
     "lodash.get": "^4.4.2",
     "lodash.identity": "^3.0.0",
     "lodash.isplainobject": "^4.0.6",

--- a/packages/terra-functional-testing/src/config/utils/getRemoteScreenshotConfiguration.js
+++ b/packages/terra-functional-testing/src/config/utils/getRemoteScreenshotConfiguration.js
@@ -1,0 +1,69 @@
+const fs = require('fs-extra');
+const path = require('path');
+const yaml = require('js-yaml');
+const { Logger } = require('@cerner/terra-cli');
+const { URL } = require('url');
+
+const logger = new Logger({ prefix: '[terra-functional-testing:getRemoteScreenshotConfiguration]' });
+
+/**
+ * Retrieves the authorization header from the .roll_out.yml file given the repository id in the publish site config
+ * @param {string} repositoryId - the id for the publish repository that matches up with the .roll_out.yml file
+ * @return {string} - returns the authentication string or undefined if no credentials provided.
+ */
+const getAuthHeader = (repositoryId) => {
+  try {
+    const authConfig = yaml.safeLoad(fs.readFileSync(path.join(process.env.HOME, '.roll_out.yml')));
+    const auth = authConfig[repositoryId];
+
+    return `Basic ${Buffer.from((`${auth.username}:${auth.password}`)).toString('base64')}`;
+  } catch (e) {
+    logger.warn(`No credentials provided for ${repositoryId}`);
+    // Ultimately, be optimistic here that whatever set up a consumer has doesn't need credentials.  If not, we'll fail later.
+    return undefined;
+  }
+};
+
+/**
+ * Creates the authentication header and url configurations needed to access the remote site where screenshots are located.
+ * @param {Object} config.siteRepositoryId - the identifier of the repository where the screenshots are located.
+ * @param {Object} config.siteRepositoryUrl - the URL of the repository where the screenshots are located.
+ * @return {Object} - returns object containing the required authentication and configurations.
+ */
+const getRemoteScreenshotConfiguration = () => {
+  const packageJson = fs.readJsonSync(path.join(process.cwd(), 'package.json'));
+  const repositoryUrl = new URL(packageJson.repository.url);
+  const defaultConfiguration = {
+    artifactId: packageJson.name,
+    groupId: `com.cerner.${repositoryUrl.pathname.match(/[^/]+/g)[0]}`,
+    version: packageJson.version,
+    site: {
+      repositoryId: 'cerner-release-main-site',
+      repositoryUrl: 'http://repo.release.cerner.corp/nexus/service/local/repositories/main-site',
+    },
+  };
+
+  const actualConfiguration = { ...defaultConfiguration, ...packageJson.rollOut };
+
+  // Get the Nexus site. For example, if repositoryUrl is http://repo.release.cerner.corp/nexus/service/local/repositories/internal-site/
+  // get "internal-site" and account for the last "/" if one exists.
+  const url = new URL(actualConfiguration.site.repositoryUrl);
+  const sitePaths = url.pathname.match(/[^/]+/g);
+
+  if (!sitePaths) {
+    throw new Error(`The repository url is malformed: ${actualConfiguration.site.repositoryUrl}`);
+  }
+
+  const nexusSite = sitePaths[sitePaths.length - 1];
+  const outputPublicPath = `/nexus/content/sites/${nexusSite}/${actualConfiguration.groupId}/${actualConfiguration.artifactId}/${actualConfiguration.version}`;
+
+  return {
+    publishScreenshotConfiguration: {
+      url: `${url.origin}/${outputPublicPath}/`.replace(/([^:]\/)\/+/g, '$1'),
+      serviceAuthHeader: getAuthHeader(actualConfiguration.site.repositoryId),
+      serviceUrl: `${actualConfiguration.site.repositoryUrl}/content-compressed/${actualConfiguration.groupId}/${actualConfiguration.artifactId}/${actualConfiguration.version}/`.replace(/([^:]\/)\/+/g, '$1'),
+    },
+  };
+};
+
+module.exports = getRemoteScreenshotConfiguration;

--- a/packages/terra-functional-testing/src/webpack-server/webpack-server.js
+++ b/packages/terra-functional-testing/src/webpack-server/webpack-server.js
@@ -114,12 +114,15 @@ class WebpackServer {
         reject();
       });
 
-      this.server = new WebpackDevServer(compiler, {
+      this.server = new WebpackDevServer({
         ...compiler.options.devServer,
         hot: false,
         liveReload: false,
         host: this.host,
         port: this.port,
+        client: {
+          overlay: false,
+        },
         devMiddleware: {
           index: 'index.html',
           stats: {
@@ -127,7 +130,7 @@ class WebpackServer {
             children: false,
           },
         },
-      });
+      }, compiler);
 
       // Start that server.
       this.server.listen(this.port, this.host, (error) => {

--- a/packages/terra-functional-testing/src/webpack-server/webpack-server.js
+++ b/packages/terra-functional-testing/src/webpack-server/webpack-server.js
@@ -117,14 +117,15 @@ class WebpackServer {
       this.server = new WebpackDevServer(compiler, {
         ...compiler.options.devServer,
         hot: false,
-        inline: false,
         liveReload: false,
         host: this.host,
         port: this.port,
-        index: 'index.html',
-        stats: {
-          colors: true,
-          children: false,
+        devMiddleware: {
+          index: 'index.html',
+          stats: {
+            colors: true,
+            children: false,
+          },
         },
       });
 

--- a/packages/terra-functional-testing/tests/jest/config/utils/__snapshots__/getRemoteScreenshotConfiguration.test.js.snap
+++ b/packages/terra-functional-testing/tests/jest/config/utils/__snapshots__/getRemoteScreenshotConfiguration.test.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getRemoteScreenshotConfiguration loads the config from the package 1`] = `
+Object {
+  "publishScreenshotConfiguration": Object {
+    "serviceAuthHeader": undefined,
+    "serviceUrl": "http://repo.release.cerner.corp/nexus/service/local/repositories/internal-site/content-compressed/mock-group-id/mock-artifact-id/1.0.0/",
+    "url": "http://repo.release.cerner.corp/nexus/content/sites/internal-site/mock-group-id/mock-artifact-id/1.0.0/",
+  },
+}
+`;
+
+exports[`getRemoteScreenshotConfiguration loads the default config 1`] = `
+Object {
+  "publishScreenshotConfiguration": Object {
+    "serviceAuthHeader": "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
+    "serviceUrl": "http://repo.release.cerner.corp/nexus/service/local/repositories/main-site/content-compressed/com.cerner.cerner/terra-functional-testing/1.0.0/",
+    "url": "http://repo.release.cerner.corp/nexus/content/sites/main-site/com.cerner.cerner/terra-functional-testing/1.0.0/",
+  },
+}
+`;
+
+exports[`getRemoteScreenshotConfiguration throws an error with a bad site 1`] = `"The repository url is malformed: http://www.badsite.com"`;

--- a/packages/terra-functional-testing/tests/jest/config/utils/getRemoteScreenshotConfiguration.test.js
+++ b/packages/terra-functional-testing/tests/jest/config/utils/getRemoteScreenshotConfiguration.test.js
@@ -1,0 +1,97 @@
+jest.mock('fs-extra');
+jest.mock('js-yaml');
+const mockWarn = jest.fn();
+jest.mock('@cerner/terra-cli/lib/utils/Logger', () => function mock() {
+  return {
+    warn: mockWarn,
+  };
+});
+
+const fs = require('fs-extra');
+const path = require('path');
+const yaml = require('js-yaml');
+const getRemoteScreenshotConfiguration = require('../../../../src/config/utils/getRemoteScreenshotConfiguration');
+
+describe('getRemoteScreenshotConfiguration', () => {
+  const oldCwd = process.cwd;
+  beforeEach(() => {
+    mockWarn.mockClear();
+  });
+
+  beforeAll(() => {
+    process.cwd = jest.fn();
+    process.cwd.mockReturnValue('/app');
+
+    fs.readFileSync.mockReturnValue('yaml string');
+    yaml.safeLoad.mockReturnValue({
+      'cerner-release-main-site': {
+        username: 'username',
+        password: 'password',
+      },
+      'ion-snapshot-site': {
+        username: 'ion',
+        password: 'ion',
+      },
+    });
+  });
+
+  afterAll(() => {
+    process.cwd = oldCwd;
+  });
+
+  it('loads the default config', () => {
+    fs.readJsonSync.mockReturnValueOnce({
+      name: 'terra-functional-testing',
+      version: '1.0.0',
+      repository: {
+        url: 'https://github.com/cerner/terra-toolkit.git',
+      },
+    });
+
+    const config = getRemoteScreenshotConfiguration();
+    expect(config).toMatchSnapshot();
+    expect(fs.readJsonSync).toHaveBeenCalledWith(path.join(process.cwd(), 'package.json'));
+  });
+
+  it('loads the config from the package', () => {
+    fs.readJsonSync.mockReturnValueOnce({
+      name: 'terra-functional-testing',
+      version: '1.0.0',
+      repository: {
+        url: 'https://github.com/cerner/terra-toolkit.git',
+      },
+      rollOut: {
+        artifactId: 'mock-artifact-id',
+        groupId: 'mock-group-id',
+        site: {
+          repositoryId: 'release-internal-site',
+          repositoryUrl: 'http://repo.release.cerner.corp/nexus/service/local/repositories/internal-site',
+        },
+        jestConfig: 'jest.js',
+        webpackConfig: 'webpack.js',
+      },
+    });
+    const config = getRemoteScreenshotConfiguration();
+    expect(config).toMatchSnapshot();
+    expect(fs.readJsonSync).toHaveBeenCalledWith(path.join(process.cwd(), 'package.json'));
+  });
+
+  it('throws an error with a bad site', () => {
+    fs.readJsonSync.mockReturnValueOnce({
+      name: 'terra-functional-testing',
+      version: '1.0.0',
+      repository: {
+        url: 'https://github.com/cerner/terra-toolkit.git',
+      },
+      rollOut: {
+        artifactId: 'mock-artifact-id',
+        groupId: 'mock-group-id',
+        site: {
+          repositoryId: 'release-internal-site',
+          repositoryUrl: 'http://www.badsite.com',
+        },
+      },
+    });
+    expect(() => getRemoteScreenshotConfiguration()).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/packages/terra-toolkit-docs/CHANGELOG.md
+++ b/packages/terra-toolkit-docs/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+* Added
+  * Added upgrade guide for webpack-config-terra
 
 ## 2.7.0 - (November 16, 2021)
 

--- a/packages/terra-toolkit-docs/src/terra-dev-site/tool/webpackConfigTerra/upgrade-guide.6/Version 3.x.tool.mdx
+++ b/packages/terra-toolkit-docs/src/terra-dev-site/tool/webpackConfigTerra/upgrade-guide.6/Version 3.x.tool.mdx
@@ -11,7 +11,7 @@ import { Badge } from '@cerner/webpack-config-terra/package.json?dev-site-packag
 Webpack-dev-server has been updated to latest version 4.x. This update will fix hot reloading issue on development mode which was stopped working after upgrading Webpack to verison 5
 
 #### Breaking Changes
-Webpack-dev-server version 3 will not work with webpack-config-terra version 3.0.0. the webpack-dev-server has replaced the configuration options ( listed below ) in it's latest version v4, this changes will cause webpack-dev-server v3 configurations to fail when webpack-config-terra is updated to v3.
+Webpack-dev-server version 3 will not work with webpack-config-terra version 3.0.0. the webpack-dev-server has replaced the configuration options ( listed below ) in it's latest version v4, this changes will cause webpack-dev-server v3 configurations to fail with webpack-config-terra v3.
 - `inline` has been removed without replacement in webpack-dev-server v4.
 - `stats`, `index` and `publicPath` has been moved to `devMiddleware` option.
 

--- a/packages/terra-toolkit-docs/src/terra-dev-site/tool/webpackConfigTerra/upgrade-guide.6/Version 3.x.tool.mdx
+++ b/packages/terra-toolkit-docs/src/terra-dev-site/tool/webpackConfigTerra/upgrade-guide.6/Version 3.x.tool.mdx
@@ -15,7 +15,7 @@ Webpack-dev-server version 3 will not work with webpack-config-terra version 3.0
 - `inline` has been removed without replacement in webpack-dev-server v4.
 - `stats`, `index` and `publicPath` has been moved to `devMiddleware` option.
 
-Updating webpack-config-terra to version 3.0.0 would require consuming projects to update webpack-dev-server to version 4 in there local dependencies.
+Updating webpack-config-terra to version 3.0.0 would require consuming projects to update webpack-dev-server to version 4 in their local dependencies.
 ```diff
   "devDependencies": {
 -   "webpack-dev-server": "^3.x.x"

--- a/packages/terra-toolkit-docs/src/terra-dev-site/tool/webpackConfigTerra/upgrade-guide.6/Version 3.x.tool.mdx
+++ b/packages/terra-toolkit-docs/src/terra-dev-site/tool/webpackConfigTerra/upgrade-guide.6/Version 3.x.tool.mdx
@@ -1,0 +1,24 @@
+import { Badge } from '@cerner/webpack-config-terra/package.json?dev-site-package';
+
+<Badge />
+
+# webpack-config-terra Upgrade Guide
+
+## Changes from @cerner/webpack-config-terra 2.0.0 to @cerner/webpack-config-terra 3.0.0
+
+#### Updated Webpack-Dev-Server from version 3 to verison 4
+
+Webpack-dev-server has been updated to latest version 4.x. This update will fix hot reloading issue on development mode which was stopped working after upgrading Webpack to verison 5
+
+#### Breaking Changes
+Webpack-dev-server version 3 will not work with webpack-config-terra version 3.0.0. the webpack-dev-server has replaced the configuration options ( listed below ) in it's latest version v4, this changes will cause webpack-dev-server v3 configurations to fail when webpack-config-terra is updated to v3.
+- `inline` has been removed without replacement in webpack-dev-server v4.
+- `stats`, `index` and `publicPath` has been moved to `devMiddleware` option.
+
+Updating webpack-config-terra to version 3.0.0 would require consuming projects to update webpack-dev-server to version 4 in there local dependencies.
+```diff
+  "devDependencies": {
+-   "webpack-dev-server": "^3.x.x"
++   "webpack-dev-server": "^4.7.2"
+  }
+```

--- a/packages/webpack-config-terra/CHANGELOG.md
+++ b/packages/webpack-config-terra/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Added
+* Breaking
   * Added devMiddleWare to support webpack-dev-server v4
 
 * Changed

--- a/packages/webpack-config-terra/CHANGELOG.md
+++ b/packages/webpack-config-terra/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+
 * Added
   * Added devMiddleWare to support webpack-dev-server v4
 

--- a/packages/webpack-config-terra/CHANGELOG.md
+++ b/packages/webpack-config-terra/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+* Added
+  * Added devMiddleWare to support webpack-dev-server v4
 
 ## 2.2.0 - (September 28, 2021)
 

--- a/packages/webpack-config-terra/src/webpack.config.js
+++ b/packages/webpack-config-terra/src/webpack.config.js
@@ -236,10 +236,12 @@ const defaultWebpackConfig = (env = {}, argv = {}, options = {}) => {
     devServer: {
       ...getWebpackDevServerStaticOptions(env),
       host: '0.0.0.0',
-      publicPath,
-      stats: {
-        colors: true,
-        children: false,
+      devMiddleware: {
+        publicPath,
+        stats: {
+          colors: true,
+          children: false,
+        },
       },
     },
     devtool: 'eval-source-map',

--- a/packages/webpack-config-terra/src/webpack.config.js
+++ b/packages/webpack-config-terra/src/webpack.config.js
@@ -236,6 +236,9 @@ const defaultWebpackConfig = (env = {}, argv = {}, options = {}) => {
     devServer: {
       ...getWebpackDevServerStaticOptions(env),
       host: '0.0.0.0',
+      client: {
+        overlay: false,
+      },
       devMiddleware: {
         publicPath,
         stats: {

--- a/packages/webpack-config-terra/tests/jest/webpack.config.test.js
+++ b/packages/webpack-config-terra/tests/jest/webpack.config.test.js
@@ -216,11 +216,14 @@ describe('webpack config', () => {
     //  and adds to dev server options', () => {
     const expectedOuput = {
       hot: false,
-      inline: false,
       host: '0.0.0.0',
-      stats: {
-        colors: true,
-        children: false,
+      inline: false,
+      devMiddleware: {
+        publicPath: '',
+        stats: {
+          children: false,
+          colors: true,
+        },
       },
     };
     expect(config.devServer).toEqual(expect.objectContaining(expectedOuput));

--- a/packages/webpack-config-terra/tests/jest/webpack.config.test.js
+++ b/packages/webpack-config-terra/tests/jest/webpack.config.test.js
@@ -217,7 +217,6 @@ describe('webpack config', () => {
     const expectedOuput = {
       hot: false,
       host: '0.0.0.0',
-      inline: false,
       devMiddleware: {
         publicPath: '',
         stats: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,7 +44,9 @@ module.exports = (env = {}) => {
       path: path.join(process.cwd(), 'build'),
     },
     devServer: {
-      publicPath: '/',
+      devMiddleware: {
+        publicPath: '/',
+      },
     },
     mode: 'production',
   };


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->
Updates Webpack-dev-server to latest version to keep it compatible with webpack 5.

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->
webpack-dev-server v4 has few breaking changes as mentioned in the migration doc [here](https://github.com/webpack/webpack-dev-server/blob/master/migration-v4.md). hence updated webpack-config-terra and functional-testing webpack-server to the same to make it compatible with webpack-dev-server 4. 

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE

PR to verify webpack-dev-server update : 
[terra-core](https://github.com/cerner/terra-core/pull/3568)
[terra-framework](https://github.com/cerner/terra-framework/pull/1501)
Have verified with Orion-Example-Component-JS and link has been provided on Jira.