### PR TITLE
Drops React-Intl V3 and V4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ services:
 branches:
   only:
     - main
+    - toolkit-mvb
 cache:
   directories:
     - docker_images

--- a/packages/terra-aggregate-translations/CHANGELOG.md
+++ b/packages/terra-aggregate-translations/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-* Removed
+* Breaking
   * Removed intl v3 and v4 support.
 
 ## 2.4.0 - (February 11, 2022)

--- a/packages/terra-aggregate-translations/CHANGELOG.md
+++ b/packages/terra-aggregate-translations/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+* Removed
+  * Removed intl v3 and v4 support.
 
 ## 2.4.0 - (February 11, 2022)
 

--- a/packages/terra-aggregate-translations/UpgradeGuide.md
+++ b/packages/terra-aggregate-translations/UpgradeGuide.md
@@ -2,8 +2,8 @@
 
 ## Changes from version 2 to version 3
 
-terra-aggregate-translations has drop the support of react-intl versions below 5. projects consuming terra-aggregate-translations version 3 should use React Intl version >= 5.
-React-intl V5 no longer exports the `intlShape` consuming project should replace the `intlShape` with `PropTypes.shape({ formatMessage: PropTypes.func })`. See [doc](https://formatjs.io/docs/intl#the-intl-object) for most complete and up to date intl shape.
+terra-aggregate-translations has drop the support of react-intl versions below 5. Projects consuming terra-aggregate-translations version 3 should use react-intl version >= 5.
+React-intl V5 no longer exports the `intlShape`. Consuming project should replace the `intlShape` with `PropTypes.shape({ formatMessage: PropTypes.func })`. See [doc](https://formatjs.io/docs/intl#the-intl-object) for most complete and up to date intl shape.
 Follow the upgrade guide of react-intl v5 to know more about the breaking changes : https://formatjs.io/docs/react-intl/upgrade-guide-5x 
 
 ## Changes from version 1 to version 2

--- a/packages/terra-aggregate-translations/UpgradeGuide.md
+++ b/packages/terra-aggregate-translations/UpgradeGuide.md
@@ -4,7 +4,7 @@
 
 `terra-aggregate-translations v3` drops support for `react-intl 4` and below. Projects consuming `terra-aggregate-translations` version 3 should use `react-intl` version `>= 5`.
 
-`react-intl v5` no longer exports the `intlShape`. Consuming projects should replace the `intlShape` with `PropTypes.shape({ formatMessage: PropTypes.func })`. See [doc](https://formatjs.io/docs/intl#the-intl-object) for more information.
+`react-intl v5` no longer exports the `intlShape`. Consuming projects should replace the `intlShape` with `PropTypes.shape()` containing the functions that are utilized by the component. See [doc](https://formatjs.io/docs/intl#the-intl-object) for most complete and up to date intl shape.
 
 Follow the upgrade guide of react-intl v5 to know more about the breaking changes : https://formatjs.io/docs/react-intl/upgrade-guide-5x 
 

--- a/packages/terra-aggregate-translations/UpgradeGuide.md
+++ b/packages/terra-aggregate-translations/UpgradeGuide.md
@@ -1,6 +1,11 @@
 # Terra Aggregate Translations
 
-## Changes from version 3 to version 4
+## Changes from version 2 to version 3
+
+terra-aggregate-translations has drop the support of react-intl versions below 5. projects consuming terra-aggregate-translations version 3 should use React Intl version >= 5.
+Follow the upgrade guide of react-intl v5 to know more about the breaking changes : https://formatjs.io/docs/react-intl/upgrade-guide-5x 
+
+## Changes from version 1 to version 2
 
 ### Project Name Updated with @cerner Scope
 

--- a/packages/terra-aggregate-translations/UpgradeGuide.md
+++ b/packages/terra-aggregate-translations/UpgradeGuide.md
@@ -3,6 +3,7 @@
 ## Changes from version 2 to version 3
 
 terra-aggregate-translations has drop the support of react-intl versions below 5. projects consuming terra-aggregate-translations version 3 should use React Intl version >= 5.
+React-intl V5 no longer exports the `intlShape` consuming project should replace the `intlShape` with `PropTypes.shape({ formatMessage: PropTypes.func })`. See [doc](https://formatjs.io/docs/intl#the-intl-object) for most complete and up to date intl shape.
 Follow the upgrade guide of react-intl v5 to know more about the breaking changes : https://formatjs.io/docs/react-intl/upgrade-guide-5x 
 
 ## Changes from version 1 to version 2

--- a/packages/terra-aggregate-translations/UpgradeGuide.md
+++ b/packages/terra-aggregate-translations/UpgradeGuide.md
@@ -6,7 +6,12 @@
 
 `react-intl v5` no longer exports the `intlShape`. Consuming projects should replace the `intlShape` with `PropTypes.shape()` containing the functions that are utilized by the component. See [doc](https://formatjs.io/docs/intl#the-intl-object) for most complete and up to date intl shape.
 
-Follow the upgrade guide of react-intl v5 to know more about the breaking changes : https://formatjs.io/docs/react-intl/upgrade-guide-5x 
+Most of the changes to react-intl api's happened in version 3 and version 4. Refer to Resources section for more information about Breaking changes happened in react-intl from version 2 to version 5.
+
+## Resources
+- Upgrade guide for version 4 -> 5 : https://formatjs.io/docs/react-intl/upgrade-guide-5x
+- Upgrade guide for version 3 -> 4 : https://formatjs.io/docs/react-intl/upgrade-guide-4x
+- Upgrade guide for version 2 -> 3 : https://formatjs.io/docs/react-intl/upgrade-guide-3x 
 
 ## Changes from version 1 to version 2
 

--- a/packages/terra-aggregate-translations/UpgradeGuide.md
+++ b/packages/terra-aggregate-translations/UpgradeGuide.md
@@ -2,8 +2,10 @@
 
 ## Changes from version 2 to version 3
 
-terra-aggregate-translations has drop the support of react-intl versions below 5. Projects consuming terra-aggregate-translations version 3 should use react-intl version >= 5.
-React-intl V5 no longer exports the `intlShape`. Consuming project should replace the `intlShape` with `PropTypes.shape({ formatMessage: PropTypes.func })`. See [doc](https://formatjs.io/docs/intl#the-intl-object) for most complete and up to date intl shape.
+`terra-aggregate-translations v3` drops support for `react-intl 4` and below. Projects consuming `terra-aggregate-translations` version 3 should use `react-intl` version `>= 5`.
+
+`react-intl v5` no longer exports the `intlShape`. Consuming projects should replace the `intlShape` with `PropTypes.shape({ formatMessage: PropTypes.func })`. See [doc](https://formatjs.io/docs/intl#the-intl-object) for more information.
+
 Follow the upgrade guide of react-intl v5 to know more about the breaking changes : https://formatjs.io/docs/react-intl/upgrade-guide-5x 
 
 ## Changes from version 1 to version 2

--- a/packages/terra-aggregate-translations/package.json
+++ b/packages/terra-aggregate-translations/package.json
@@ -54,6 +54,6 @@
   },
   "peerDependencies": {
     "intl": "^1.2.5",
-    "react-intl": "^2.8.0 || ^5.0.0"
+    "react-intl": "^5.0.0"
   }
 }

--- a/packages/terra-aggregate-translations/package.json
+++ b/packages/terra-aggregate-translations/package.json
@@ -54,6 +54,6 @@
   },
   "peerDependencies": {
     "intl": "^1.2.5",
-    "react-intl": "^5.0.0"
+    "react-intl": "^5.8.2"
   }
 }

--- a/packages/terra-aggregate-translations/src/aggregate-translations.js
+++ b/packages/terra-aggregate-translations/src/aggregate-translations.js
@@ -2,13 +2,10 @@ const path = require('path');
 const chalk = require('chalk');
 const fse = require('fs-extra');
 const glob = require('glob');
-// eslint-disable-next-line import/no-unresolved
-const { intlShape } = require('react-intl');
 const supportedLocales = require('./config/i18nSupportedLocales');
 
 const aggregateMessages = require('./aggregate-messages');
 const writeAggregatedTranslations = require('./write-aggregated-translations');
-const writeI18nLoaders = require('./write-i18n-loaders');
 const defaultSearchPatterns = require('./config/defaultSearchPatterns');
 
 const isFile = filePath => (fse.existsSync(filePath) && !fse.lstatSync(filePath).isDirectory());
@@ -61,7 +58,7 @@ const defaults = (options = {}) => {
  */
 const aggregatedTranslations = (options) => {
   const {
-    baseDir, directories, fileSystem, locales, outputDir, excludes, format,
+    baseDir, directories, fileSystem, locales, outputDir, excludes,
   } = defaults(options);
 
   const searchPaths = [
@@ -85,19 +82,8 @@ const aggregatedTranslations = (options) => {
   const outputDirectory = path.resolve(baseDir, outputDir);
   fileSystem.mkdirpSync(outputDirectory);
 
-  /**
-   * Detecting react-intl version used. `react-intl` v3 and greater does not export the intlShape.
-   * In order to use these versions of `react-intl` consumers should utilize terra-application v2, which provides the i18n loaders.
-   */
-  const isReactIntlv5 = !intlShape;
-
   // Write aggregated translation messages to a file for each locale
-  writeAggregatedTranslations(aggregatedMessages, locales, fileSystem, outputDirectory, isReactIntlv5);
-
-  if (!isReactIntlv5) {
-    // Write intl and translations loaders for the specified locales
-    writeI18nLoaders(locales, fileSystem, outputDirectory, format);
-  }
+  writeAggregatedTranslations(aggregatedMessages, locales, fileSystem, outputDirectory);
 
   return locales;
 };

--- a/packages/terra-aggregate-translations/src/generate-translation-file.js
+++ b/packages/terra-aggregate-translations/src/generate-translation-file.js
@@ -16,32 +16,7 @@ const sortMessages = (messages) => {
   return sortedMessages;
 };
 
-const translationFile = (locale, baseLocale, messages) => (
-  `'use strict';\n
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports.messages = exports.locale = exports.areTranslationsLoaded = undefined;
-
-var _reactIntl = require('react-intl');
-
-var _${baseLocale} = require('react-intl/locale-data/${baseLocale}');
-
-var _${baseLocale}2 = _interopRequireDefault(_${baseLocale});
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-(0, _reactIntl.addLocaleData)(_${baseLocale}2.default);
-
-var messages = ${JSON.stringify(messages, null, 2)};
-var areTranslationsLoaded = true;
-var locale = '${locale}';
-exports.areTranslationsLoaded = areTranslationsLoaded;
-exports.locale = locale;
-exports.messages = messages;
-`);
-
-const v5TranslationFile = (messages) => (
+const translationFile = (messages) => (
   `'use strict';\n
   Object.defineProperty(exports, "__esModule", {
     value: true
@@ -52,13 +27,9 @@ const v5TranslationFile = (messages) => (
   exports.default = _default;
 `);
 
-const generateTranslationFile = (locale, messages, isReactIntlV5) => {
+const generateTranslationFile = (messages) => {
   const sortedMessages = sortMessages(messages);
-  const baseLocale = locale.split('-')[0];
-  if (isReactIntlV5) {
-    return v5TranslationFile(sortedMessages);
-  }
-  return translationFile(locale, baseLocale, sortedMessages);
+  return translationFile(sortedMessages);
 };
 
 module.exports = generateTranslationFile;

--- a/packages/terra-aggregate-translations/src/write-aggregated-translations.js
+++ b/packages/terra-aggregate-translations/src/write-aggregated-translations.js
@@ -3,7 +3,7 @@ const chalk = require('chalk');
 const supportedLocales = require('./config/i18nSupportedLocales');
 const generateTranslationFile = require('./generate-translation-file');
 
-const writeAggregatedTranslations = (aggregatedMessages, locales, fileSystem, outputDir, isReactIntlV5) => {
+const writeAggregatedTranslations = (aggregatedMessages, locales, fileSystem, outputDir) => {
   // Create a file of aggregated translation messages for each locale
   locales.forEach((locale) => {
     if (locale in aggregatedMessages) {
@@ -24,7 +24,7 @@ const writeAggregatedTranslations = (aggregatedMessages, locales, fileSystem, ou
           mergedMessages = { ...baseLocaleMessages, ...messages };
         }
       }
-      fileSystem.writeFileSync(translationFilePath, generateTranslationFile(locale, mergedMessages, isReactIntlV5));
+      fileSystem.writeFileSync(translationFilePath, generateTranslationFile(mergedMessages));
     } else {
       throw new Error(chalk.red(`Translations aggregated for ${locale} locale, but messages were not loaded correctly. Please check that your translated modules were installed correctly.`));
     }

--- a/packages/terra-aggregate-translations/tests/jest/__snapshots__/generate-translation-file.test.js.snap
+++ b/packages/terra-aggregate-translations/tests/jest/__snapshots__/generate-translation-file.test.js.snap
@@ -3,32 +3,18 @@
 exports[`generate en translations file creates the compiled en translation file 1`] = `
 "'use strict';
 
-Object.defineProperty(exports, \\"__esModule\\", {
-  value: true
-});
-exports.messages = exports.locale = exports.areTranslationsLoaded = undefined;
+  Object.defineProperty(exports, \\"__esModule\\", {
+    value: true
+  });
+  exports.default = void 0;
 
-var _reactIntl = require('react-intl');
-
-var _en = require('react-intl/locale-data/en');
-
-var _en2 = _interopRequireDefault(_en);
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-(0, _reactIntl.addLocaleData)(_en2.default);
-
-var messages = {
+  var _default = {
   \\"Terra.fixtures.test\\": \\"Test...\\",
   \\"Terra.Fixtures1.test\\": \\"Test...\\",
   \\"Terra.More.fixtures.test\\": \\"Test...\\",
   \\"Terra.test.fixtures.test\\": \\"Test...\\"
 };
-var areTranslationsLoaded = true;
-var locale = 'en';
-exports.areTranslationsLoaded = areTranslationsLoaded;
-exports.locale = locale;
-exports.messages = messages;
+  exports.default = _default;
 "
 `;
 
@@ -53,32 +39,18 @@ exports[`generate en translations file for react-intl v5 creates the compiled en
 exports[`generate en-US translations file creates the compiled en-US translation file 1`] = `
 "'use strict';
 
-Object.defineProperty(exports, \\"__esModule\\", {
-  value: true
-});
-exports.messages = exports.locale = exports.areTranslationsLoaded = undefined;
+  Object.defineProperty(exports, \\"__esModule\\", {
+    value: true
+  });
+  exports.default = void 0;
 
-var _reactIntl = require('react-intl');
-
-var _en = require('react-intl/locale-data/en');
-
-var _en2 = _interopRequireDefault(_en);
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-(0, _reactIntl.addLocaleData)(_en2.default);
-
-var messages = {
+  var _default = {
   \\"Terra.fixtures.test\\": \\"Test...\\",
   \\"Terra.Fixtures1.test\\": \\"Test...\\",
   \\"Terra.More.fixtures.test\\": \\"Test...\\",
   \\"Terra.test.fixtures.test\\": \\"Test...\\"
 };
-var areTranslationsLoaded = true;
-var locale = 'en-US';
-exports.areTranslationsLoaded = areTranslationsLoaded;
-exports.locale = locale;
-exports.messages = messages;
+  exports.default = _default;
 "
 `;
 

--- a/packages/terra-aggregate-translations/tests/jest/aggregate-translations.test.js
+++ b/packages/terra-aggregate-translations/tests/jest/aggregate-translations.test.js
@@ -103,7 +103,7 @@ describe('aggregate-translations', () => {
 
     expect(writtenFilePaths).toEqual(expect.arrayContaining(translationsFiles));
     const numSupportedLocales = i18nSupportedLocales.length;
-    expect(writtenFilePaths.length).toEqual(numSupportedLocales + 2);
+    expect(writtenFilePaths.length).toEqual(numSupportedLocales);
   });
 
   it('aggregates on the specified locales', () => {
@@ -114,7 +114,7 @@ describe('aggregate-translations', () => {
     const supportedLocales = aggregateTranslations({ locales: ['en'] });
 
     expect(writtenFilePaths).toEqual(expect.arrayContaining(translationsFiles));
-    expect(writtenFilePaths.length).toEqual(3);
+    expect(writtenFilePaths.length).toEqual(1);
     expect(supportedLocales).toEqual(['en']);
   });
 
@@ -127,7 +127,7 @@ describe('aggregate-translations', () => {
     const supportedLocales = aggregateTranslations({ locales: ['es'] });
 
     expect(writtenFilePaths).toEqual(expect.arrayContaining(translationsFiles));
-    expect(writtenFilePaths.length).toEqual(4);
+    expect(writtenFilePaths.length).toEqual(2);
     expect(supportedLocales).toEqual(['es', 'en']);
   });
 

--- a/packages/terra-aggregate-translations/tests/jest/generate-translation-file.test.js
+++ b/packages/terra-aggregate-translations/tests/jest/generate-translation-file.test.js
@@ -13,7 +13,7 @@ locales.forEach((locale) => {
         'Terra.fixtures.test': 'Test...',
       };
 
-      translationsFile = generateTranslationFile(locale, unsortedMessages);
+      translationsFile = generateTranslationFile(unsortedMessages);
     });
 
     it(`creates the compiled ${locale} translation file`, () => {
@@ -41,7 +41,7 @@ locales.forEach((locale) => {
         'Terra.fixtures.test': 'Test...',
       };
 
-      translationsFile = generateTranslationFile(locale, unsortedMessages, true);
+      translationsFile = generateTranslationFile(unsortedMessages);
     });
 
     it(`creates the compiled ${locale} translation file`, () => {


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->
Removes Flexing between React Intl V5 and React Intl V2 code. Drops React-Intl V2 support in terra-aggregate-translations.

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
