### PR TITLE
[terra-functional-testing] Delete screenshots directories before each test run.

### DIFF
--- a/packages/terra-enzyme-intl/CHANGELOG.md
+++ b/packages/terra-enzyme-intl/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Fixed jest test due to react-intl update.
+
 ## 4.6.0 - (February 11, 2022)
 
 * Changed

--- a/packages/terra-enzyme-intl/CHANGELOG.md
+++ b/packages/terra-enzyme-intl/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Fixed
-  * Fixed jest test due to react-intl update.
+  * Fixed jest test failure caused by to react-intl update.
 
 ## 4.6.0 - (February 11, 2022)
 

--- a/packages/terra-enzyme-intl/CHANGELOG.md
+++ b/packages/terra-enzyme-intl/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Fixed
-  * Fixed jest test failure caused by to react-intl update.
+  * Fixed jest test failure caused by react-intl update.
 
 ## 4.6.0 - (February 11, 2022)
 

--- a/packages/terra-enzyme-intl/tests/jest/__snapshots__/enzyme-intl.test.jsx.snap
+++ b/packages/terra-enzyme-intl/tests/jest/__snapshots__/enzyme-intl.test.jsx.snap
@@ -34,6 +34,7 @@ exports[`mountWithIntl using injectIntl should match the snapshot 1`] = `
     foo="bar"
     intl={
       Object {
+        "$t": [Function],
         "defaultFormats": Object {},
         "defaultLocale": "en",
         "defaultRichTextElements": undefined,
@@ -176,6 +177,7 @@ exports[`shallowWithIntl using injectIntl should match the snapshot 1`] = `
   foo="bar"
   intl={
     Object {
+      "$t": [Function],
       "defaultFormats": Object {},
       "defaultLocale": "en",
       "defaultRichTextElements": undefined,

--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added
   * Added authentication for accessing screenshots from the remote site.
   * Added `useRemoteReferenceScreenshots` cli option for downloading reference screenshots from a remote site for screenshot comparisons.
+  * Delete the `reference` screenshot directory when `useRemoteReferenceScreenshots` is true.
 
 * Fixed
   * Fixed deleting the `diff`, `error`, and `latest` screenshot directories at the beginning of each test run.

--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -6,6 +6,9 @@
   * Added authentication for accessing screenshots from the remote site.
   * Added `useRemoteReferenceScreenshots` cli option for downloading reference screenshots from a remote site for screenshot comparisons.
 
+* Fixed
+  * Fixed deleting the `diff`, `error`, and `latest` screenshot directories at the beginning of each test run.
+
 ## 2.7.0 - (February 11, 2022)
 
 * Changed

--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -8,7 +8,7 @@
   * Delete the `reference` screenshot directory when `useRemoteReferenceScreenshots` is true.
 
 * Fixed
-  * Fixed deleting the `diff`, `error`, and `latest` screenshot directories at the beginning of each test run.
+  * Fixed deleting the `diff`, `error`, and optionally the `latest` screenshot directories at the beginning of each test run.
 
 ## 2.7.0 - (February 11, 2022)
 

--- a/packages/terra-functional-testing/src/commands/utils/cleanScreenshots.js
+++ b/packages/terra-functional-testing/src/commands/utils/cleanScreenshots.js
@@ -8,10 +8,10 @@ const logger = new Logger({ prefix: '[terra-functional-testing:cleanScreenshots]
 // eslint-disable-next-line global-require, import/no-dynamic-require
 const isDirectory = filePath => (fs.existsSync(filePath) && fs.lstatSync(filePath).isDirectory());
 
-  /**
-   * Delete the `diff`, `error`, `latest` and `reference` screenshot directories for each test run so all the screenshots are current.
-   * @param {boolean} cleanReferenceScreenshots - A flag to determine if the reference screenshots should also be deleted since they will be downloaded from the remote repository. 
-   */
+/**
+ * Delete the `diff`, `error`, `latest` and `reference` screenshot directories for each test run so all the screenshots are current.
+ * @param {boolean} cleanReferenceScreenshots - A flag to determine if the reference screenshots should also be deleted since they will be downloaded from the remote repository.
+ */
 async function cleanScreenshots(cleanReferenceScreenshots) {
   const monoRepoPath = path.resolve(process.cwd(), 'packages');
   const isMonoRepo = fs.existsSync(monoRepoPath);
@@ -29,7 +29,6 @@ async function cleanScreenshots(cleanReferenceScreenshots) {
       if (cleanReferenceScreenshots) {
         patterns.push(path.resolve(monoRepoPath, packageName, 'tests', 'wdio', '**', '__snapshots__', 'reference'));
       }
-
     });
   } else {
     patterns.push(path.resolve(process.cwd(), 'tests', 'wdio', '**', '__snapshots__', 'diff'));

--- a/packages/terra-functional-testing/src/commands/utils/cleanScreenshots.js
+++ b/packages/terra-functional-testing/src/commands/utils/cleanScreenshots.js
@@ -8,7 +8,11 @@ const logger = new Logger({ prefix: '[terra-functional-testing:cleanScreenshots]
 // eslint-disable-next-line global-require, import/no-dynamic-require
 const isDirectory = filePath => (fs.existsSync(filePath) && fs.lstatSync(filePath).isDirectory());
 
-async function cleanScreenshots() {
+  /**
+   * Delete the `diff`, `error`, `latest` and `reference` screenshot directories for each test run so all the screenshots are current.
+   * @param {boolean} cleanReferenceScreenshots - A flag to determine if the reference screenshots should also be deleted since they will be downloaded from the remote repository. 
+   */
+async function cleanScreenshots(cleanReferenceScreenshots) {
   const monoRepoPath = path.resolve(process.cwd(), 'packages');
   const isMonoRepo = fs.existsSync(monoRepoPath);
   const patterns = [];
@@ -21,11 +25,20 @@ async function cleanScreenshots() {
       patterns.push(path.resolve(monoRepoPath, packageName, 'tests', 'wdio', '**', '__snapshots__', 'diff'));
       patterns.push(path.resolve(monoRepoPath, packageName, 'tests', 'wdio', '**', '__snapshots__', 'error'));
       patterns.push(path.resolve(monoRepoPath, packageName, 'tests', 'wdio', '**', '__snapshots__', 'latest'));
+
+      if (cleanReferenceScreenshots) {
+        patterns.push(path.resolve(monoRepoPath, packageName, 'tests', 'wdio', '**', '__snapshots__', 'reference'));
+      }
+
     });
   } else {
     patterns.push(path.resolve(process.cwd(), 'tests', 'wdio', '**', '__snapshots__', 'diff'));
     patterns.push(path.resolve(process.cwd(), 'tests', 'wdio', '**', '__snapshots__', 'error'));
     patterns.push(path.resolve(process.cwd(), 'tests', 'wdio', '**', '__snapshots__', 'latest'));
+
+    if (cleanReferenceScreenshots) {
+      patterns.push(path.resolve(process.cwd(), 'tests', 'wdio', '**', '__snapshots__', 'reference'));
+    }
   }
 
   // For each of the three directory patterns, do a glob search to identify all the existing and matching screenshot directories and delete them.

--- a/packages/terra-functional-testing/src/terra-cli/wdio/test-runner.js
+++ b/packages/terra-functional-testing/src/terra-cli/wdio/test-runner.js
@@ -104,7 +104,7 @@ class TestRunner {
     } = options;
 
     // Clean only the non reference screenshots.
-    cleanScreenshots();
+    cleanScreenshots(options.useRemoteReferenceScreenshots);
 
     await TestRunner.configureScreenshots(options);
 

--- a/packages/terra-functional-testing/src/terra-cli/wdio/test-runner.js
+++ b/packages/terra-functional-testing/src/terra-cli/wdio/test-runner.js
@@ -103,7 +103,6 @@ class TestRunner {
       ...cliOptions
     } = options;
 
-    // Clean only the non reference screenshots.
     cleanScreenshots(options.useRemoteReferenceScreenshots);
 
     await TestRunner.configureScreenshots(options);

--- a/packages/terra-functional-testing/tests/jest/commands/utils/cleanScreenshots.test.js
+++ b/packages/terra-functional-testing/tests/jest/commands/utils/cleanScreenshots.test.js
@@ -26,9 +26,11 @@ describe('cleanScreenshots', () => {
     jest.spyOn(path, 'resolve').mockImplementation(() => mockPath);
     jest.spyOn(fs, 'existsSync').mockImplementation(() => true);
     jest.spyOn(fs, 'readdirSync').mockImplementationOnce(() => ['terra-functional-testing']);
-    jest.spyOn(glob, 'sync').mockImplementation(() => ['latest']);
+    jest.spyOn(glob, 'sync').mockImplementationOnce(() => ['diff']);
+    jest.spyOn(glob, 'sync').mockImplementationOnce(() => ['error']);
+    jest.spyOn(glob, 'sync').mockImplementationOnce(() => ['latest']);
     jest.spyOn(fs, 'lstatSync').mockImplementation(() => ({ isDirectory: () => true }));
-    jest.spyOn(fs, 'removeSync').mockImplementationOnce(() => { });
+    jest.spyOn(fs, 'removeSync').mockImplementation(() => { });
 
     cleanScreenshots();
 
@@ -36,32 +38,35 @@ describe('cleanScreenshots', () => {
     expect(fs.existsSync).toHaveBeenCalledWith(mockPath);
     expect(fs.readdirSync).toHaveBeenCalledWith(mockPath);
     expect(glob.sync).toHaveBeenCalledWith(mockPath);
-    expect(fs.lstatSync).toHaveBeenCalledWith(mockPath);
-    expect(fs.removeSync).toHaveBeenCalledWith(mockPath);
+    expect(fs.lstatSync).toHaveBeenNthCalledWith(1, 'diff');
+    expect(fs.lstatSync).toHaveBeenNthCalledWith(2, 'error');
+    expect(fs.lstatSync).toHaveBeenNthCalledWith(3, 'latest');
+    expect(fs.removeSync).toHaveBeenNthCalledWith(1, 'diff');
+    expect(fs.removeSync).toHaveBeenNthCalledWith(2, 'error');
+    expect(fs.removeSync).toHaveBeenNthCalledWith(3, 'latest');
   });
 
   it('should clean screenshots for non-monorepo project', () => {
-    const mockPath = 'terra-toolkit/packages';
-    const cwd = process.cwd();
+    const mockPath = 'terra-toolkit';
     jest.spyOn(path, 'resolve').mockImplementation(() => mockPath);
     jest.spyOn(fs, 'existsSync').mockImplementationOnce(() => false);
     jest.spyOn(fs, 'existsSync').mockImplementation(() => true);
-    jest.spyOn(glob, 'sync').mockImplementation(() => ['latest']);
+    jest.spyOn(glob, 'sync').mockImplementationOnce(() => ['diff']);
+    jest.spyOn(glob, 'sync').mockImplementationOnce(() => ['error']);
+    jest.spyOn(glob, 'sync').mockImplementationOnce(() => ['latest']);
     jest.spyOn(fs, 'lstatSync').mockImplementation(() => ({ isDirectory: () => true }));
     jest.spyOn(fs, 'removeSync').mockImplementation(() => { });
 
     cleanScreenshots();
 
-    expect(path.resolve).toHaveBeenCalledWith(cwd, 'packages');
+    expect(path.resolve).toHaveBeenCalledWith(process.cwd(), 'packages');
     expect(fs.existsSync).toHaveBeenCalledWith(mockPath);
-    expect(glob.sync).toHaveBeenNthCalledWith(1, `${cwd}/tests/wdio/**/__snapshots__/diff`);
-    expect(glob.sync).toHaveBeenNthCalledWith(2, `${cwd}/tests/wdio/**/__snapshots__/error`);
-    expect(glob.sync).toHaveBeenNthCalledWith(3, `${cwd}/tests/wdio/**/__snapshots__/latest`);
-    expect(fs.lstatSync).toHaveBeenNthCalledWith(1, `${cwd}/tests/wdio/**/__snapshots__/diff`);
-    expect(fs.lstatSync).toHaveBeenNthCalledWith(2, `${cwd}/tests/wdio/**/__snapshots__/error`);
-    expect(fs.lstatSync).toHaveBeenNthCalledWith(3, `${cwd}/tests/wdio/**/__snapshots__/latest`);
-    expect(fs.removeSync).toHaveBeenNthCalledWith(1, `${cwd}/tests/wdio/**/__snapshots__/diff`);
-    expect(fs.removeSync).toHaveBeenNthCalledWith(2, `${cwd}/tests/wdio/**/__snapshots__/error`);
-    expect(fs.removeSync).toHaveBeenNthCalledWith(3, `${cwd}/tests/wdio/**/__snapshots__/latest`);
+    expect(glob.sync).toHaveBeenCalledWith(mockPath);
+    expect(fs.lstatSync).toHaveBeenNthCalledWith(1, 'diff');
+    expect(fs.lstatSync).toHaveBeenNthCalledWith(2, 'error');
+    expect(fs.lstatSync).toHaveBeenNthCalledWith(3, 'latest');
+    expect(fs.removeSync).toHaveBeenNthCalledWith(1, 'diff');
+    expect(fs.removeSync).toHaveBeenNthCalledWith(2, 'error');
+    expect(fs.removeSync).toHaveBeenNthCalledWith(3, 'latest');
   });
 });

--- a/packages/terra-functional-testing/tests/jest/commands/utils/cleanScreenshots.test.js
+++ b/packages/terra-functional-testing/tests/jest/commands/utils/cleanScreenshots.test.js
@@ -32,7 +32,7 @@ describe('cleanScreenshots', () => {
     jest.spyOn(fs, 'lstatSync').mockImplementation(() => ({ isDirectory: () => true }));
     jest.spyOn(fs, 'removeSync').mockImplementation(() => { });
 
-    cleanScreenshots();
+    cleanScreenshots(false);
 
     expect(path.resolve).toHaveBeenCalledWith(process.cwd(), 'packages');
     expect(fs.existsSync).toHaveBeenCalledWith(mockPath);
@@ -46,6 +46,34 @@ describe('cleanScreenshots', () => {
     expect(fs.removeSync).toHaveBeenNthCalledWith(3, 'latest');
   });
 
+  it('should clean reference screenshots for monorepo project', () => {
+    const mockPath = 'terra-toolkit/packages';
+    jest.spyOn(path, 'resolve').mockImplementation(() => mockPath);
+    jest.spyOn(fs, 'existsSync').mockImplementation(() => true);
+    jest.spyOn(fs, 'readdirSync').mockImplementationOnce(() => ['terra-functional-testing']);
+    jest.spyOn(glob, 'sync').mockImplementationOnce(() => ['diff']);
+    jest.spyOn(glob, 'sync').mockImplementationOnce(() => ['error']);
+    jest.spyOn(glob, 'sync').mockImplementationOnce(() => ['latest']);
+    jest.spyOn(glob, 'sync').mockImplementationOnce(() => ['reference']);
+    jest.spyOn(fs, 'lstatSync').mockImplementation(() => ({ isDirectory: () => true }));
+    jest.spyOn(fs, 'removeSync').mockImplementation(() => { });
+
+    cleanScreenshots(true);
+
+    expect(path.resolve).toHaveBeenCalledWith(process.cwd(), 'packages');
+    expect(fs.existsSync).toHaveBeenCalledWith(mockPath);
+    expect(fs.readdirSync).toHaveBeenCalledWith(mockPath);
+    expect(glob.sync).toHaveBeenCalledWith(mockPath);
+    expect(fs.lstatSync).toHaveBeenNthCalledWith(1, 'diff');
+    expect(fs.lstatSync).toHaveBeenNthCalledWith(2, 'error');
+    expect(fs.lstatSync).toHaveBeenNthCalledWith(3, 'latest');
+    expect(fs.lstatSync).toHaveBeenNthCalledWith(4, 'reference');
+    expect(fs.removeSync).toHaveBeenNthCalledWith(1, 'diff');
+    expect(fs.removeSync).toHaveBeenNthCalledWith(2, 'error');
+    expect(fs.removeSync).toHaveBeenNthCalledWith(3, 'latest');
+    expect(fs.removeSync).toHaveBeenNthCalledWith(4, 'reference');
+  });
+
   it('should clean screenshots for non-monorepo project', () => {
     const mockPath = 'terra-toolkit';
     jest.spyOn(path, 'resolve').mockImplementation(() => mockPath);
@@ -57,7 +85,7 @@ describe('cleanScreenshots', () => {
     jest.spyOn(fs, 'lstatSync').mockImplementation(() => ({ isDirectory: () => true }));
     jest.spyOn(fs, 'removeSync').mockImplementation(() => { });
 
-    cleanScreenshots();
+    cleanScreenshots(false);
 
     expect(path.resolve).toHaveBeenCalledWith(process.cwd(), 'packages');
     expect(fs.existsSync).toHaveBeenCalledWith(mockPath);
@@ -68,5 +96,32 @@ describe('cleanScreenshots', () => {
     expect(fs.removeSync).toHaveBeenNthCalledWith(1, 'diff');
     expect(fs.removeSync).toHaveBeenNthCalledWith(2, 'error');
     expect(fs.removeSync).toHaveBeenNthCalledWith(3, 'latest');
+  });
+
+  it('should clean reference screenshots for non-monorepo project', () => {
+    const mockPath = 'terra-toolkit';
+    jest.spyOn(path, 'resolve').mockImplementation(() => mockPath);
+    jest.spyOn(fs, 'existsSync').mockImplementationOnce(() => false);
+    jest.spyOn(fs, 'existsSync').mockImplementation(() => true);
+    jest.spyOn(glob, 'sync').mockImplementationOnce(() => ['diff']);
+    jest.spyOn(glob, 'sync').mockImplementationOnce(() => ['error']);
+    jest.spyOn(glob, 'sync').mockImplementationOnce(() => ['latest']);
+    jest.spyOn(glob, 'sync').mockImplementationOnce(() => ['reference']);
+    jest.spyOn(fs, 'lstatSync').mockImplementation(() => ({ isDirectory: () => true }));
+    jest.spyOn(fs, 'removeSync').mockImplementation(() => { });
+
+    cleanScreenshots(true);
+
+    expect(path.resolve).toHaveBeenCalledWith(process.cwd(), 'packages');
+    expect(fs.existsSync).toHaveBeenCalledWith(mockPath);
+    expect(glob.sync).toHaveBeenCalledWith(mockPath);
+    expect(fs.lstatSync).toHaveBeenNthCalledWith(1, 'diff');
+    expect(fs.lstatSync).toHaveBeenNthCalledWith(2, 'error');
+    expect(fs.lstatSync).toHaveBeenNthCalledWith(3, 'latest');
+    expect(fs.lstatSync).toHaveBeenNthCalledWith(4, 'reference');
+    expect(fs.removeSync).toHaveBeenNthCalledWith(1, 'diff');
+    expect(fs.removeSync).toHaveBeenNthCalledWith(2, 'error');
+    expect(fs.removeSync).toHaveBeenNthCalledWith(3, 'latest');
+    expect(fs.removeSync).toHaveBeenNthCalledWith(4, 'reference');
   });
 });


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

- Fixed deleting the `diff`, `error`, and `latest` screenshot directories at the beginning of each test run.
- Delete the `reference` screenshot directory when `useRemoteReferenceScreenshots` is true because the reference screenshots will be downloaded from the remote repository.
- Fixed terra-enzyme-intl jest test due to react-intl update. The main branch build is also failing due to the  react-intl update.

### Other tracking details
UXPLATFORM-6370

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
