### PR TITLE
Allow travis to wait until npm install finishes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   # Clean install on any new build
   - npm run clean
 install:
-  - travis_wait 5 npm install
+  - travis_wait 15 npm install
 before_script:
   # Load Docker Cache
   - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   # Clean install on any new build
   - npm run clean
 install:
-  - travis_wait 20 npm install
+  - travis_wait 25 npm install
 before_script:
   # Load Docker Cache
   - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   # Clean install on any new build
   - npm run clean
 install:
-  - travis_wait 15 npm install
+  - travis_wait 30 npm install
 before_script:
   # Load Docker Cache
   - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ cache:
 before_install:
   # Clean install on any new build
   - npm run clean
+install:
+  - travis_wait 5 npm install
 before_script:
   # Load Docker Cache
   - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   # Clean install on any new build
   - npm run clean
 install:
-  - travis_wait 30 npm install
+  - travis_wait 20 npm install
 before_script:
   # Load Docker Cache
   - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   # Clean install on any new build
   - npm run clean
 install:
-  - travis_wait 25 npm install
+  - travis_wait 30 npm install
 before_script:
   # Load Docker Cache
   - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ before_install:
   # Clean install on any new build
   - npm run clean
 install:
+  # This needs to be investigated further why npm install now takes longer to finish and causes Travis to timeout and terminute the build.
+  # See https://github.com/cerner/terra-toolkit/pull/744 for description of error.
   - travis_wait 30 npm install
 before_script:
   # Load Docker Cache

--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -5,8 +5,8 @@
 ## 3.0.0 - (May 12, 2022)
 
 * Breaking
-  * Updated webpack-dev-server to version 4
-  * Added devMiddleWare to support webpack-dev-server v4
+  * Updated webpack-dev-server to version 4.
+  * Added devMiddleWare to support webpack-dev-server v4.
 
 * Added
   * Added authentication for accessing screenshots from the remote site.

--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -5,8 +5,8 @@
 ## 3.0.0 - (May 12, 2022)
 
 * Breaking
-  * Updated webpack-dev-server to version 4.
-  * Added devMiddleWare to support webpack-dev-server v4.
+  * Updated webpack-dev-server to version 4
+  * Added devMiddleWare to support webpack-dev-server v4
 
 * Added
   * Added authentication for accessing screenshots from the remote site.


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

The `npm install` step is now taking longer than usual and Travis timeouts due to the command not finishing within the default 10 minutes. The PR is to temporarily increase the time to allow the command to finish. This was tested with a wait time of 10, 15, 20, and 25 and the timeout still occurs. A wait time of 30 allows the build to pass.

```
No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
The build has been terminated
```


### Additional Details
![Screen Shot 2022-05-17 at 12 30 08 PM](https://user-images.githubusercontent.com/22618655/168874903-cbcc8d06-6b48-4b00-9661-5babe0ffd792.png)


@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
