### PR TITLE
Revert Node version to support versions greater than 14 and publish packages

### DIFF
--- a/packages/duplicate-package-checker-webpack-plugin/CHANGELOG.md
+++ b/packages/duplicate-package-checker-webpack-plugin/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## 2.3.0 - (February 11, 2022)
 
 * Changed
-  * Revert Node version to support versions greater than 14.
+  * Revert limiting upper Node version to 14.
 
 ## 2.2.0 - (February 8, 2022)
 

--- a/packages/duplicate-package-checker-webpack-plugin/CHANGELOG.md
+++ b/packages/duplicate-package-checker-webpack-plugin/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Revert Node version to support versions greater than 14.
+
 ## 2.2.0 - (February 8, 2022)
 
 * Changed

--- a/packages/duplicate-package-checker-webpack-plugin/CHANGELOG.md
+++ b/packages/duplicate-package-checker-webpack-plugin/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 2.3.0 - (February 11, 2022)
+
 * Changed
   * Revert Node version to support versions greater than 14.
 

--- a/packages/duplicate-package-checker-webpack-plugin/README.md
+++ b/packages/duplicate-package-checker-webpack-plugin/README.md
@@ -77,7 +77,7 @@ It is suggested that strict mode is kept enabled since this improves visibility 
 
 ## Node version support
 
-This package was developed and tested using Node 10 up to Node 14. This package has not been thoroughly tested using Node 16 or greater. No known issues have been reported in newer Node versions, so this package is set to allow Node version 10 or greater. However, consumers utilizing Node 16 or greater should use this package at their own risk.
+This package was developed and tested using Node 10 up to Node 14. Consumers using Node 16 or greater are advised to use it at their own risk since those versions are not officially supported due to lack of thorough testing.
 
 ## Resolving duplicate packages in your bundle
 

--- a/packages/duplicate-package-checker-webpack-plugin/README.md
+++ b/packages/duplicate-package-checker-webpack-plugin/README.md
@@ -77,7 +77,7 @@ It is suggested that strict mode is kept enabled since this improves visibility 
 
 ## Node version support
 
-This package was developed and tested using Node 10 up to Node 14. This package has not been tested by us using Node 16 or greater. We don't want to restrict consumers on Node 16 or greater from using this package. For this reason the node version in package.json is set to `>=10` to allow Node 16 and above to use the package. No known issues were reported in newer Node versions but it is recommended that consumers to fully test it if you're using Node 16 or greater and report any issue.
+This package was developed and tested using Node 10 up to Node 14. This package has not been thoroughly tested using Node 16 or greater. No known issues have been reported in newer Node versions, so this package is set to allow Node version 10 or greater. However, consumers utilizing Node 16 or greater should use this package at their own risk.
 
 ## Resolving duplicate packages in your bundle
 

--- a/packages/duplicate-package-checker-webpack-plugin/README.md
+++ b/packages/duplicate-package-checker-webpack-plugin/README.md
@@ -75,6 +75,10 @@ Packages with different major versions introduce backward incompatible changes a
 
 It is suggested that strict mode is kept enabled since this improves visibility into your bundle and can help in solving and identifying potential issues.
 
+## Node version support
+
+This package was developed and tested using Node 10 up to Node 14. This package has not been tested by us using Node 16 or greater. We don't want to restrict consumers on Node 16 or greater from using this package. For this reason the node version in package.json is set to `>=10` to allow Node 16 and above to use the package. No known issues were reported in newer Node versions but it is recommended that consumers to fully test it if you're using Node 16 or greater and report any issue.
+
 ## Resolving duplicate packages in your bundle
 
 There are multiple ways you can go about resolving duplicate packages in your bundle, the right solution mostly depends on what tools you're using and on each particular case.

--- a/packages/duplicate-package-checker-webpack-plugin/package.json
+++ b/packages/duplicate-package-checker-webpack-plugin/package.json
@@ -4,7 +4,7 @@
   "description": "Webpack plugin that warns you when multiple versions of the same package exist in a build.",
   "main": "lib/index.js",
   "engines": {
-    "node": "^10.0.0 || ^12.0.0 || ^14.0.0"
+    "node": ">=10"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/duplicate-package-checker-webpack-plugin/package.json
+++ b/packages/duplicate-package-checker-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerner/duplicate-package-checker-webpack-plugin",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Webpack plugin that warns you when multiple versions of the same package exist in a build.",
   "main": "lib/index.js",
   "engines": {

--- a/packages/eslint-config-terra/CHANGELOG.md
+++ b/packages/eslint-config-terra/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Revert Node version to support versions greater than 14.
+
 ## 5.3.0 - (February 8, 2022)
 
 * Changed
@@ -139,7 +142,7 @@
 
 * Changed
   * Update ESLint and related dependencies to ESLint v5 compatible versions
-  * Disabled the deprecated `jsx-a11y/label-has-for rule`. More info about this rule deprecation here: https://github.com/evcohen/eslint-plugin-jsx-a11y/releases/tag/v6.1.0
+  * Disabled the deprecated `jsx-a11y/label-has-for rule`. More info about this rule deprecation here: <https://github.com/evcohen/eslint-plugin-jsx-a11y/releases/tag/v6.1.0>
   * Replaced `jsx-a11y/label-has-for` rule with new `jsx-a11y/label-has-associated-control` rule
   * Disabled `react/destructuring-assignment` rule
 
@@ -147,6 +150,7 @@
 
 * Changed
   * Updated 'jsx-a11y/label-has-for' to require id or nested input for label mapping
+  
 ## 1.0.1 - (June 19, 2018)
 
 * Changed

--- a/packages/eslint-config-terra/CHANGELOG.md
+++ b/packages/eslint-config-terra/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 5.4.0 - (February 11, 2022)
+
 * Changed
   * Revert Node version to support versions greater than 14.
 

--- a/packages/eslint-config-terra/CHANGELOG.md
+++ b/packages/eslint-config-terra/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## 5.4.0 - (February 11, 2022)
 
 * Changed
-  * Revert Node version to support versions greater than 14.
+  * Revert limiting upper Node version to 14.
 
 ## 5.3.0 - (February 8, 2022)
 

--- a/packages/eslint-config-terra/README.md
+++ b/packages/eslint-config-terra/README.md
@@ -47,7 +47,7 @@ Then, [define the browsers](https://github.com/amilajack/eslint-plugin-compat#ta
 
 ## Node version support
 
-This package was developed and tested using Node 10 up to Node 14. This package has not been tested by us using Node 16 or greater. We don't want to restrict consumers on Node 16 or greater from using this package. For this reason the node version in package.json is set to `>=10.13.0` to allow Node 16 and above to use the package. No known issues were reported in newer Node versions but it is recommended that consumers to fully test it if you're using Node 16 or greater and report any issue.
+This package was developed and tested using Node 10 up to Node 14. This package has not been thoroughly tested using Node 16 or greater. No known issues have been reported in newer Node versions, so this package is set to allow Node version 10 or greater. However, consumers utilizing Node 16 or greater should use this package at their own risk.
 
 ## Versioning
 

--- a/packages/eslint-config-terra/README.md
+++ b/packages/eslint-config-terra/README.md
@@ -47,7 +47,7 @@ Then, [define the browsers](https://github.com/amilajack/eslint-plugin-compat#ta
 
 ## Node version support
 
-This package was developed and tested using Node 10 up to Node 14. This package has not been thoroughly tested using Node 16 or greater. No known issues have been reported in newer Node versions, so this package is set to allow Node version 10 or greater. However, consumers utilizing Node 16 or greater should use this package at their own risk.
+This package was developed and tested using Node 10 up to Node 14. Consumers using Node 16 or greater are advised to use it at their own risk since those versions are not officially supported due to lack of thorough testing.
 
 ## Versioning
 

--- a/packages/eslint-config-terra/README.md
+++ b/packages/eslint-config-terra/README.md
@@ -45,6 +45,10 @@ Then, [define the browsers](https://github.com/amilajack/eslint-plugin-compat#ta
 }
 ```
 
+## Node version support
+
+This package was developed and tested using Node 10 up to Node 14. This package has not been tested by us using Node 16 or greater. We don't want to restrict consumers on Node 16 or greater from using this package. For this reason the node version in package.json is set to `>=10.13.0` to allow Node 16 and above to use the package. No known issues were reported in newer Node versions but it is recommended that consumers to fully test it if you're using Node 16 or greater and report any issue.
+
 ## Versioning
 
 eslint-config-terra is considered to be stable and will follow [SemVer](http://semver.org/) for versioning.

--- a/packages/eslint-config-terra/package.json
+++ b/packages/eslint-config-terra/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/cerner/terra-toolkit/issues"
   },
   "engines": {
-    "node": "^10.13.0 || ^12.0.0 || ^14.0.0"
+    "node": ">=10.13.0"
   },
   "homepage": "https://github.com/cerner/terra-toolkit",
   "scripts": {

--- a/packages/eslint-config-terra/package.json
+++ b/packages/eslint-config-terra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerner/eslint-config-terra",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "Terra Eslint Config",
   "main": "eslint.config.js",
   "publishConfig": {

--- a/packages/jest-config-terra/CHANGELOG.md
+++ b/packages/jest-config-terra/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## 1.5.0 - (February 11, 2022)
 
 * Changed
-  * Revert Node version to support versions greater than 14.
+  * Revert limiting upper Node version to 14.
 
 ## 1.4.0 - (February 8, 2022)
 

--- a/packages/jest-config-terra/CHANGELOG.md
+++ b/packages/jest-config-terra/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.5.0 - (February 11, 2022)
+
 * Changed
   * Revert Node version to support versions greater than 14.
 

--- a/packages/jest-config-terra/CHANGELOG.md
+++ b/packages/jest-config-terra/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Revert Node version to support versions greater than 14.
+
 ## 1.4.0 - (February 8, 2022)
 
 * Changed

--- a/packages/jest-config-terra/README.md
+++ b/packages/jest-config-terra/README.md
@@ -5,6 +5,10 @@
 
 A base jest config for the terra application framework.
 
+## Node version support
+
+This package was developed and tested using Node 10 up to Node 14. This package has not been tested by us using Node 16 or greater. We don't want to restrict consumers on Node 16 or greater from using this package. For this reason the node version in package.json is set to `>=10.13.0` to allow Node 16 and above to use the package. No known issues were reported in newer Node versions but it is recommended that consumers to fully test it if you're using Node 16 or greater and report any issue.
+
 ## Versioning
 
 jest-config-terra is considered to be stable and will follow [SemVer](http://semver.org/) for versioning.

--- a/packages/jest-config-terra/README.md
+++ b/packages/jest-config-terra/README.md
@@ -7,7 +7,7 @@ A base jest config for the terra application framework.
 
 ## Node version support
 
-This package was developed and tested using Node 10 up to Node 14. This package has not been tested by us using Node 16 or greater. We don't want to restrict consumers on Node 16 or greater from using this package. For this reason the node version in package.json is set to `>=10.13.0` to allow Node 16 and above to use the package. No known issues were reported in newer Node versions but it is recommended that consumers to fully test it if you're using Node 16 or greater and report any issue.
+This package was developed and tested using Node 10 up to Node 14. This package has not been thoroughly tested using Node 16 or greater. No known issues have been reported in newer Node versions, so this package is set to allow Node version 10 or greater. However, consumers utilizing Node 16 or greater should use this package at their own risk.
 
 ## Versioning
 

--- a/packages/jest-config-terra/README.md
+++ b/packages/jest-config-terra/README.md
@@ -7,7 +7,7 @@ A base jest config for the terra application framework.
 
 ## Node version support
 
-This package was developed and tested using Node 10 up to Node 14. This package has not been thoroughly tested using Node 16 or greater. No known issues have been reported in newer Node versions, so this package is set to allow Node version 10 or greater. However, consumers utilizing Node 16 or greater should use this package at their own risk.
+This package was developed and tested using Node 10 up to Node 14. Consumers using Node 16 or greater are advised to use it at their own risk since those versions are not officially supported due to lack of thorough testing.
 
 ## Versioning
 

--- a/packages/jest-config-terra/package.json
+++ b/packages/jest-config-terra/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/cerner/terra-toolkit/issues"
   },
   "engines": {
-    "node": "^10.13.0 || ^12.0.0 || ^14.0.0"
+    "node": ">=10.13.0"
   },
   "homepage": "https://github.com/cerner/terra-toolkit",
   "files": [

--- a/packages/jest-config-terra/package.json
+++ b/packages/jest-config-terra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerner/jest-config-terra",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "A base jest config for the terra application framework.",
   "main": "jest.config.js",
   "publishConfig": {
@@ -36,7 +36,7 @@
     "jest": "jest --config ../../jest.config.js"
   },
   "dependencies": {
-    "@cerner/terra-cli": "^1.8.0",
+    "@cerner/terra-cli": "^1.9.0",
     "@jest/reporters": "^25.3.0",
     "babel-jest": "^26.6.3",
     "identity-obj-proxy": "^3.0.0",

--- a/packages/package-json-lint-config-terra/CHANGELOG.md
+++ b/packages/package-json-lint-config-terra/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Revert Node version to support versions greater than 14.
+
 ## 1.3.0 - (February 8, 2022)
 
 * Changed
@@ -9,6 +12,7 @@
 
 * Changed
   * Minor dependency bump
+
 ## 1.2.0 - (October 12, 2021)
 
 * Added

--- a/packages/package-json-lint-config-terra/CHANGELOG.md
+++ b/packages/package-json-lint-config-terra/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.4.0 - (February 11, 2022)
+
 * Changed
   * Revert Node version to support versions greater than 14.
 

--- a/packages/package-json-lint-config-terra/CHANGELOG.md
+++ b/packages/package-json-lint-config-terra/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## 1.4.0 - (February 11, 2022)
 
 * Changed
-  * Revert Node version to support versions greater than 14.
+  * Revert limiting upper Node version to 14.
 
 ## 1.3.0 - (February 8, 2022)
 

--- a/packages/package-json-lint-config-terra/README.md
+++ b/packages/package-json-lint-config-terra/README.md
@@ -36,6 +36,10 @@ First, include the configuration defined by `@cerner/package-json-lint-config-te
 }
 ```
 
+## Node version support
+
+This package was developed and tested using Node 10 up to Node 14. This package has not been tested by us using Node 16 or greater. We don't want to restrict consumers on Node 16 or greater from using this package. For this reason the node version in package.json is set to `>=10.13.0` to allow Node 16 and above to use the package. No known issues were reported in newer Node versions but it is recommended that consumers to fully test it if you're using Node 16 or greater and report any issue.
+
 ## Versioning
 
 @cerner/package-json-lint-config-terra is considered to be stable and will follow [SemVer](http://semver.org/) for versioning.

--- a/packages/package-json-lint-config-terra/README.md
+++ b/packages/package-json-lint-config-terra/README.md
@@ -38,7 +38,7 @@ First, include the configuration defined by `@cerner/package-json-lint-config-te
 
 ## Node version support
 
-This package was developed and tested using Node 10 up to Node 14. This package has not been thoroughly tested using Node 16 or greater. No known issues have been reported in newer Node versions, so this package is set to allow Node version 10 or greater. However, consumers utilizing Node 16 or greater should use this package at their own risk.
+This package was developed and tested using Node 10 up to Node 14. Consumers using Node 16 or greater are advised to use it at their own risk since those versions are not officially supported due to lack of thorough testing.
 
 ## Versioning
 

--- a/packages/package-json-lint-config-terra/README.md
+++ b/packages/package-json-lint-config-terra/README.md
@@ -38,7 +38,7 @@ First, include the configuration defined by `@cerner/package-json-lint-config-te
 
 ## Node version support
 
-This package was developed and tested using Node 10 up to Node 14. This package has not been tested by us using Node 16 or greater. We don't want to restrict consumers on Node 16 or greater from using this package. For this reason the node version in package.json is set to `>=10.13.0` to allow Node 16 and above to use the package. No known issues were reported in newer Node versions but it is recommended that consumers to fully test it if you're using Node 16 or greater and report any issue.
+This package was developed and tested using Node 10 up to Node 14. This package has not been thoroughly tested using Node 16 or greater. No known issues have been reported in newer Node versions, so this package is set to allow Node version 10 or greater. However, consumers utilizing Node 16 or greater should use this package at their own risk.
 
 ## Versioning
 

--- a/packages/package-json-lint-config-terra/package.json
+++ b/packages/package-json-lint-config-terra/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/cerner/terra-toolkit/issues"
   },
   "engines": {
-    "node": "^10.13.0 || ^12.0.0 || ^14.0.0"
+    "node": ">=10.13.0"
   },
   "homepage": "https://github.com/cerner/terra-toolkit",
   "scripts": {

--- a/packages/package-json-lint-config-terra/package.json
+++ b/packages/package-json-lint-config-terra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerner/package-json-lint-config-terra",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Package Json Lint Config",
   "main": "package-json-lint.config.js",
   "publishConfig": {

--- a/packages/package-json-lint/CHANGELOG.md
+++ b/packages/package-json-lint/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## 1.5.0 - (February 11, 2022)
 
 * Changed
-  * Revert Node version to support versions greater than 14.
+  * Revert limiting upper Node version to 14.
 
 ## 1.4.0 - (February 8, 2022)
 

--- a/packages/package-json-lint/CHANGELOG.md
+++ b/packages/package-json-lint/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.5.0 - (February 11, 2022)
+
 * Changed
   * Revert Node version to support versions greater than 14.
 

--- a/packages/package-json-lint/CHANGELOG.md
+++ b/packages/package-json-lint/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Revert Node version to support versions greater than 14.
+
 ## 1.4.0 - (February 8, 2022)
 
 * Changed

--- a/packages/package-json-lint/README.md
+++ b/packages/package-json-lint/README.md
@@ -7,7 +7,7 @@ Linter for package.json files.
 
 ## Node version support
 
-This package was developed and tested using Node 10 up to Node 14. This package has not been tested by us using Node 16 or greater. We don't want to restrict consumers on Node 16 or greater from using this package. For this reason the node version in package.json is set to `>=10` to allow Node 16 and above to use the package. No known issues were reported in newer Node versions but it is recommended that consumers to fully test it if you're using Node 16 or greater and report any issue.
+This package was developed and tested using Node 10 up to Node 14. This package has not been thoroughly tested using Node 16 or greater. No known issues have been reported in newer Node versions, so this package is set to allow Node version 10 or greater. However, consumers utilizing Node 16 or greater should use this package at their own risk.
 
 ## Versioning
 

--- a/packages/package-json-lint/README.md
+++ b/packages/package-json-lint/README.md
@@ -5,6 +5,10 @@
 
 Linter for package.json files.
 
+## Node version support
+
+This package was developed and tested using Node 10 up to Node 14. This package has not been tested by us using Node 16 or greater. We don't want to restrict consumers on Node 16 or greater from using this package. For this reason the node version in package.json is set to `>=10` to allow Node 16 and above to use the package. No known issues were reported in newer Node versions but it is recommended that consumers to fully test it if you're using Node 16 or greater and report any issue.
+
 ## Versioning
 
 package-json-lint is considered to be stable and will follow [SemVer](http://semver.org/) for versioning.

--- a/packages/package-json-lint/README.md
+++ b/packages/package-json-lint/README.md
@@ -7,7 +7,7 @@ Linter for package.json files.
 
 ## Node version support
 
-This package was developed and tested using Node 10 up to Node 14. This package has not been thoroughly tested using Node 16 or greater. No known issues have been reported in newer Node versions, so this package is set to allow Node version 10 or greater. However, consumers utilizing Node 16 or greater should use this package at their own risk.
+This package was developed and tested using Node 10 up to Node 14. Consumers using Node 16 or greater are advised to use it at their own risk since those versions are not officially supported due to lack of thorough testing.
 
 ## Versioning
 

--- a/packages/package-json-lint/package.json
+++ b/packages/package-json-lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerner/package-json-lint",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Package JSON linter",
   "publishConfig": {
     "access": "public"
@@ -47,7 +47,7 @@
     "@cerner/terra-cli": "^1.0.0"
   },
   "devDependencies": {
-    "@cerner/terra-cli": "^1.8.0",
+    "@cerner/terra-cli": "^1.9.0",
     "strip-ansi": "^6.0.0",
     "yargs": "^16.1.1"
   }

--- a/packages/package-json-lint/package.json
+++ b/packages/package-json-lint/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/cerner/terra-toolkit/issues"
   },
   "engines": {
-    "node": "^10.0.0 || ^12.0.0 || ^14.0.0"
+    "node": ">=10"
   },
   "homepage": "https://github.com/cerner/terra-toolkit",
   "scripts": {

--- a/packages/stylelint-config-terra/CHANGELOG.md
+++ b/packages/stylelint-config-terra/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Revert Node version to support versions greater than 14.
+
 ## 4.2.0 - (February 8, 2022)
 
 * Changed

--- a/packages/stylelint-config-terra/CHANGELOG.md
+++ b/packages/stylelint-config-terra/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 4.3.0 - (February 11, 2022)
+
 * Changed
   * Revert Node version to support versions greater than 14.
 

--- a/packages/stylelint-config-terra/CHANGELOG.md
+++ b/packages/stylelint-config-terra/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## 4.3.0 - (February 11, 2022)
 
 * Changed
-  * Revert Node version to support versions greater than 14.
+  * Revert limiting upper Node version to 14.
 
 ## 4.2.0 - (February 8, 2022)
 

--- a/packages/stylelint-config-terra/README.md
+++ b/packages/stylelint-config-terra/README.md
@@ -60,6 +60,10 @@ The following custom rules are enabled by default.
 * [terra/custom-property-pattern](https://github.com/cerner/terra-toolkit/blob/main/packages/stylelint-config-terra/src/rules/custom-property-pattern): Requires custom properties to be written in lowercase alphanumeric characters and hyphens.
 * [terra/custom-property-pseudo-selectors](https://github.com/cerner/terra-toolkit/blob/main/packages/stylelint-config-terra/src/rules/custom-property-pseudo-selectors): Requires custom properties to include all ancestor pseudo selectors in order.
 
+## Node version support
+
+This package was developed and tested using Node 10 up to Node 14. This package has not been tested by us using Node 16 or greater. We don't want to restrict consumers on Node 16 or greater from using this package. For this reason the node version in package.json is set to `>=10` to allow Node 16 and above to use the package. No known issues were reported in newer Node versions but it is recommended that consumers to fully test it if you're using Node 16 or greater and report any issue.
+
 ## Contributing
 
 Please read through our [contributing guidelines](CONTRIBUTING.md). Included are directions for issue reporting and pull requests.

--- a/packages/stylelint-config-terra/README.md
+++ b/packages/stylelint-config-terra/README.md
@@ -62,7 +62,7 @@ The following custom rules are enabled by default.
 
 ## Node version support
 
-This package was developed and tested using Node 10 up to Node 14. This package has not been thoroughly tested using Node 16 or greater. No known issues have been reported in newer Node versions, so this package is set to allow Node version 10 or greater. However, consumers utilizing Node 16 or greater should use this package at their own risk.
+This package was developed and tested using Node 10 up to Node 14. Consumers using Node 16 or greater are advised to use it at their own risk since those versions are not officially supported due to lack of thorough testing.
 
 ## Contributing
 

--- a/packages/stylelint-config-terra/README.md
+++ b/packages/stylelint-config-terra/README.md
@@ -62,7 +62,7 @@ The following custom rules are enabled by default.
 
 ## Node version support
 
-This package was developed and tested using Node 10 up to Node 14. This package has not been tested by us using Node 16 or greater. We don't want to restrict consumers on Node 16 or greater from using this package. For this reason the node version in package.json is set to `>=10` to allow Node 16 and above to use the package. No known issues were reported in newer Node versions but it is recommended that consumers to fully test it if you're using Node 16 or greater and report any issue.
+This package was developed and tested using Node 10 up to Node 14. This package has not been thoroughly tested using Node 16 or greater. No known issues have been reported in newer Node versions, so this package is set to allow Node version 10 or greater. However, consumers utilizing Node 16 or greater should use this package at their own risk.
 
 ## Contributing
 

--- a/packages/stylelint-config-terra/package.json
+++ b/packages/stylelint-config-terra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerner/stylelint-config-terra",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "Terra Stylelint Shared Config",
   "main": "stylelint.config.js",
   "repository": {

--- a/packages/stylelint-config-terra/package.json
+++ b/packages/stylelint-config-terra/package.json
@@ -23,7 +23,7 @@
     "linter"
   ],
   "engines": {
-    "node": "^10.13.0 || ^12.0.0 || ^14.0.0"
+    "node": ">=10"
   },
   "author": "Cerner Corporation",
   "license": "Apache-2.0",

--- a/packages/terra-aggregate-translations/CHANGELOG.md
+++ b/packages/terra-aggregate-translations/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Revert Node version to support versions greater than 14.
+
 ## 2.3.0 - (February 8, 2022)
 
 * Changed

--- a/packages/terra-aggregate-translations/CHANGELOG.md
+++ b/packages/terra-aggregate-translations/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 2.4.0 - (February 11, 2022)
+
 * Changed
   * Revert Node version to support versions greater than 14.
 

--- a/packages/terra-aggregate-translations/CHANGELOG.md
+++ b/packages/terra-aggregate-translations/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## 2.4.0 - (February 11, 2022)
 
 * Changed
-  * Revert Node version to support versions greater than 14.
+  * Revert limiting upper Node version to 14.
 
 ## 2.3.0 - (February 8, 2022)
 

--- a/packages/terra-aggregate-translations/README.md
+++ b/packages/terra-aggregate-translations/README.md
@@ -151,7 +151,7 @@ module.exports = environment
 
 ## Node version support
 
-This package was developed and tested using Node 10 up to Node 14. This package has not been tested by us using Node 16 or greater. We don't want to restrict consumers on Node 16 or greater from using this package. For this reason the node version in package.json is set to `>=10` to allow Node 16 and above to use the package. No known issues were reported in newer Node versions but it is recommended that consumers to fully test it if you're using Node 16 or greater and report any issue.
+This package was developed and tested using Node 10 up to Node 14. This package has not been thoroughly tested using Node 16 or greater. No known issues have been reported in newer Node versions, so this package is set to allow Node version 10 or greater. However, consumers utilizing Node 16 or greater should use this package at their own risk.
 
 ## LICENSE
 

--- a/packages/terra-aggregate-translations/README.md
+++ b/packages/terra-aggregate-translations/README.md
@@ -149,6 +149,10 @@ environment.resolvedModules.append('aggregated-translations', 'tmp/aggregated-tr
 module.exports = environment
 ```
 
+## Node version support
+
+This package was developed and tested using Node 10 up to Node 14. This package has not been tested by us using Node 16 or greater. We don't want to restrict consumers on Node 16 or greater from using this package. For this reason the node version in package.json is set to `>=10` to allow Node 16 and above to use the package. No known issues were reported in newer Node versions but it is recommended that consumers to fully test it if you're using Node 16 or greater and report any issue.
+
 ## LICENSE
 
 Copyright 2019 - present Cerner Innovation, Inc.

--- a/packages/terra-aggregate-translations/README.md
+++ b/packages/terra-aggregate-translations/README.md
@@ -151,7 +151,7 @@ module.exports = environment
 
 ## Node version support
 
-This package was developed and tested using Node 10 up to Node 14. This package has not been thoroughly tested using Node 16 or greater. No known issues have been reported in newer Node versions, so this package is set to allow Node version 10 or greater. However, consumers utilizing Node 16 or greater should use this package at their own risk.
+This package was developed and tested using Node 10 up to Node 14. Consumers using Node 16 or greater are advised to use it at their own risk since those versions are not officially supported due to lack of thorough testing.
 
 ## LICENSE
 

--- a/packages/terra-aggregate-translations/package.json
+++ b/packages/terra-aggregate-translations/package.json
@@ -6,7 +6,7 @@
     "access": "public"
   },
   "engines": {
-    "node": "^10.0.0 || ^12.0.0 || ^14.0.0"
+    "node": ">=10"
   },
   "repository": {
     "type": "git",

--- a/packages/terra-aggregate-translations/package.json
+++ b/packages/terra-aggregate-translations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerner/terra-aggregate-translations",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "The terra-aggregate-translations pre-build tool assists with creating the translation, intl loader and translation loader files that are configured for the specified locales. This tool is offered as a CLI script and as a setup function.",
   "publishConfig": {
     "access": "public"

--- a/packages/terra-cli/CHANGELOG.md
+++ b/packages/terra-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Revert Node version to support versions greater than 14.
+
 ## 1.8.0 - (February 8, 2022)
 
 * Changed

--- a/packages/terra-cli/CHANGELOG.md
+++ b/packages/terra-cli/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## 1.9.0 - (February 11, 2022)
 
 * Changed
-  * Revert Node version to support versions greater than 14.
+  * Revert limiting upper Node version to 14.
 
 ## 1.8.0 - (February 8, 2022)
 

--- a/packages/terra-cli/CHANGELOG.md
+++ b/packages/terra-cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.9.0 - (February 11, 2022)
+
 * Changed
   * Revert Node version to support versions greater than 14.
 

--- a/packages/terra-cli/README.md
+++ b/packages/terra-cli/README.md
@@ -7,7 +7,7 @@ Terra's common CLI for package commands.
 
 ## Node version support
 
-This package was developed and tested using Node 10 up to Node 14. This package has not been thoroughly tested using Node 16 or greater. No known issues have been reported in newer Node versions, so this package is set to allow Node version 10 or greater. However, consumers utilizing Node 16 or greater should use this package at their own risk.
+This package was developed and tested using Node 10 up to Node 14. Consumers using Node 16 or greater are advised to use it at their own risk since those versions are not officially supported due to lack of thorough testing.
 
 ## Versioning
 

--- a/packages/terra-cli/README.md
+++ b/packages/terra-cli/README.md
@@ -5,6 +5,10 @@
 
 Terra's common CLI for package commands.
 
+## Node version support
+
+This package was developed and tested using Node 10 up to Node 14. This package has not been tested by us using Node 16 or greater. We don't want to restrict consumers on Node 16 or greater from using this package. For this reason the node version in package.json is set to `>=10.13.0` to allow Node 16 and above to use the package. No known issues were reported in newer Node versions but it is recommended that consumers to fully test it if you're using Node 16 or greater and report any issue.
+
 ## Versioning
 
 terra-cli is considered to be stable and will follow [SemVer](http://semver.org/) for versioning.

--- a/packages/terra-cli/README.md
+++ b/packages/terra-cli/README.md
@@ -7,7 +7,7 @@ Terra's common CLI for package commands.
 
 ## Node version support
 
-This package was developed and tested using Node 10 up to Node 14. This package has not been tested by us using Node 16 or greater. We don't want to restrict consumers on Node 16 or greater from using this package. For this reason the node version in package.json is set to `>=10.13.0` to allow Node 16 and above to use the package. No known issues were reported in newer Node versions but it is recommended that consumers to fully test it if you're using Node 16 or greater and report any issue.
+This package was developed and tested using Node 10 up to Node 14. This package has not been thoroughly tested using Node 16 or greater. No known issues have been reported in newer Node versions, so this package is set to allow Node version 10 or greater. However, consumers utilizing Node 16 or greater should use this package at their own risk.
 
 ## Versioning
 

--- a/packages/terra-cli/package.json
+++ b/packages/terra-cli/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/cerner/terra-toolkit/issues"
   },
   "engines": {
-    "node": "^10.13.0 || ^12.0.0 || ^14.0.0"
+    "node": ">=10.13.0"
   },
   "homepage": "https://github.com/cerner/terra-toolkit",
   "scripts": {

--- a/packages/terra-cli/package.json
+++ b/packages/terra-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerner/terra-cli",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Terra Cli",
   "main": "index.js",
   "bin": {

--- a/packages/terra-enzyme-intl/CHANGELOG.md
+++ b/packages/terra-enzyme-intl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 4.6.0 - (February 11, 2022)
+
 * Changed
   * Revert Node version to support versions greater than 14.
 

--- a/packages/terra-enzyme-intl/CHANGELOG.md
+++ b/packages/terra-enzyme-intl/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## 4.6.0 - (February 11, 2022)
 
 * Changed
-  * Revert Node version to support versions greater than 14.
+  * Revert limiting upper Node version to 14.
 
 ## 4.5.0 - (February 8, 2022)
 

--- a/packages/terra-enzyme-intl/CHANGELOG.md
+++ b/packages/terra-enzyme-intl/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Revert Node version to support versions greater than 14.
+
 ## 4.5.0 - (February 8, 2022)
 
 * Changed

--- a/packages/terra-enzyme-intl/README.md
+++ b/packages/terra-enzyme-intl/README.md
@@ -171,7 +171,7 @@ expect(result).toMatchSnapshot(); // OK, doesn't depend on real translations
 
 ## Node version support
 
-This package was developed and tested using Node 10 up to Node 14. This package has not been tested by us using Node 16 or greater. We don't want to restrict consumers on Node 16 or greater from using this package. For this reason the node version in package.json is set to `>=10` to allow Node 16 and above to use the package. No known issues were reported in newer Node versions but it is recommended that consumers to fully test it if you're using Node 16 or greater and report any issue.
+This package was developed and tested using Node 10 up to Node 14. This package has not been thoroughly tested using Node 16 or greater. No known issues have been reported in newer Node versions, so this package is set to allow Node version 10 or greater. However, consumers utilizing Node 16 or greater should use this package at their own risk.
 
 ## LICENSE
 

--- a/packages/terra-enzyme-intl/README.md
+++ b/packages/terra-enzyme-intl/README.md
@@ -169,6 +169,10 @@ const result = foo(id, mockIntl);
 expect(result).toMatchSnapshot(); // OK, doesn't depend on real translations
 ```
 
+## Node version support
+
+This package was developed and tested using Node 10 up to Node 14. This package has not been tested by us using Node 16 or greater. We don't want to restrict consumers on Node 16 or greater from using this package. For this reason the node version in package.json is set to `>=10` to allow Node 16 and above to use the package. No known issues were reported in newer Node versions but it is recommended that consumers to fully test it if you're using Node 16 or greater and report any issue.
+
 ## LICENSE
 
 Copyright 2018 - 2020 Cerner Innovation, Inc.

--- a/packages/terra-enzyme-intl/README.md
+++ b/packages/terra-enzyme-intl/README.md
@@ -171,7 +171,7 @@ expect(result).toMatchSnapshot(); // OK, doesn't depend on real translations
 
 ## Node version support
 
-This package was developed and tested using Node 10 up to Node 14. This package has not been thoroughly tested using Node 16 or greater. No known issues have been reported in newer Node versions, so this package is set to allow Node version 10 or greater. However, consumers utilizing Node 16 or greater should use this package at their own risk.
+This package was developed and tested using Node 10 up to Node 14. Consumers using Node 16 or greater are advised to use it at their own risk since those versions are not officially supported due to lack of thorough testing.
 
 ## LICENSE
 

--- a/packages/terra-enzyme-intl/package.json
+++ b/packages/terra-enzyme-intl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerner/terra-enzyme-intl",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "description": "Enzyme helpers for fortifying tests that depend on react-intl by decoupling the need for actual translations.",
   "main": "lib/index.js",
   "publishConfig": {

--- a/packages/terra-enzyme-intl/package.json
+++ b/packages/terra-enzyme-intl/package.json
@@ -7,7 +7,7 @@
     "access": "public"
   },
   "engines": {
-    "node": "^10.0.0 || ^12.0.0 || ^14.0.0"
+    "node": ">=10"
   },
   "repository": {
     "type": "git",

--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 2.7.0 - (February 11, 2022)
+
+* Changed
+  * Minor dependency version bump
+
 ## 2.6.0 - (February 8, 2022)
 
 * Changed

--- a/packages/terra-functional-testing/package.json
+++ b/packages/terra-functional-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerner/terra-functional-testing",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "main": "lib/index.js",
   "description": "A functional testing utility for applications built using Terra.",
   "publishConfig": {
@@ -83,7 +83,7 @@
     "webpack-cli": "^3.3.12 || ^4.0.0"
   },
   "devDependencies": {
-    "@cerner/terra-cli": "^1.8.0",
+    "@cerner/terra-cli": "^1.9.0",
     "chai": "^4.2.0",
     "lodash.groupby": "^4.6.0",
     "lodash.map": "^4.6.0",

--- a/packages/terra-open-source-scripts/CHANGELOG.md
+++ b/packages/terra-open-source-scripts/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## 1.12.0 - (February 11, 2022)
 
 * Changed
-  * Revert Node version to support versions greater than 14.
+  * Revert limiting upper Node version to 14.
 
 ## 1.11.0 - (February 8, 2022)
 

--- a/packages/terra-open-source-scripts/CHANGELOG.md
+++ b/packages/terra-open-source-scripts/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Revert Node version to support versions greater than 14.
+
 ## 1.11.0 - (February 8, 2022)
 
 * Changed

--- a/packages/terra-open-source-scripts/CHANGELOG.md
+++ b/packages/terra-open-source-scripts/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.12.0 - (February 11, 2022)
+
 * Changed
   * Revert Node version to support versions greater than 14.
 

--- a/packages/terra-open-source-scripts/README.md
+++ b/packages/terra-open-source-scripts/README.md
@@ -10,7 +10,7 @@ Terra's common open source scripts provided as [terra-cli](https://www.npmjs.org
 
 ## Node version support
 
-This package was developed and tested using Node 10 up to Node 14. This package has not been thoroughly tested using Node 16 or greater. No known issues have been reported in newer Node versions, so this package is set to allow Node version 10 or greater. However, consumers utilizing Node 16 or greater should use this package at their own risk.
+This package was developed and tested using Node 10 up to Node 14. Consumers using Node 16 or greater are advised to use it at their own risk since those versions are not officially supported due to lack of thorough testing.
 
 ## Versioning
 

--- a/packages/terra-open-source-scripts/README.md
+++ b/packages/terra-open-source-scripts/README.md
@@ -8,6 +8,10 @@ Terra's common open source scripts provided as [terra-cli](https://www.npmjs.org
 * prepare-for-release - prepares a given project for release by updating versions and changelogs. Supports both single and mono repos
 * release - releases a given project to npm and tags it in git. Supports both single and mono repos
 
+## Node version support
+
+This package was developed and tested using Node 10 up to Node 14. This package has not been tested by us using Node 16 or greater. We don't want to restrict consumers on Node 16 or greater from using this package. For this reason the node version in package.json is set to `>=10.13.0` to allow Node 16 and above to use the package. No known issues were reported in newer Node versions but it is recommended that consumers to fully test it if you're using Node 16 or greater and report any issue.
+
 ## Versioning
 
 terra-cli is considered to be stable and will follow [SemVer](http://semver.org/) for versioning.

--- a/packages/terra-open-source-scripts/README.md
+++ b/packages/terra-open-source-scripts/README.md
@@ -10,7 +10,7 @@ Terra's common open source scripts provided as [terra-cli](https://www.npmjs.org
 
 ## Node version support
 
-This package was developed and tested using Node 10 up to Node 14. This package has not been tested by us using Node 16 or greater. We don't want to restrict consumers on Node 16 or greater from using this package. For this reason the node version in package.json is set to `>=10.13.0` to allow Node 16 and above to use the package. No known issues were reported in newer Node versions but it is recommended that consumers to fully test it if you're using Node 16 or greater and report any issue.
+This package was developed and tested using Node 10 up to Node 14. This package has not been thoroughly tested using Node 16 or greater. No known issues have been reported in newer Node versions, so this package is set to allow Node version 10 or greater. However, consumers utilizing Node 16 or greater should use this package at their own risk.
 
 ## Versioning
 

--- a/packages/terra-open-source-scripts/package.json
+++ b/packages/terra-open-source-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerner/terra-open-source-scripts",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Terra package with various scripts for open source development",
   "main": "index.js",
   "publishConfig": {
@@ -43,7 +43,7 @@
     "@cerner/terra-cli": "^1.0.0"
   },
   "devDependencies": {
-    "@cerner/terra-cli": "^1.8.0",
+    "@cerner/terra-cli": "^1.9.0",
     "yargs": "^16.1.1"
   }
 }

--- a/packages/terra-open-source-scripts/package.json
+++ b/packages/terra-open-source-scripts/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/cerner/terra-toolkit/issues"
   },
   "engines": {
-    "node": "^10.13.0 || ^12.0.0 || ^14.0.0"
+    "node": ">=10.13.0"
   },
   "homepage": "https://github.com/cerner/terra-toolkit",
   "scripts": {

--- a/packages/terra-toolkit-docs/CHANGELOG.md
+++ b/packages/terra-toolkit-docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 2.9.0 - (February 11, 2022)
+
 * Changed
   * Revert Node version to support versions greater than 14.
 

--- a/packages/terra-toolkit-docs/CHANGELOG.md
+++ b/packages/terra-toolkit-docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Revert Node version to support versions greater than 14.
+
 ## 2.8.0 - (February 8, 2022)
 
 * Changed

--- a/packages/terra-toolkit-docs/CHANGELOG.md
+++ b/packages/terra-toolkit-docs/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## 2.9.0 - (February 11, 2022)
 
 * Changed
-  * Revert Node version to support versions greater than 14.
+  * Revert limiting upper Node version to 14.
 
 ## 2.8.0 - (February 8, 2022)
 

--- a/packages/terra-toolkit-docs/README.md
+++ b/packages/terra-toolkit-docs/README.md
@@ -7,7 +7,7 @@ Contains documentation for packages in the terra-toolkit monorepo
 
 ## Node version support
 
-This package was developed and tested using Node 10 up to Node 14. This package has not been thoroughly tested using Node 16 or greater. No known issues have been reported in newer Node versions, so this package is set to allow Node version 10 or greater. However, consumers utilizing Node 16 or greater should use this package at their own risk.
+This package was developed and tested using Node 10 up to Node 14. Consumers using Node 16 or greater are advised to use it at their own risk since those versions are not officially supported due to lack of thorough testing.
 
 ## Versioning
 

--- a/packages/terra-toolkit-docs/README.md
+++ b/packages/terra-toolkit-docs/README.md
@@ -5,6 +5,10 @@
 
 Contains documentation for packages in the terra-toolkit monorepo
 
+## Node version support
+
+This package was developed and tested using Node 10 up to Node 14. This package has not been tested by us using Node 16 or greater. We don't want to restrict consumers on Node 16 or greater from using this package. For this reason the node version in package.json is set to `>=10.13.0` to allow Node 16 and above to use the package. No known issues were reported in newer Node versions but it is recommended that consumers to fully test it if you're using Node 16 or greater and report any issue.
+
 ## Versioning
 
 terra-toolkit-docs is considered to be stable and will follow [SemVer](http://semver.org/) for versioning.

--- a/packages/terra-toolkit-docs/README.md
+++ b/packages/terra-toolkit-docs/README.md
@@ -7,7 +7,7 @@ Contains documentation for packages in the terra-toolkit monorepo
 
 ## Node version support
 
-This package was developed and tested using Node 10 up to Node 14. This package has not been tested by us using Node 16 or greater. We don't want to restrict consumers on Node 16 or greater from using this package. For this reason the node version in package.json is set to `>=10.13.0` to allow Node 16 and above to use the package. No known issues were reported in newer Node versions but it is recommended that consumers to fully test it if you're using Node 16 or greater and report any issue.
+This package was developed and tested using Node 10 up to Node 14. This package has not been thoroughly tested using Node 16 or greater. No known issues have been reported in newer Node versions, so this package is set to allow Node version 10 or greater. However, consumers utilizing Node 16 or greater should use this package at their own risk.
 
 ## Versioning
 

--- a/packages/terra-toolkit-docs/package.json
+++ b/packages/terra-toolkit-docs/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/cerner/terra-toolkit/issues"
   },
   "engines": {
-    "node": "^10.13.0 || ^12.0.0 || ^14.0.0"
+    "node": ">=10.13.0"
   },
   "homepage": "https://github.com/cerner/terra-toolkit",
   "scripts": {

--- a/packages/terra-toolkit-docs/package.json
+++ b/packages/terra-toolkit-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerner/terra-toolkit-docs",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "Contains documentation for packages in the terra-toolkit monorepo",
   "main": "index.js",
   "publishConfig": {
@@ -32,11 +32,11 @@
     "precompile": "rm -rf lib"
   },
   "dependencies": {
-    "@cerner/eslint-config-terra": "^5.3.0",
-    "@cerner/jest-config-terra": "^1.4.0",
-    "@cerner/package-json-lint": "^1.4.0",
-    "@cerner/stylelint-config-terra": "^4.2.0",
-    "@cerner/terra-functional-testing": "^2.6.0",
-    "@cerner/webpack-config-terra": "^2.3.0"
+    "@cerner/eslint-config-terra": "^5.4.0",
+    "@cerner/jest-config-terra": "^1.5.0",
+    "@cerner/package-json-lint": "^1.5.0",
+    "@cerner/stylelint-config-terra": "^4.3.0",
+    "@cerner/terra-functional-testing": "^2.7.0",
+    "@cerner/webpack-config-terra": "^2.4.0"
   }
 }

--- a/packages/webpack-config-terra/CHANGELOG.md
+++ b/packages/webpack-config-terra/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Revert Node version to support versions greater than 14.
+
 ## 2.3.0 - (February 8, 2022)
 
 * Changed

--- a/packages/webpack-config-terra/CHANGELOG.md
+++ b/packages/webpack-config-terra/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 2.4.0 - (February 11, 2022)
+
 * Changed
   * Revert Node version to support versions greater than 14.
 

--- a/packages/webpack-config-terra/CHANGELOG.md
+++ b/packages/webpack-config-terra/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## 2.4.0 - (February 11, 2022)
 
 * Changed
-  * Revert Node version to support versions greater than 14.
+  * Revert limiting upper Node version to 14.
 
 ## 2.3.0 - (February 8, 2022)
 

--- a/packages/webpack-config-terra/README.md
+++ b/packages/webpack-config-terra/README.md
@@ -7,7 +7,7 @@ Terra's sharable Webpack configuration.
 
 ## Node version support
 
-This package was developed and tested using Node 10 up to Node 14. This package has not been thoroughly tested using Node 16 or greater. No known issues have been reported in newer Node versions, so this package is set to allow Node version 10 or greater. However, consumers utilizing Node 16 or greater should use this package at their own risk.
+This package was developed and tested using Node 10 up to Node 14. Consumers using Node 16 or greater are advised to use it at their own risk since those versions are not officially supported due to lack of thorough testing.
 
 ## Versioning
 

--- a/packages/webpack-config-terra/README.md
+++ b/packages/webpack-config-terra/README.md
@@ -5,6 +5,10 @@
 
 Terra's sharable Webpack configuration.
 
+## Node version support
+
+This package was developed and tested using Node 10 up to Node 14. This package has not been tested by us using Node 16 or greater. We don't want to restrict consumers on Node 16 or greater from using this package. For this reason the node version in package.json is set to `>=10.13.0` to allow Node 16 and above to use the package. No known issues were reported in newer Node versions but it is recommended that consumers to fully test it if you're using Node 16 or greater and report any issue.
+
 ## Versioning
 
 webpack-config-terra is considered to be stable and will follow [SemVer](http://semver.org/) for versioning.

--- a/packages/webpack-config-terra/README.md
+++ b/packages/webpack-config-terra/README.md
@@ -7,7 +7,7 @@ Terra's sharable Webpack configuration.
 
 ## Node version support
 
-This package was developed and tested using Node 10 up to Node 14. This package has not been tested by us using Node 16 or greater. We don't want to restrict consumers on Node 16 or greater from using this package. For this reason the node version in package.json is set to `>=10.13.0` to allow Node 16 and above to use the package. No known issues were reported in newer Node versions but it is recommended that consumers to fully test it if you're using Node 16 or greater and report any issue.
+This package was developed and tested using Node 10 up to Node 14. This package has not been thoroughly tested using Node 16 or greater. No known issues have been reported in newer Node versions, so this package is set to allow Node version 10 or greater. However, consumers utilizing Node 16 or greater should use this package at their own risk.
 
 ## Versioning
 

--- a/packages/webpack-config-terra/package.json
+++ b/packages/webpack-config-terra/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/cerner/terra-toolkit/issues"
   },
   "engines": {
-    "node": "^10.13.0 || ^12.0.0 || ^14.0.0"
+    "node": ">=10.13.0"
   },
   "homepage": "https://github.com/cerner/terra-toolkit",
   "scripts": {

--- a/packages/webpack-config-terra/package.json
+++ b/packages/webpack-config-terra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerner/webpack-config-terra",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Terra Webpack Config",
   "main": "lib/webpack.config.js",
   "publishConfig": {
@@ -35,8 +35,8 @@
     "jest": "jest --config ../../jest.config.js"
   },
   "dependencies": {
-    "@cerner/duplicate-package-checker-webpack-plugin": "^2.2.0",
-    "@cerner/terra-aggregate-translations": "^2.3.0",
+    "@cerner/duplicate-package-checker-webpack-plugin": "^2.3.0",
+    "@cerner/terra-aggregate-translations": "^2.4.0",
     "@mjhenkes/postcss-rtl": "^2.0.0",
     "autoprefixer": "^10.0.0",
     "babel-loader": "^8.0.5",


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

- PR #727 close-ended the Node version up to 14 and this affected consumers on 16+.
- Reverted the Node version to support versions greater than 14.
- Added doc for Node version support. 
- Publish these packages

Closes #730 

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
