### PR TITLE
[terra-functional-testing] Add useRemoteScreenshots cli option 

### DIFF
--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Added
-  * Added `useRemoteScreenshots` cli option for downloading reference screenshots from a remote site for screenshot comparisons.
+  * Added `useRemoteReferenceScreenshots` cli option for downloading reference screenshots from a remote site for screenshot comparisons.
 
 ## 2.7.0 - (February 11, 2022)
 

--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Added `useRemoteScreenshots` cli option for downloading reference screenshots from a remote site for screenshot comparisons.
+
 ## 2.7.0 - (February 11, 2022)
 
 * Changed

--- a/packages/terra-functional-testing/src/config/utils/getConfigurationOptions.js
+++ b/packages/terra-functional-testing/src/config/utils/getConfigurationOptions.js
@@ -25,6 +25,7 @@ const getConfigurationOptions = (options) => {
     suite,
     theme,
     updateScreenshots,
+    useRemoteScreenshots,
     useSeleniumStandaloneService,
   } = options;
 
@@ -45,6 +46,7 @@ const getConfigurationOptions = (options) => {
       ...(theme ? { theme } : { theme: getDefaultThemeName() }),
       overrideTheme: theme,
       updateScreenshots,
+      useRemoteScreenshots,
       ...fs.existsSync(defaultWebpackPath) && { webpackConfig: defaultWebpackPath },
     },
     ...spec && { spec },

--- a/packages/terra-functional-testing/src/config/utils/getConfigurationOptions.js
+++ b/packages/terra-functional-testing/src/config/utils/getConfigurationOptions.js
@@ -25,7 +25,7 @@ const getConfigurationOptions = (options) => {
     suite,
     theme,
     updateScreenshots,
-    useRemoteScreenshots,
+    useRemoteReferenceScreenshots,
     useSeleniumStandaloneService,
   } = options;
 
@@ -46,7 +46,7 @@ const getConfigurationOptions = (options) => {
       ...(theme ? { theme } : { theme: getDefaultThemeName() }),
       overrideTheme: theme,
       updateScreenshots,
-      useRemoteScreenshots,
+      useRemoteReferenceScreenshots,
       ...fs.existsSync(defaultWebpackPath) && { webpackConfig: defaultWebpackPath },
     },
     ...spec && { spec },

--- a/packages/terra-functional-testing/src/terra-cli/wdio/index.js
+++ b/packages/terra-functional-testing/src/terra-cli/wdio/index.js
@@ -184,7 +184,7 @@ const cli = {
         describe: 'Whether or not to automatically update all reference screenshots with the latest screenshots.',
         default: false,
       },
-      useRemoteScreenshots: {
+      useRemoteReferenceScreenshots: {
         type: 'boolean',
         describe: 'A flag to download reference screenshots from a remote site for screenshot comparisons instead of using the local reference screenshots.',
         default: false,

--- a/packages/terra-functional-testing/src/terra-cli/wdio/index.js
+++ b/packages/terra-functional-testing/src/terra-cli/wdio/index.js
@@ -184,6 +184,11 @@ const cli = {
         describe: 'Whether or not to automatically update all reference screenshots with the latest screenshots.',
         default: false,
       },
+      useRemoteScreenshots: {
+        type: 'boolean',
+        describe: 'A flag to download reference screenshots from a remote site for screenshot comparisons instead of using the local reference screenshots.',
+        default: false,
+      },
       useSeleniumStandaloneService: {
         type: 'boolean',
         describe: 'A flag to use the selenium standalone service instead of the selenium docker service.',

--- a/packages/terra-functional-testing/src/terra-cli/wdio/test-runner.js
+++ b/packages/terra-functional-testing/src/terra-cli/wdio/test-runner.js
@@ -48,7 +48,7 @@ class TestRunner {
    * @param {array} options.suite - Overrides specs and runs only the defined suites.
    * @param {string} options.theme - A theme for the test run.
    * @param {boolean} options.updateScreenshots - Updates all reference screenshots with the latest screenshots.
-   * @param {boolean} options.useRemoteScreenshots - A flag to download reference screenshots from a remote site for screenshot comparisons instead of using the local reference screenshots.
+   * @param {boolean} options.useRemoteReferenceScreenshots - A flag to download reference screenshots from a remote site for screenshot comparisons instead of using the local reference screenshots.
    * @param {boolean} options.useSeleniumStandaloneService - A flag to use the selenium standalone service instead of the selenium docker service.
    * @returns {Promise} A promise that resolves with the test run exit code.
    */
@@ -92,7 +92,7 @@ class TestRunner {
    * @param {array} options.suite - Overrides specs and runs only the defined suites.
    * @param {string} options.themes - A list of themes for the test run.
    * @param {boolean} options.updateScreenshots - Updates all reference screenshots with the latest screenshots.
-   * @param {boolean} options.useRemoteScreenshots - A flag to download reference screenshots from a remote site for screenshot comparisons instead of using the local reference screenshots.
+   * @param {boolean} options.useRemoteReferenceScreenshots - A flag to download reference screenshots from a remote site for screenshot comparisons instead of using the local reference screenshots.
    * @param {boolean} options.useSeleniumStandaloneService - A flag to use the selenium standalone service instead of the selenium docker service.
    */
   static async start(options) {

--- a/packages/terra-functional-testing/src/terra-cli/wdio/test-runner.js
+++ b/packages/terra-functional-testing/src/terra-cli/wdio/test-runner.js
@@ -48,6 +48,7 @@ class TestRunner {
    * @param {array} options.suite - Overrides specs and runs only the defined suites.
    * @param {string} options.theme - A theme for the test run.
    * @param {boolean} options.updateScreenshots - Updates all reference screenshots with the latest screenshots.
+   * @param {boolean} options.useRemoteScreenshots - A flag to download reference screenshots from a remote site for screenshot comparisons instead of using the local reference screenshots.
    * @param {boolean} options.useSeleniumStandaloneService - A flag to use the selenium standalone service instead of the selenium docker service.
    * @returns {Promise} A promise that resolves with the test run exit code.
    */
@@ -91,6 +92,7 @@ class TestRunner {
    * @param {array} options.suite - Overrides specs and runs only the defined suites.
    * @param {string} options.themes - A list of themes for the test run.
    * @param {boolean} options.updateScreenshots - Updates all reference screenshots with the latest screenshots.
+   * @param {boolean} options.useRemoteScreenshots - A flag to download reference screenshots from a remote site for screenshot comparisons instead of using the local reference screenshots.
    * @param {boolean} options.useSeleniumStandaloneService - A flag to use the selenium standalone service instead of the selenium docker service.
    */
   static async start(options) {

--- a/packages/terra-functional-testing/tests/jest/config/utils/getConfigurationOptions.test.js
+++ b/packages/terra-functional-testing/tests/jest/config/utils/getConfigurationOptions.test.js
@@ -21,7 +21,7 @@ describe('getCapabilities', () => {
       suite: 'test-suite',
       theme: 'terra-default-theme',
       updateScreenshots: true,
-      useRemoteScreenshots: true,
+      useRemoteReferenceScreenshots: true,
       useSeleniumStandaloneService: false,
     };
 
@@ -47,7 +47,7 @@ describe('getCapabilities', () => {
         theme: options.theme,
         overrideTheme: options.theme,
         updateScreenshots: true,
-        useRemoteScreenshots: true,
+        useRemoteReferenceScreenshots: true,
         webpackConfig: defaultWebpackPath,
       },
     };
@@ -73,7 +73,7 @@ describe('getCapabilities', () => {
       suite: 'test-suite',
       theme: 'terra-default-theme',
       updateScreenshots: true,
-      useRemoteScreenshots: false,
+      useRemoteReferenceScreenshots: false,
       useSeleniumStandaloneService: true,
     };
 
@@ -99,7 +99,7 @@ describe('getCapabilities', () => {
         theme: options.theme,
         overrideTheme: options.theme,
         updateScreenshots: true,
-        useRemoteScreenshots: false,
+        useRemoteReferenceScreenshots: false,
         webpackConfig: defaultWebpackPath,
       },
     };
@@ -130,7 +130,7 @@ describe('getCapabilities', () => {
         theme: 'terra-default-theme',
         overrideTheme: undefined,
         updateScreenshots: undefined,
-        useRemoteScreenshots: undefined,
+        useRemoteReferenceScreenshots: undefined,
         webpackConfig: defaultWebpackPath,
       },
     };

--- a/packages/terra-functional-testing/tests/jest/config/utils/getConfigurationOptions.test.js
+++ b/packages/terra-functional-testing/tests/jest/config/utils/getConfigurationOptions.test.js
@@ -21,6 +21,7 @@ describe('getCapabilities', () => {
       suite: 'test-suite',
       theme: 'terra-default-theme',
       updateScreenshots: true,
+      useRemoteScreenshots: true,
       useSeleniumStandaloneService: false,
     };
 
@@ -46,6 +47,7 @@ describe('getCapabilities', () => {
         theme: options.theme,
         overrideTheme: options.theme,
         updateScreenshots: true,
+        useRemoteScreenshots: true,
         webpackConfig: defaultWebpackPath,
       },
     };
@@ -71,6 +73,7 @@ describe('getCapabilities', () => {
       suite: 'test-suite',
       theme: 'terra-default-theme',
       updateScreenshots: true,
+      useRemoteScreenshots: false,
       useSeleniumStandaloneService: true,
     };
 
@@ -96,6 +99,7 @@ describe('getCapabilities', () => {
         theme: options.theme,
         overrideTheme: options.theme,
         updateScreenshots: true,
+        useRemoteScreenshots: false,
         webpackConfig: defaultWebpackPath,
       },
     };
@@ -126,6 +130,7 @@ describe('getCapabilities', () => {
         theme: 'terra-default-theme',
         overrideTheme: undefined,
         updateScreenshots: undefined,
+        useRemoteScreenshots: undefined,
         webpackConfig: defaultWebpackPath,
       },
     };

--- a/packages/terra-functional-testing/tests/jest/terra-cli/wdio/__snapshots__/index.test.js.snap
+++ b/packages/terra-functional-testing/tests/jest/terra-cli/wdio/__snapshots__/index.test.js.snap
@@ -55,6 +55,11 @@ Options:
                                         all reference screenshots with the
                                         latest screenshots.
                                                       [boolean] [default: false]
+      --useRemoteScreenshots            A flag to download reference screenshots
+                                        from a remote site for screenshot
+                                        comparisons instead of using the local
+                                        reference screenshots.
+                                                      [boolean] [default: false]
       --useSeleniumStandaloneService    A flag to use the selenium standalone
                                         service instead of the selenium docker
                                         service.      [boolean] [default: false]"

--- a/packages/terra-functional-testing/tests/jest/terra-cli/wdio/__snapshots__/index.test.js.snap
+++ b/packages/terra-functional-testing/tests/jest/terra-cli/wdio/__snapshots__/index.test.js.snap
@@ -55,7 +55,7 @@ Options:
                                         all reference screenshots with the
                                         latest screenshots.
                                                       [boolean] [default: false]
-      --useRemoteScreenshots            A flag to download reference screenshots
+      --useRemoteReferenceScreenshots   A flag to download reference screenshots
                                         from a remote site for screenshot
                                         comparisons instead of using the local
                                         reference screenshots.

--- a/packages/terra-functional-testing/tests/jest/terra-cli/wdio/test-runner.test.js
+++ b/packages/terra-functional-testing/tests/jest/terra-cli/wdio/test-runner.test.js
@@ -54,6 +54,7 @@ describe('Test Runner', () => {
         suite: 'test-suite',
         theme: 'terra-default-theme',
         updateScreenshots: true,
+        useRemoteScreenshots: true,
         useSeleniumStandaloneService: true,
       };
 
@@ -220,6 +221,7 @@ describe('Test Runner', () => {
         suite: 'test-suite',
         themes: ['terra-default-theme'],
         updateScreenshots: true,
+        useRemoteScreenshots: true,
         useSeleniumStandaloneService: true,
       });
 
@@ -239,6 +241,7 @@ describe('Test Runner', () => {
         suite: 'test-suite',
         theme: 'terra-default-theme',
         updateScreenshots: true,
+        useRemoteScreenshots: true,
         useSeleniumStandaloneService: true,
       });
     });

--- a/packages/terra-functional-testing/tests/jest/terra-cli/wdio/test-runner.test.js
+++ b/packages/terra-functional-testing/tests/jest/terra-cli/wdio/test-runner.test.js
@@ -54,7 +54,7 @@ describe('Test Runner', () => {
         suite: 'test-suite',
         theme: 'terra-default-theme',
         updateScreenshots: true,
-        useRemoteScreenshots: true,
+        useRemoteReferenceScreenshots: true,
         useSeleniumStandaloneService: true,
       };
 
@@ -221,7 +221,7 @@ describe('Test Runner', () => {
         suite: 'test-suite',
         themes: ['terra-default-theme'],
         updateScreenshots: true,
-        useRemoteScreenshots: true,
+        useRemoteReferenceScreenshots: true,
         useSeleniumStandaloneService: true,
       });
 
@@ -241,7 +241,7 @@ describe('Test Runner', () => {
         suite: 'test-suite',
         theme: 'terra-default-theme',
         updateScreenshots: true,
-        useRemoteScreenshots: true,
+        useRemoteReferenceScreenshots: true,
         useSeleniumStandaloneService: true,
       });
     });


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

Added `useRemoteScreenshots` cli option to allow downloading reference screenshots from a remote site for screenshot comparisons. The default value for `useRemoteScreenshots` is false which will continue to use the project's local reference screenshot like it is works today for passivity.

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
