### PR TITLE
Fixed a reference bug

### DIFF
--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * A latent referencing bug that was not (yet) causing a test failure because it manifested as an unhandled promise. Thus, it emitted a warning but the test still passed.
+
 ## 3.2.1 - (August 30, 2022)
 
 * Added

--- a/packages/terra-functional-testing/src/services/wdio-terra-service.js
+++ b/packages/terra-functional-testing/src/services/wdio-terra-service.js
@@ -42,8 +42,8 @@ class TerraService {
    */
   async onPrepare(config) {
     try {
-      if (this.serviceOptions.useRemoteReferenceScreenshots) {
-        const screenshotConfig = config.getRemoteScreenshotConfiguration ? config.getRemoteScreenshotConfiguration(config.screenshotsSites, this.serviceOptions.buildBranch) : {};
+      if (this.serviceOptions.useRemoteReferenceScreenshots && config.getRemoteScreenshotConfiguration) {
+        const screenshotConfig = config.getRemoteScreenshotConfiguration(config.screenshotsSites, this.serviceOptions.buildBranch);
         const screenshotRequestor = new ScreenshotRequestor(screenshotConfig.publishScreenshotConfiguration);
         await screenshotRequestor.download();
       }

--- a/packages/terra-functional-testing/src/services/wdio-terra-service.js
+++ b/packages/terra-functional-testing/src/services/wdio-terra-service.js
@@ -169,8 +169,13 @@ class TerraService {
             throw Error(`Error posting issue comment. Status code: ${postCommentResult.status}`);
           }
         }
-      } else if (this.serviceOptions.useRemoteReferenceScreenshots && !this.serviceOptions.buildBranch.match(BUILD_BRANCH.pullRequest) && this.serviceOptions.buildType === BUILD_TYPE.branchEventCause) {
-        const screenshotConfig = config.getRemoteScreenshotConfiguration ? config.getRemoteScreenshotConfiguration(config.screenshotsSites, this.serviceOptions.buildBranch) : {};
+      } else if (
+        this.serviceOptions.useRemoteReferenceScreenshots
+        && !this.serviceOptions.buildBranch.match(BUILD_BRANCH.pullRequest)
+        && this.serviceOptions.buildType === BUILD_TYPE.branchEventCause
+        && config.getRemoteScreenshotConfiguration
+      ) {
+        const screenshotConfig = config.getRemoteScreenshotConfiguration(config.screenshotsSites, this.serviceOptions.buildBranch);
         const screenshotRequestor = new ScreenshotRequestor(screenshotConfig.publishScreenshotConfiguration);
         await screenshotRequestor.upload();
       }

--- a/packages/terra-functional-testing/tests/jest/services/wdio-terra-service.test.js
+++ b/packages/terra-functional-testing/tests/jest/services/wdio-terra-service.test.js
@@ -14,7 +14,7 @@ jest.mock('../../../src/commands/utils');
 
 const mockIsExisting = jest.fn().mockImplementation(() => true);
 const element = {
-  waitForExist: () => {},
+  waitForExist: () => { },
   isExisting: mockIsExisting,
 };
 
@@ -30,7 +30,7 @@ const config = {
     theme: 'mock-theme',
     formFactor: 'huge',
   },
-  getRemoteScreenshotConfiguration: jest.fn().mockImplementation(() => {}),
+  getRemoteScreenshotConfiguration: jest.fn().mockImplementation(() => { }),
 };
 
 const capabilities = { browserName: 'chrome' };
@@ -171,7 +171,11 @@ describe('WDIO Terra Service', () => {
         repositoryId: 'mock-repositoryId',
         repositoryUrl: 'mock-repositoryUrl',
       },
-      getRemoteScreenshotConfiguration: jest.fn().mockImplementation(() => {}),
+      getRemoteScreenshotConfiguration: jest.fn().mockImplementation(() => (
+        {
+          publishScreenshotConfiguration: jest.fn(),
+        }
+      )),
     };
 
     const service = new WdioTerraService({}, {}, localConfig);


### PR DESCRIPTION
### Summary
The new onComplete logic of terra-wdio-service was allowing some invalid logic: [calling a function with an undefined argument](https://github.com/cerner/terra-toolkit/blob/main/packages/terra-functional-testing/src/services/wdio-terra-service.js#L173-L174). This was masked from our test runs because unhandled promises are not being flagged as failures in our CI setup. Future versions of node will fail these. 

I fixed it by adding "do you have this thing?" to the if-check above the logic.

### Additional Details
We should update our CI system to fail tests due to unhandled promises ASAP. I bet we have more of these latent bugs being emitted only as warnings.
