### PR TITLE
bumped package-json-lint

### DIFF
--- a/packages/package-json-lint-config-terra/CHANGELOG.md
+++ b/packages/package-json-lint-config-terra/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Changed
+  * Minor dependency bump
 ## 1.2.0 - (October 12, 2021)
 
 * Added

--- a/packages/package-json-lint-config-terra/package.json
+++ b/packages/package-json-lint-config-terra/package.json
@@ -33,6 +33,6 @@
     "lint": "eslint --ext .js,.jsx ."
   },
   "peerDependencies": {
-    "@cerner/package-json-lint": "^0.0.0"
+    "@cerner/package-json-lint": "^1.0.0"
   }
 }


### PR DESCRIPTION
### Summary
I was seeing errors installing terra-framework:
```
npm WARN @cerner/package-json-lint-config-terra@1.2.0 requires a peer of @cerner/package-json-lint@^0.0.0 but none is installed. You must install peer dependencies yourself.
```
It does not seem right to depend on a 0.0.0 version, so I bumped it to 1.0 This PR should fix that problem, once terra-framework is updated to consume the new version of this project.
