### PR TITLE
[functional-testing] Fixed WDIO test Failures due to negative width value and invalid Ip address

### DIFF
--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## Unreleased
 
+* Fixed
+  * Fixed WDIO failures on IE due to negative width value being passed to `browser.setViewportSize()`.
+  * Fixed `getIpAddress` helper to return `ipv4` address for host when connected to VPN.
+
 ## 3.3.1 - (March 29, 2023)
 
-* Fixes
+* Fixed
   * Updated `mocha` to fix CVE
   * Added `babel-cli` to fix install issue 
 

--- a/packages/terra-functional-testing/src/commands/utils/setViewportSize.js
+++ b/packages/terra-functional-testing/src/commands/utils/setViewportSize.js
@@ -8,8 +8,8 @@ const setViewportSize = (viewport, retryNo = 0) => {
   const windowSize = global.browser.getWindowSize();
   const viewportSize = getViewportSize();
 
-  const widthDiff = windowSize.width - viewportSize.width;
-  const heightDiff = windowSize.height - viewportSize.height;
+  const widthDiff = Math.abs(windowSize.width - viewportSize.width);
+  const heightDiff = Math.abs(windowSize.height - viewportSize.height);
 
   // change window size with indent
   global.browser.setWindowSize(width + widthDiff, height + heightDiff);

--- a/packages/terra-functional-testing/src/config/utils/getIpAddress.js
+++ b/packages/terra-functional-testing/src/config/utils/getIpAddress.js
@@ -2,10 +2,15 @@ const ip = require('ip');
 const os = require('os');
 
 module.exports = () => {
-  const utun = Object.entries(os.networkInterfaces()).find(([key, networkInterface]) => key.includes('utun') && networkInterface[0] && networkInterface[0].family === 'IPv4');
-
-  if (utun && utun[1]) {
-    return utun[1][0].address;
+  const utun = Object.entries(os.networkInterfaces()).find(([key]) => key.includes(('utun3')));
+  if (utun && utun.length > 0) {
+    let ipv4;
+    utun.forEach((utunItem) => {
+      if (Array.isArray(utunItem)) {
+        ipv4 = utunItem.filter((networkItem) => networkItem.family === 'IPv4');
+      }
+    });
+    return ipv4[0].address;
   }
 
   return ip.address();

--- a/packages/terra-functional-testing/src/config/utils/getIpAddress.js
+++ b/packages/terra-functional-testing/src/config/utils/getIpAddress.js
@@ -2,15 +2,16 @@ const ip = require('ip');
 const os = require('os');
 
 module.exports = () => {
-  const utun = Object.entries(os.networkInterfaces()).find(([key]) => key.includes(('utun3')));
+  const utun = Object.entries(os.networkInterfaces()).filter(([key]) => key.includes(('utun'))).flat();
+
   if (utun && utun.length > 0) {
-    let ipv4;
+    let IPv4;
     utun.forEach((utunItem) => {
       if (Array.isArray(utunItem)) {
-        ipv4 = utunItem.filter((networkItem) => networkItem.family === 'IPv4');
+        IPv4 = utunItem.filter((networkItem) => networkItem.family === 'IPv4');
       }
     });
-    return ipv4[0].address;
+    return (IPv4) ? IPv4[0].address : ip.address();
   }
 
   return ip.address();


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->
1. WDIO tests started failing on Jenkins with below error functional-testing. upon investigation we found that [viewportSize.width](https://github.com/cerner/terra-toolkit/blob/79f1cf8c0c3892a5368a95cee14ca447c1e2cd76/packages/terra-functional-testing/src/commands/utils/setViewportSize.js#L11) is greater than `windowSize.width`. Due to this `widthDiff` and `heightDiff` were having negative values after calculation. Since browser.setWindowSize expects non negative integer wdio tests were failed with below error.

```js
[2023-04-05T12:51:49.327Z] [internet explorer 11 windows #1-3] 1) [large] "before all" hook for [large]

[2023-04-05T12:51:49.327Z] [internet explorer 11 windows #1-3] setWindowSize expects width and height to be a number in the 0 to 2^31 − 1 range

[2023-04-05T12:51:49.327Z] [internet explorer 11 windows #1-3] Error: setWindowSize expects width and height to be a number in the 0 to 2^31 − 1 range

[2023-04-05T12:51:49.327Z] [internet explorer 11 windows #1-3]   at setViewportSize (/app/node_modules/@cerner/terra-functional-testing/lib/commands/utils/setViewportSize.js:14:18)

[2023-04-05T12:51:49.327Z] [internet explorer 11 windows #1-3]   at setViewport (/app/node_modules/@cerner/terra-functional-testing/lib/commands/utils/setViewport.js:22:3)

[2023-04-05T12:51:49.328Z] [internet explorer 11 windows #1-3]   at Context.<anonymous> (/app/node_modules/@cerner/terra-functional-testing/lib/commands/utils/describeViewports.js:27:9)
```

2. WDIO tests started failing when connected to VPN. getIpAddress helper was returning invalid ipv4 address due to which WDIO tests were failing on local machine. 
 
### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->
1. Math.abs() function is used to get absolute value of negative values so that setWindowSize() function work as expected.
2. updated `getIpAddress()` helper to return valid ipv4 address.

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
3. Add the appropriate labels
4. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
