### PR TITLE
Determine targeted branch name for pr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,4 +64,4 @@ lib
 !/packages/terra-cli/tests/jest/fixtures/**/lib/
 !/packages/duplicate-package-checker-webpack-plugin/tests/jest/**/node_modules/
 .idea
-packages/terra-functional-testing/src/.DS_Store
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ lib
 !/packages/terra-cli/tests/jest/fixtures/**/lib/
 !/packages/duplicate-package-checker-webpack-plugin/tests/jest/**/node_modules/
 .idea
+packages/terra-functional-testing/src/.DS_Store

--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+* Added
+  * Upon merging a PR, the updated screenshots will be posted to the remote site.
+
+* Changed
+  * The github util module was abandoned unused, and has been replaced with an octokit wrapper meant to limit the auth strategy to use Github personal access tokens, or PATs.
+
 ## 3.2.1 - (August 30, 2022)
 
 * Added

--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -6,7 +6,7 @@
   * Upon merging a PR, the updated screenshots will be posted to the remote site.
 
 * Changed
-  * The github util module was abandoned, unused, and has been replaced with an octokit wrapper meant to limit the auth strategy to use Github personal access tokens, or PATs.
+  * The github util module is replaced with an octokit wrapper to limit the auth strategy to Github PATs ( personal access tokens).
 
 ## 3.2.1 - (August 30, 2022)
 

--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -6,7 +6,7 @@
   * Upon merging a PR, the updated screenshots will be posted to the remote site.
 
 * Changed
-  * The github util module was abandoned unused, and has been replaced with an octokit wrapper meant to limit the auth strategy to use Github personal access tokens, or PATs.
+  * The github util module was abandoned, unused, and has been replaced with an octokit wrapper meant to limit the auth strategy to use Github personal access tokens, or PATs.
 
 ## 3.2.1 - (August 30, 2022)
 

--- a/packages/terra-functional-testing/src/commands/utils/createOctokit.js
+++ b/packages/terra-functional-testing/src/commands/utils/createOctokit.js
@@ -1,6 +1,6 @@
 const { Octokit } = require('@octokit/core');
 
-/** Creates an {@link https://github.com/octokit/core.js|Octokit core} instance from simplifieid options.
+/** Creates an {@link https://github.com/octokit/core.js|Octokit core} instance from simplified options.
  * @param {string} [baseUrl] - An alternative github API base to https://github.com/api/v3
  * @param {string} [pat] - A {@link https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token|Personal Access Token} with which to authenticate your requests.
  * @returns a new Octokit instance.

--- a/packages/terra-functional-testing/src/commands/utils/createOctokit.js
+++ b/packages/terra-functional-testing/src/commands/utils/createOctokit.js
@@ -1,0 +1,19 @@
+const { Octokit } = require('@octokit/core');
+
+/** Creates an {@link https://github.com/octokit/core.js|Octokit core} instance from simplifieid options.
+ * @param {string} [baseUrl] - An alternative github API base to https://github.com/api/v3
+ * @param {string} [pat] - A {@link https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token|Personal Access Token} with which to authenticate your requests.
+ * @returns a new Octokit instance.
+ */
+function createOctokit(baseUrl = null, token = null) {
+  const options = {};
+  if (token) {
+    options.auth = token;
+  }
+  if (baseUrl) {
+    options.baseUrl = baseUrl;
+  }
+  return new Octokit(options);
+}
+
+module.exports = createOctokit;

--- a/packages/terra-functional-testing/src/commands/utils/index.js
+++ b/packages/terra-functional-testing/src/commands/utils/index.js
@@ -1,4 +1,5 @@
 const cleanScreenshots = require('./cleanScreenshots');
+const createOctokit = require('./createOctokit');
 const describeTests = require('./describeTests');
 const describeViewports = require('./describeViewports');
 const dispatchCustomEvent = require('./dispatchCustomEvent');
@@ -6,13 +7,14 @@ const eventEmitter = require('./eventEmitter');
 const getViewports = require('./getViewports');
 const getViewportSize = require('./getViewportSize');
 const hideInputCaret = require('./hideInputCaret');
+const ScreenshotRequestor = require('./ScreenshotRequestor');
 const setApplicationLocale = require('./setApplicationLocale');
 const setViewport = require('./setViewport');
 const setViewportSize = require('./setViewportSize');
-const ScreenshotRequestor = require('./ScreenshotRequestor');
 
 module.exports = {
   cleanScreenshots,
+  createOctokit,
   describeTests,
   describeViewports,
   dispatchCustomEvent,
@@ -20,8 +22,8 @@ module.exports = {
   getViewports,
   getViewportSize,
   hideInputCaret,
+  ScreenshotRequestor,
   setApplicationLocale,
   setViewport,
   setViewportSize,
-  ScreenshotRequestor,
 };

--- a/packages/terra-functional-testing/src/services/wdio-terra-service.js
+++ b/packages/terra-functional-testing/src/services/wdio-terra-service.js
@@ -154,7 +154,7 @@ class TerraService {
 
       if (this.serviceOptions.useRemoteReferenceScreenshots && process.env.SCREENSHOT_MISMATCH_CHECK && this.serviceOptions.buildBranch.match(BUILD_BRANCH.pullRequest)) {
         // When a PR is updated, we will one time post a warning mesage to the PR if the screenshots mismatch. This
-        // gives the end-user the oppertunity to fix the mismatch before the PR is merged. See the else block below
+        // gives the end-user the opportunity to fix the mismatch before the PR is merged. See the else block below
         // for what happens when the PR is merged.
         if (!this.serviceOptions.gitToken || !this.serviceOptions.gitApiUrl) {
           throw new Error('No git token recieved');

--- a/packages/terra-functional-testing/src/services/wdio-terra-service.js
+++ b/packages/terra-functional-testing/src/services/wdio-terra-service.js
@@ -153,6 +153,9 @@ class TerraService {
       const octokit = createOctokit(this.serviceOptions.gitApiUrl, this.serviceOptions.gitToken);
 
       if (this.serviceOptions.useRemoteReferenceScreenshots && process.env.SCREENSHOT_MISMATCH_CHECK && this.serviceOptions.buildBranch.match(BUILD_BRANCH.pullRequest)) {
+        // When a PR is updated, we will one time post a warning mesage to the PR if the screenshots mismatch. This
+        // gives the end-user the oppertunity to fix the mismatch before the PR is merged. See the else block below
+        // for what happens when the PR is merged.
         if (!this.serviceOptions.gitToken || !this.serviceOptions.gitApiUrl) {
           throw new Error('No git token recieved');
         }
@@ -179,6 +182,9 @@ class TerraService {
           }
         }
       } else if (
+        // Branch event here means the PR has been merged. We will upload the screenshots to the base branch of the PR.
+        // The PR's base branch is the merge target of the PR, so if the PR was from my-feature to master, base branch's
+        // ref is master.
         this.serviceOptions.useRemoteReferenceScreenshots
         && !this.serviceOptions.buildBranch.match(BUILD_BRANCH.pullRequest)
         && this.serviceOptions.buildType === BUILD_TYPE.branchEventCause

--- a/packages/terra-functional-testing/src/services/wdio-terra-service.js
+++ b/packages/terra-functional-testing/src/services/wdio-terra-service.js
@@ -18,6 +18,23 @@ const {
 } = require('../commands/utils');
 const { BUILD_BRANCH, BUILD_TYPE } = require('../constants');
 
+/**
+ * Throw a SevereServiceError which stops the runner.
+* @param {string} errorMessage - The reason you're stopping the run.
+* @throws { SevereServiceError }
+*/
+const stopTheRunner = (errorMessage) => {
+  throw new SevereServiceError(errorMessage);
+};
+
+/**
+ * One-liner to stop the runner with a properly formatted octokit error object.
+ * @param {object} rejectionError An octokit error object that is given when a request fails. See https://github.com/octokit/request.js/#request.
+ */
+const handleOctokitRequestFailure = (rejectionError) => {
+  stopTheRunner(JSON.stringify(rejectionError, null, 4));
+};
+
 class TerraService {
   /**
    * Service constructor.
@@ -202,4 +219,8 @@ class TerraService {
   }
 }
 
-module.exports = TerraService;
+module.exports = {
+  handleOctokitRequestFailure,
+  stopTheRunner,
+  TerraService,
+};

--- a/packages/terra-functional-testing/src/services/wdio-terra-service.js
+++ b/packages/terra-functional-testing/src/services/wdio-terra-service.js
@@ -8,6 +8,7 @@ const { SevereServiceError } = require('webdriverio');
 const { accessibility, element, screenshot } = require('../commands/validates');
 const { toBeAccessible, toMatchReference } = require('../commands/expect');
 const {
+  createOctokit,
   describeTests,
   describeViewports,
   getViewports,
@@ -155,7 +156,8 @@ class TerraService {
         const packageJson = fs.readJsonSync(path.join(process.cwd(), 'package.json'));
         const repoUrl = new URL(packageJson.repository.url);
         const repoName = repoUrl.pathname.match(/[^/]+/g);
-        const octokit = new Octokit({ baseUrl: `${this.serviceOptions.gitApiUrl}`, auth: `${this.serviceOptions.gitToken}` });
+        // const octokit = new Octokit({ baseUrl: `${this.serviceOptions.gitApiUrl}`, auth: `${this.serviceOptions.gitToken}` });
+        const octokit = createOctokit(this.serviceOptions.gitApiUrl, this.serviceOptions.gitToken);
         const message = `:warning: :bangbang: **WDIO MISMATCH** \n\nCheck that screenshot change is intended at: ${this.serviceOptions.buildUrl} \n\nIf screenshot change is intended, remote reference screenshots will be updated upon PR merge. \nIf screenshot change is unintended, please fix screenshot issues before PR merge to prevent them from being uploaded. \n\nNote: This comment only appears the first time a screenshot mismatch is detected on a PR build, future builds will need to be checked for unintended screenshot mismatchs.`;
 
         const commentsResult = await octokit.request(`GET /repos/${repoName[0]}/${repoName[1]}/issues/${this.serviceOptions.issueNumber}/comments`);
@@ -169,8 +171,13 @@ class TerraService {
             throw Error(`Error posting issue comment. Status code: ${postCommentResult.status}`);
           }
         }
-      } else if (this.serviceOptions.useRemoteReferenceScreenshots && !this.serviceOptions.buildBranch.match(BUILD_BRANCH.pullRequest) && this.serviceOptions.buildType === BUILD_TYPE.branchEventCause) {
-        const screenshotConfig = config.getRemoteScreenshotConfiguration ? config.getRemoteScreenshotConfiguration(config.screenshotsSites, this.serviceOptions.buildBranch) : {};
+      } else if (
+        this.serviceOptions.useRemoteReferenceScreenshots
+        && !this.serviceOptions.buildBranch.match(BUILD_BRANCH.pullRequest)
+        && this.serviceOptions.buildType === BUILD_TYPE.branchEventCause
+        && config.getRemoteScreenshotConfiguration
+      ) {
+        const screenshotConfig = config.getRemoteScreenshotConfiguration(config.screenshotsSites, this.serviceOptions.buildBranch);
         const screenshotRequestor = new ScreenshotRequestor(screenshotConfig.publishScreenshotConfiguration);
         await screenshotRequestor.upload();
       }

--- a/packages/terra-functional-testing/tests/jest/commands/utils/createOctokit.test.js
+++ b/packages/terra-functional-testing/tests/jest/commands/utils/createOctokit.test.js
@@ -1,0 +1,24 @@
+const { Octokit } = require('@octokit/core');
+const createOctokit = require('../../../../src/commands/utils/createOctokit');
+
+jest.mock('@octokit/core');
+
+describe('createApiClient', () => {
+  beforeEach(() => {
+    Octokit.mockClear();
+  });
+  it('can create an octokit for calling github.com unauthenticated', () => {
+    createOctokit();
+    expect(Octokit).toHaveBeenCalledWith({});
+  });
+
+  it('can create an octokit for calling enterprise github', () => {
+    createOctokit('https://github.example.com');
+    expect(Octokit).toHaveBeenCalledWith({ baseUrl: 'https://github.example.com' });
+  });
+
+  it('can create an octokit that authenticates requests with a PAT', () => {
+    createOctokit(null, 'my-token');
+    expect(Octokit).toHaveBeenCalledWith({ auth: 'my-token' });
+  });
+});

--- a/packages/terra-functional-testing/tests/jest/services/wdio-terra-service.test.js
+++ b/packages/terra-functional-testing/tests/jest/services/wdio-terra-service.test.js
@@ -1,7 +1,11 @@
 const fs = require('fs-extra');
 const { URL } = require('url');
 const { SevereServiceError } = require('webdriverio');
-const WdioTerraService = require('../../../src/services/wdio-terra-service');
+const {
+  handleOctokitRequestFailure,
+  stopTheRunner,
+  TerraService: WdioTerraService,
+} = require('../../../src/services/wdio-terra-service');
 const { setViewport, createOctokit } = require('../../../src/commands/utils');
 const { BUILD_BRANCH, BUILD_TYPE } = require('../../../src/constants/index');
 
@@ -177,6 +181,30 @@ describe('WDIO Terra Service', () => {
       },
       getRemoteScreenshotConfiguration: jest.fn(() => ({ publishScreenshotConfiguration: 1 })),
     };
+
+    const octokitError = {
+      // Error object structure is documented at https://github.com/octokit/request.js/#request.
+      status: 1,
+      request: '2',
+      response: '3',
+    };
+
+    describe('stopTheRunner', () => {
+      it('throws a SevereServiceError', () => {
+        expect(() => {
+          stopTheRunner('oh no!');
+        }).toThrow(new SevereServiceError('oh no!'));
+      });
+    });
+
+    describe('handleOctokitRequestFailure', () => {
+      it('throws a SevereServiceError with stringified, formatted error object', () => {
+        expect(() => {
+          // Error object structure is documented at https://github.com/octokit/request.js/#request.
+          handleOctokitRequestFailure(octokitError);
+        }).toThrow(new SevereServiceError(JSON.stringify(octokitError, null, 4)));
+      });
+    });
 
     it('should upload screenshots in onComplete', async () => {
       const localConfig = {


### PR DESCRIPTION
### Summary
When WDIO's onComplete() runs: we will upload the updated screenshots of a merged PR build to a remote repo. Part of this change also changes the unused github util module with an octokit wrapper. The wrapper just takes any thought out of choosing an auth strategy - it requires using PATs.

### Additional Details
I fixed a couple test bugs too while I was in there. I was worried some fails positives or fails would be masked by them.