### PR TITLE
Prevent an infinite loop when watching files

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,9 @@ const jestConfig = require('./packages/jest-config-terra');
 
 module.exports = {
   ...jestConfig,
+  watchPathIgnorePatterns: [
+    './tests/jest/reports/results/terra-functional-testing.json',
+  ],
   modulePathIgnorePatterns: [
     'packages/terra-cli/tests/jest/fixtures',
     'packages/duplicate-package-checker-webpack-plugin/tests/jest',


### PR DESCRIPTION
### Summary
This fixes an infinite loop I was getting due to the updated coverage JSON file being flagged as changed. With this change, now this works:

```
npx jest --watch
```
