### PR TITLE
uuid version locked to 8.2.0

### DIFF
--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Changed
-  * Updated `uuid` to `v8` for consistency across Terra repos.
+  * Updated `uuid` to `v8.2.0` for consistency across Terra repos.
 
 ## 3.5.0 - (April 27, 2023)
 

--- a/packages/terra-functional-testing/package.json
+++ b/packages/terra-functional-testing/package.json
@@ -78,7 +78,7 @@
     "node-fetch": "^2.6.0",
     "octokit": "^1.8.0",
     "strip-ansi": "^6.0.0",
-    "uuid": "^8.3.2",
+    "uuid": "8.2.0",
     "webdriverio": "^7.7.3",
     "webpack-dev-server": "^4.7.2",
     "which": "^2.0.2"


### PR DESCRIPTION
### Summary
Per test issues caused to some projects that use terra-toolkit by stringify updated in uuid v8.3.0, the uuid version has been locked to 8.2.0

### Testing
This change was tested using:

- [ ] WDIO
- [x] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review
