### PR TITLE
Util module for looking up a PR in github api

### DIFF
--- a/packages/terra-functional-testing/package.json
+++ b/packages/terra-functional-testing/package.json
@@ -75,6 +75,7 @@
     "lodash.isundefined": "^3.0.1",
     "lodash.pickby": "^4.6.0",
     "node-fetch": "^2.6.0",
+    "octokit": "^1.8.0",
     "strip-ansi": "^6.0.0",
     "uuid": "^3.0.0",
     "webdriverio": "^7.7.3",

--- a/packages/terra-functional-testing/src/commands/utils/gh.js
+++ b/packages/terra-functional-testing/src/commands/utils/gh.js
@@ -1,0 +1,68 @@
+/**
+ * This module encapsulates the full-power octokit library inside a simple interface.
+ * https://github.com/octokit/octokit.js
+ *
+ * It supports both github.com and enterprise github hosts.
+ * Requires your github host to have API v3 and https.
+ */
+const { Octokit } = require('octokit');
+
+/**
+ * Look up information about a github PR.
+ *
+ * @param {string} config.githubHostname The hostname of your github. Can be 'github.com' or your enterprise github (e.g. 'github.example.com').
+ * @param {string} config.repoOwner Would be 'cerner' for https://github.com/cerner/terra-core/pulls/1.
+ * @param {string} config.repoName Would be 'terra-core' for https://github.com/cerner/terra-core/pulls/1.
+ * @param {string} config.prNumber Would be '1' for https://github.com/cerner/terra-core/pulls/1.
+ * @returns An objection containing the PR's number, unique ID, head and base refs.
+ *
+ * If anything goes wrong looking up the PR, an exception will be thrown.
+ */
+async function getPr(config) {
+  const {
+    githubHostname, owner, repo, prNumber,
+  } = config;
+
+  const octokit = new Octokit({
+    baseURL: `https://${githubHostname}/api/v3`,
+  });
+  let result;
+
+  try {
+    result = await octokit.request('GET /repos/{owner}/{repo}/pulls/{prNumber}', {
+      owner,
+      repo,
+      prNumber,
+    });
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error(`Something went wrong trying to look up ${owner}/${repo} #${prNumber} from ${githubHostname}.`);
+    throw e;
+  }
+
+  return {
+    githubId: result.data.id,
+    prNumber: result.data.number,
+    head: {
+      ref: result.data.head.ref,
+    },
+    base: {
+      ref: result.data.base.ref,
+    },
+  };
+}
+
+async function test() {
+  const config = {
+    githubHostname: 'github.com',
+    owner: 'cerner',
+    repo: 'terra-core',
+    prNumber: '1',
+  };
+  const pr = await getPr(config);
+  console.log(pr);
+}
+
+module.exports = {
+  test,
+};


### PR DESCRIPTION
### Summary
I've added a light weight wrapper around the github API. Its first use will be looking up PR information.

### Additional Details
This is a micro PR. I want to try merging to main before figuring out the rest of the work. This is an experiment in trunk-based dev.

### Testing
I included a tiny test method that you can run yourself in the CLI:
```
> node -e 'require("./packages/terra-functional-testing/src/commands/utils/gh").test()'
{
  githubId: 107902132,
  prNumber: 1,
  head: { ref: 'remove-obsolete-snapshots' },
  base: { ref: 'master' }
}
```

<img width="837" alt="image" src="https://user-images.githubusercontent.com/52507228/174904558-df2f1416-6b76-4838-9ea1-f72da1d9c78a.png">


Proper unit tests, and integration tests will be written as part of another PR - this code is effectively feature flagged (it's never called).

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
