### PR TITLE
Reverts terra-aggregate-translations to V2

### DIFF
--- a/packages/webpack-config-terra/CHANGELOG.md
+++ b/packages/webpack-config-terra/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## Unreleased
 
+* Changed
+  * Reverts terra-aggregate-translations to v2.
+
 ## 3.0.0 - (May 12, 2022)
 
 * Breaking
-  * Added devMiddleWare to support webpack-dev-server v4
+  * Added devMiddleWare to support webpack-dev-server v4.
 
 ## 2.4.0 - (February 11, 2022)
 

--- a/packages/webpack-config-terra/package.json
+++ b/packages/webpack-config-terra/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@cerner/duplicate-package-checker-webpack-plugin": "^2.3.0",
-    "@cerner/terra-aggregate-translations": "^3.0.0",
+    "@cerner/terra-aggregate-translations": "^2.0.0",
     "@mjhenkes/postcss-rtl": "^2.0.0",
     "autoprefixer": "^10.0.0",
     "babel-loader": "^8.0.5",


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->
This PR reverts aggregate-translations to v2 in order to allow the projects to consume webpack-config-terra v3, which are not updated to support react-intl v5.

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

webpack-config-terra version 3 was released to update webpack-dev-server to version 4.
Along with the webpack-config-terra, terra-aggregate-translations was released with react-intl version 5 updates. Due to this version update in webpack-config-terra v3 now requires consuming projects to be compatible with react-intl version 5 and all it's dependent projects to be updated to support react-intl V5.
since most of the orion-components and Orion framework components are not yet released with react-intl-v5 changes. consuming webpack-config-terra V3 would be challenging.
In order to limit MVB changes of webpack-config-terra to webpack-dev-server V4 upgrade terra-aggregate-translations needs to reverted back to V2.

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
