### PR TITLE
[terra-functional-testing] Consume new environment variable to determine matching

### DIFF
--- a/packages/terra-enzyme-intl/tests/jest/__snapshots__/enzyme-intl.test.jsx.snap
+++ b/packages/terra-enzyme-intl/tests/jest/__snapshots__/enzyme-intl.test.jsx.snap
@@ -34,6 +34,7 @@ exports[`mountWithIntl using injectIntl should match the snapshot 1`] = `
     foo="bar"
     intl={
       Object {
+        "$t": [Function],
         "defaultFormats": Object {},
         "defaultLocale": "en",
         "defaultRichTextElements": undefined,
@@ -176,6 +177,7 @@ exports[`shallowWithIntl using injectIntl should match the snapshot 1`] = `
   foo="bar"
   intl={
     Object {
+      "$t": [Function],
       "defaultFormats": Object {},
       "defaultLocale": "en",
       "defaultRichTextElements": undefined,

--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added
   * Added authentication for accessing screenshots from the remote site.
   * Added `useRemoteReferenceScreenshots` cli option for downloading reference screenshots from a remote site for screenshot comparisons.
+  * Added a check of the `BUILD_BRANCH` environment variable to determines if tests should pass regardless of image mismatch
 
 ## 2.7.0 - (February 11, 2022)
 
@@ -15,7 +16,7 @@
 
 * Changed
   * Updated component to support Node 14.
-  
+
 ## 2.5.0 - (September 28, 2021)
 
 * Added

--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -6,7 +6,7 @@
   * Added authentication for accessing screenshots from the remote site.
   * Added `useRemoteReferenceScreenshots` cli option for downloading reference screenshots from a remote site for screenshot comparisons.
   * Delete the `reference` screenshot directory when `useRemoteReferenceScreenshots` is true.
-  * Added a check of the `BUILD_BRANCH` environment variable to determines if tests should pass regardless of image mismatch
+  * Added a check of the `BUILD_BRANCH` environment variable to determine if tests should pass regardless of image mismatch
 
 * Fixed
   * Fixed deleting the `diff`, `error`, and optionally the `latest` screenshot directories at the beginning of each test run.

--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -6,7 +6,7 @@
   * Added authentication for accessing screenshots from the remote site.
   * Added `useRemoteReferenceScreenshots` cli option for downloading reference screenshots from a remote site for screenshot comparisons.
   * Delete the `reference` screenshot directory when `useRemoteReferenceScreenshots` is true.
-  * Added a check of the `BUILD_BRANCH` environment variable to determine if tests should pass regardless of image mismatch
+  * Added a check of the `BUILD_BRANCH` environment variable to determine if tests should pass regardless of image mismatch.
 
 * Fixed
   * Fixed deleting the `diff`, `error`, and optionally the `latest` screenshot directories at the beginning of each test run.

--- a/packages/terra-functional-testing/src/commands/expect/toMatchReference.js
+++ b/packages/terra-functional-testing/src/commands/expect/toMatchReference.js
@@ -1,4 +1,4 @@
-const { BUILD_TYPES } = require('../../constants');
+const { BUILD_BRANCH } = require('../../constants');
 /**
  * An assertion method to be paired with Visual Regression Service to assert each screenshot is within
  * the mismatch tolerance and are the same size.
@@ -38,7 +38,7 @@ function toMatchReference(screenshot) {
 
   let pass = global.Terra.serviceOptions.ignoreScreenshotMismatch || imagesMatch;
 
-  if (process.env.BUILD_TYPE === BUILD_TYPES.pullRequest && !pass) {
+  if (global.Terra.serviceOptions.useRemoteReferenceScreenshots && global.Terra.serviceOptions.buildBranch === BUILD_BRANCH.pullRequest && !pass) {
     pass = true;
     if (message.length > 0) {
       message = message.concat('\n');

--- a/packages/terra-functional-testing/src/commands/expect/toMatchReference.js
+++ b/packages/terra-functional-testing/src/commands/expect/toMatchReference.js
@@ -43,11 +43,11 @@ function toMatchReference(screenshot) {
     if (message.length > 0) {
       message = message.concat('\n');
     }
-    message = message.concat(`Screenshot has changed and needs to be reviewed.`);
+    message = message.concat('Screenshot has changed and needs to be reviewed.');
   }
 
   return {
-    pass: pass,
+    pass,
     message: () => message,
   };
 }

--- a/packages/terra-functional-testing/src/commands/expect/toMatchReference.js
+++ b/packages/terra-functional-testing/src/commands/expect/toMatchReference.js
@@ -1,3 +1,4 @@
+const { BUILD_TYPES } = require('../../constants');
 /**
  * An assertion method to be paired with Visual Regression Service to assert each screenshot is within
  * the mismatch tolerance and are the same size.
@@ -35,8 +36,18 @@ function toMatchReference(screenshot) {
     message = message.concat(`Expected the screenshot to be within the mismatch tolerance, but received a mismatch difference of ${misMatchPercentage}%.`);
   }
 
+  let pass = global.Terra.serviceOptions.ignoreScreenshotMismatch || imagesMatch;
+
+  if (process.env.BUILD_TYPE === BUILD_TYPES.pullRequest && !pass) {
+    pass = true;
+    if (message.length > 0) {
+      message = message.concat('\n');
+    }
+    message = message.concat(`Screenshot has changed and needs to be reviewed.`);
+  }
+
   return {
-    pass: global.Terra.serviceOptions.ignoreScreenshotMismatch || imagesMatch,
+    pass: pass,
     message: () => message,
   };
 }

--- a/packages/terra-functional-testing/src/config/utils/getConfigurationOptions.js
+++ b/packages/terra-functional-testing/src/config/utils/getConfigurationOptions.js
@@ -10,6 +10,7 @@ const getConfigurationOptions = (options) => {
   const {
     assetServerPort,
     browsers,
+    buildBranch,
     disableSeleniumService,
     ignoreScreenshotMismatch,
     externalHost,
@@ -35,6 +36,7 @@ const getConfigurationOptions = (options) => {
     hostname: seleniumServiceUrl || gridUrl || (useSeleniumStandaloneService ? 'standalone-chrome' : 'localhost'),
     port: seleniumServicePort || (gridUrl ? 80 : 4444),
     launcherOptions: {
+      buildBranch,
       disableSeleniumService: disableSeleniumService || useSeleniumStandaloneService || !!gridUrl,
       ignoreScreenshotMismatch,
       formFactor,

--- a/packages/terra-functional-testing/src/constants/index.js
+++ b/packages/terra-functional-testing/src/constants/index.js
@@ -25,4 +25,10 @@ const TERRA_VIEWPORTS = {
   },
 };
 
-module.exports = { TERRA_VIEWPORTS };
+const BUILD_TYPES = {
+  master: 'master',
+  dev: 'dev',
+  pullRequest: 'pullRequest',
+}
+
+module.exports = { TERRA_VIEWPORTS, BUILD_TYPES };

--- a/packages/terra-functional-testing/src/constants/index.js
+++ b/packages/terra-functional-testing/src/constants/index.js
@@ -25,10 +25,10 @@ const TERRA_VIEWPORTS = {
   },
 };
 
-const BUILD_TYPES = {
+const BUILD_BRANCH = {
   master: 'master',
   dev: 'dev',
   pullRequest: 'pullRequest',
 }
 
-module.exports = { TERRA_VIEWPORTS, BUILD_TYPES };
+module.exports = { TERRA_VIEWPORTS, BUILD_BRANCH };

--- a/packages/terra-functional-testing/src/constants/index.js
+++ b/packages/terra-functional-testing/src/constants/index.js
@@ -29,6 +29,6 @@ const BUILD_BRANCH = {
   master: 'master',
   dev: 'dev',
   pullRequest: 'pullRequest',
-}
+};
 
 module.exports = { TERRA_VIEWPORTS, BUILD_BRANCH };

--- a/packages/terra-functional-testing/src/terra-cli/wdio/index.js
+++ b/packages/terra-functional-testing/src/terra-cli/wdio/index.js
@@ -40,6 +40,17 @@ const cli = {
           return [];
         },
       },
+      buildBranch: {
+        type: 'string',
+        describe: 'The type of branch being built',
+        default: () => {
+          if (process.env.BUILD_BRANCH) {
+            return process.env.BUILD_BRANCH;
+          }
+
+          return undefined;
+        },
+      },
       c: {
         type: 'string',
         alias: 'config',

--- a/packages/terra-functional-testing/src/terra-cli/wdio/test-runner.js
+++ b/packages/terra-functional-testing/src/terra-cli/wdio/test-runner.js
@@ -33,6 +33,7 @@ class TestRunner {
    * @param {Object} options - The test run options.
    * @param {number} options.assetServerPort - The port to run the webpack and express asset services on.
    * @param {string} options.browsers - A list of browsers for the test run.
+   * @param {string} options.buildBranch - The type of branch being built.
    * @param {string} options.config - A file path to the test runner configuration.
    * @param {boolean} options.disableSeleniumService - A flag to disable the selenium docker service.
    * @param {string} options.externalHost - The host address the testing environment is connected to.
@@ -77,6 +78,7 @@ class TestRunner {
    * @param {Object} options - The test run options.
    * @param {number} options.assetServerPort - The port to run the webpack and express asset services on.
    * @param {string} options.browsers - A list of browsers for the test run.
+   * @param {string} options.buildBranch - The type of branch being built.
    * @param {string} options.config - A file path to the test runner configuration.
    * @param {boolean} options.disableSeleniumService - A flag to disable the selenium docker service.
    * @param {string} options.externalHost - The host address the testing environment is connected to.

--- a/packages/terra-functional-testing/tests/jest/commands/expect/toMatchReference.test.js
+++ b/packages/terra-functional-testing/tests/jest/commands/expect/toMatchReference.test.js
@@ -1,4 +1,5 @@
 const toMatchReference = require('../../../../src/commands/expect/toMatchReference');
+const { BUILD_BRANCH } = require('../../../../src/constants');
 
 describe('toMatchReference', () => {
   beforeAll(() => {
@@ -111,6 +112,139 @@ describe('toMatchReference', () => {
 
     const expectedMessage = 'Expected the screenshot to match the reference screenshot, but received a screenshot with different dimensions.\nExpected the screenshot to be within the mismatch tolerance, but received a mismatch difference of 0.1%.';
 
+    expect(result.message()).toEqual(expectedMessage);
+  });
+
+  it('should pass if matches reference screenshot and buildBranch is master', () => {
+    global.Terra = {
+      serviceOptions: {
+        buildBranch: BUILD_BRANCH.master,
+      },
+    };
+    const receivedScreenshot = {
+      isNewScreenshot: false,
+      isSameDimensions: true,
+      isWithinMismatchTolerance: true,
+      misMatchPercentage: 0.10,
+      screenshotWasUpdated: false,
+    };
+
+    const result = toMatchReference(receivedScreenshot);
+
+    expect(result.pass).toBe(true);
+  });
+
+  it('should not pass if not within mismatch tolerance and buildBranch is master', () => {
+    global.Terra = {
+      serviceOptions: {
+        buildBranch: BUILD_BRANCH.master,
+      },
+    };
+    const receivedScreenshot = {
+      isNewScreenshot: false,
+      isSameDimensions: true,
+      isWithinMismatchTolerance: false,
+      misMatchPercentage: 0.10,
+      screenshotWasUpdated: false,
+    };
+
+    const result = toMatchReference(receivedScreenshot);
+
+    expect(result.pass).toBe(false);
+  });
+
+  it('should pass if matches reference screenshot and buildBranch is dev', () => {
+    global.Terra = {
+      serviceOptions: {
+        buildBranch: BUILD_BRANCH.dev,
+      },
+    };
+    const receivedScreenshot = {
+      isNewScreenshot: false,
+      isSameDimensions: true,
+      isWithinMismatchTolerance: true,
+      misMatchPercentage: 0.10,
+      screenshotWasUpdated: false,
+    };
+
+    const result = toMatchReference(receivedScreenshot);
+
+    expect(result.pass).toBe(true);
+  });
+
+  it('should not pass if not within mismatch tolerance and buildBranch is dev', () => {
+    global.Terra = {
+      serviceOptions: {
+        buildBranch: BUILD_BRANCH.dev,
+      },
+    };
+    const receivedScreenshot = {
+      isNewScreenshot: false,
+      isSameDimensions: true,
+      isWithinMismatchTolerance: false,
+      misMatchPercentage: 0.10,
+      screenshotWasUpdated: false,
+    };
+
+    const result = toMatchReference(receivedScreenshot);
+
+    expect(result.pass).toBe(false);
+  });
+
+  it('should pass if matches reference screenshot and buildBranch is pullRequest', () => {
+    global.Terra = {
+      serviceOptions: {
+        buildBranch: BUILD_BRANCH.pullRequest,
+      },
+    };
+    const receivedScreenshot = {
+      isNewScreenshot: false,
+      isSameDimensions: true,
+      isWithinMismatchTolerance: true,
+      misMatchPercentage: 0.10,
+      screenshotWasUpdated: false,
+    };
+
+    const result = toMatchReference(receivedScreenshot);
+
+    expect(result.pass).toBe(true);
+  });
+
+  it('should not pass if not within mismatch tolerance, buildBranch is pullRequest, and useRemoteReferenceScreenshots is false', () => {
+    global.Terra = {
+      serviceOptions: {
+        buildBranch: BUILD_BRANCH.pullRequest,
+        useRemoteReferenceScreenshots: false,
+      },
+    };
+    const receivedScreenshot = {
+      isSameDimensions: false,
+      misMatchPercentage: 0.10,
+    };
+
+    const result = toMatchReference(receivedScreenshot);
+    const expectedMessage = 'Expected the screenshot to match the reference screenshot, but received a screenshot with different dimensions.\nExpected the screenshot to be within the mismatch tolerance, but received a mismatch difference of 0.1%.';
+
+    expect(result.pass).toBe(false);
+    expect(result.message()).toEqual(expectedMessage);
+  });
+
+  it('should pass if not within mismatch tolerance but buildBranch is pullRequest and useRemoteReferenceScreenshots is true', () => {
+    global.Terra = {
+      serviceOptions: {
+        buildBranch: BUILD_BRANCH.pullRequest,
+        useRemoteReferenceScreenshots: true,
+      },
+    };
+    const receivedScreenshot = {
+      isSameDimensions: false,
+      misMatchPercentage: 0.10,
+    };
+
+    const result = toMatchReference(receivedScreenshot);
+    const expectedMessage = 'Expected the screenshot to match the reference screenshot, but received a screenshot with different dimensions.\nExpected the screenshot to be within the mismatch tolerance, but received a mismatch difference of 0.1%.\nScreenshot has changed and needs to be reviewed.';
+
+    expect(result.pass).toBe(true);
     expect(result.message()).toEqual(expectedMessage);
   });
 });

--- a/packages/terra-functional-testing/tests/jest/config/utils/getConfigurationOptions.test.js
+++ b/packages/terra-functional-testing/tests/jest/config/utils/getConfigurationOptions.test.js
@@ -2,12 +2,14 @@ const path = require('path');
 const getConfigurationOptions = require('../../../../src/config/utils/getConfigurationOptions');
 const getCapabilities = require('../../../../src/config/utils/getCapabilities');
 const getIpAddress = require('../../../../src/config/utils/getIpAddress');
+const { BUILD_BRANCH } = require('../../../../src/constants/index');
 
 describe('getCapabilities', () => {
   it('should get configuration from cli options', async () => {
     const options = {
       assetServerPort: 8080,
       browsers: ['chrome'],
+      buildBranch: BUILD_BRANCH.pullRequest,
       config: '/path',
       disableSeleniumService: true,
       externalHost: 'externalHost',
@@ -36,6 +38,7 @@ describe('getCapabilities', () => {
       spec: options.spec,
       suite: options.suite,
       launcherOptions: {
+        buildBranch: BUILD_BRANCH.pullRequest,
         disableSeleniumService: true,
         formFactor: options.formFactor,
         gridUrl: options.gridUrl,
@@ -61,6 +64,7 @@ describe('getCapabilities', () => {
     const options = {
       assetServerPort: 8080,
       browsers: ['chrome'],
+      buildBranch: BUILD_BRANCH.master,
       config: '/path',
       disableSeleniumService: false,
       externalHost: 'externalHost',
@@ -88,6 +92,7 @@ describe('getCapabilities', () => {
       spec: options.spec,
       suite: options.suite,
       launcherOptions: {
+        buildBranch: BUILD_BRANCH.master,
         disableSeleniumService: true,
         formFactor: options.formFactor,
         gridUrl: undefined,
@@ -119,6 +124,7 @@ describe('getCapabilities', () => {
       hostname: 'localhost',
       port: 4444,
       launcherOptions: {
+        buildBranch: undefined,
         disableSeleniumService: false,
         formFactor: undefined,
         gridUrl: undefined,

--- a/packages/terra-functional-testing/tests/jest/terra-cli/wdio/__snapshots__/index.test.js.snap
+++ b/packages/terra-functional-testing/tests/jest/terra-cli/wdio/__snapshots__/index.test.js.snap
@@ -13,6 +13,8 @@ Options:
                                                   [number] [default: (_default)]
       --browsers                        A list of browsers for the test run.
                                                    [array] [default: (_default)]
+      --buildBranch                     The type of branch being built
+                                                  [string] [default: (_default)]
   -c, --config                          A file path to the test runner
                                         configuration.                  [string]
       --disableSeleniumService          A flag to disable the selenium docker


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->
- Consumes new BUILD_TYPE environment variable to determine if tests should fail due to screenshot mismatching depending on which build type we are in. 
- If screenshots were failing also sets message to say those screenshots need reviewed.

#### Other Tracking details
UXPLATFORM-6372

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
