### PR TITLE
[terra-functional-testing] Add option to use HTTPS when gridUrl is provided

### DIFF
--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Added `useHttps` to use a secure http connection when the `gridUrl` flag is also provided.
+
 * Changed
   * Updated `uuid` to `v8.2.0` for consistency across Terra repos.
 

--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Added
-  * Added `useHttps` to use a secure http connection when the `gridUrl` flag is also provided.
+  * Added `useHttps` flag to use a secure http connection when the `gridUrl` flag is also provided.
 
 * Changed
   * Updated `uuid` to `v8.2.0` for consistency across Terra repos.

--- a/packages/terra-functional-testing/src/config/utils/getConfigurationOptions.js
+++ b/packages/terra-functional-testing/src/config/utils/getConfigurationOptions.js
@@ -31,6 +31,7 @@ const getConfigurationOptions = (options) => {
     suite,
     theme,
     updateScreenshots,
+    useHttps,
     useRemoteReferenceScreenshots,
     useSeleniumStandaloneService,
   } = options;
@@ -58,6 +59,7 @@ const getConfigurationOptions = (options) => {
       site,
       ...(theme ? { theme } : { theme: getDefaultThemeName() }),
       updateScreenshots,
+      useHttps,
       useRemoteReferenceScreenshots,
       ...fs.existsSync(defaultWebpackPath) && { webpackConfig: defaultWebpackPath },
     },

--- a/packages/terra-functional-testing/src/terra-cli/wdio/index.js
+++ b/packages/terra-functional-testing/src/terra-cli/wdio/index.js
@@ -250,6 +250,11 @@ const cli = {
         describe: 'Whether or not to automatically update all reference screenshots with the latest screenshots.',
         default: false,
       },
+      useHttps: {
+        type: 'boolean',
+        describe: 'A flag to turn on secure HTTP for the webpack server when a gridUrl is provided.',
+        default: process.env.USE_HTTPS === 'true',
+      },
       useRemoteReferenceScreenshots: {
         type: 'boolean',
         describe: 'A flag to download reference screenshots from a remote site for screenshot comparisons instead of using the local reference screenshots.',

--- a/packages/terra-functional-testing/src/terra-cli/wdio/test-runner.js
+++ b/packages/terra-functional-testing/src/terra-cli/wdio/test-runner.js
@@ -50,6 +50,7 @@ class TestRunner {
    * @param {array} options.suite - Overrides specs and runs only the defined suites.
    * @param {string} options.theme - A theme for the test run.
    * @param {boolean} options.updateScreenshots - Updates all reference screenshots with the latest screenshots.
+   * @param {boolean} options.useHttps - A flag to turn on secure HTTP for the webpack server when a gridUrl is provided.
    * @param {boolean} options.useRemoteReferenceScreenshots - A flag to download reference screenshots from a remote site for screenshot comparisons instead of using the local reference screenshots.
    * @param {boolean} options.useSeleniumStandaloneService - A flag to use the selenium standalone service instead of the selenium docker service.
    * @returns {Promise} A promise that resolves with the test run exit code.
@@ -100,6 +101,7 @@ class TestRunner {
    * @param {array} options.suite - Overrides specs and runs only the defined suites.
    * @param {string} options.themes - A list of themes for the test run.
    * @param {boolean} options.updateScreenshots - Updates all reference screenshots with the latest screenshots.
+   * @param {boolean} options.useHttps - A flag to turn on secure HTTP for the webpack server when a gridUrl is provided.
    * @param {boolean} options.useRemoteReferenceScreenshots - A flag to download reference screenshots from a remote site for screenshot comparisons instead of using the local reference screenshots.
    * @param {boolean} options.useSeleniumStandaloneService - A flag to use the selenium standalone service instead of the selenium docker service.
    */

--- a/packages/terra-functional-testing/src/webpack-server/webpack-server.js
+++ b/packages/terra-functional-testing/src/webpack-server/webpack-server.js
@@ -7,7 +7,9 @@ const logger = new Logger({ prefix: '[terra-functional-testing:webpack-server]' 
 
 class WebpackServer {
   constructor(options = {}) {
-    const { useHttps, host, port, gridUrl } = options;
+    const {
+      useHttps, host, port, gridUrl,
+    } = options;
 
     const protocol = (useHttps === true) ? 'https' : 'http';
     this.config = WebpackServer.config(options);

--- a/packages/terra-functional-testing/src/webpack-server/webpack-server.js
+++ b/packages/terra-functional-testing/src/webpack-server/webpack-server.js
@@ -7,12 +7,13 @@ const logger = new Logger({ prefix: '[terra-functional-testing:webpack-server]' 
 
 class WebpackServer {
   constructor(options = {}) {
-    const { host, port } = options;
+    const { useHttps, host, port, gridUrl } = options;
 
+    const protocol = (useHttps === true) ? 'https' : 'http';
     this.config = WebpackServer.config(options);
     this.host = host || '0.0.0.0';
     this.port = port || '8080';
-    this.gridStatusUrl = options.gridUrl ? `http://${options.gridUrl}:80/status` : undefined;
+    this.gridStatusUrl = gridUrl ? `${protocol}://${gridUrl}:80/status` : undefined;
   }
 
   /**

--- a/packages/terra-functional-testing/tests/jest/terra-cli/wdio/__snapshots__/index.test.js.snap
+++ b/packages/terra-functional-testing/tests/jest/terra-cli/wdio/__snapshots__/index.test.js.snap
@@ -66,6 +66,9 @@ Options:
                                         all reference screenshots with the
                                         latest screenshots.
                                                       [boolean] [default: false]
+      --useHttps                        A flag to turn on secure HTTP for the
+                                        webpack server when a gridUrl is
+                                        provided.     [boolean] [default: false]
       --useRemoteReferenceScreenshots   A flag to download reference screenshots
                                         from a remote site for screenshot
                                         comparisons instead of using the local

--- a/packages/terra-functional-testing/tests/jest/webpack-server/webpack-server.test.js
+++ b/packages/terra-functional-testing/tests/jest/webpack-server/webpack-server.test.js
@@ -42,12 +42,13 @@ describe('Webpack Server', () => {
         port: 'mock',
         theme: 'mock',
         gridUrl: '1.1.1.1',
+        useHttps: true,
       });
 
       expect(server.config).toEqual('config');
       expect(server.host).toEqual('0.0.0.0');
       expect(server.port).toEqual('mock');
-      expect(server.gridStatusUrl).toEqual('http://1.1.1.1:80/status');
+      expect(server.gridStatusUrl).toEqual('https://1.1.1.1:80/status');
     });
   });
 

--- a/packages/terra-toolkit-docs/CHANGELOG.md
+++ b/packages/terra-toolkit-docs/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Added
-  * Added `useHttps` to use a secure http connection when the `gridUrl` flag is also provided.
+  * Added `useHttps` flag information to `terra-functional-testing` documentation.
 
 ## 2.13.0 - (April 27, 2023)
 

--- a/packages/terra-toolkit-docs/CHANGELOG.md
+++ b/packages/terra-toolkit-docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Added `useHttps` to use a secure http connection when the `gridUrl` flag is also provided.
+
 ## 2.13.0 - (April 27, 2023)
 
 * Changed

--- a/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/About.1.tool.mdx
+++ b/packages/terra-toolkit-docs/src/terra-dev-site/tool/terra-functional-testing/About.1.tool.mdx
@@ -54,6 +54,7 @@ package.json
 | --suite                          | array   |                                                  | Overrides specs and runs only the defined suites.                                                                                         |
 | --themes                         | array   | theme specified in terra-theme.config.js file    | A list of themes for the test run.                                                                                                        |
 | --updateScreenshots, -u          | boolean | false                                            | Updates all reference screenshots with the latest screenshots.                                                                            |
+| --useHttps                       | boolean | false                                            | A flag to turn on secure HTTP for the webpack server when a gridUrl is provided.                                                          |
 
 The following example will run the test suite a total of four times. Once for each permutation of the specified locales and form factors.
 


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**
A new flag for enabling an https connection when the `gridUrl` parameter is also provided.

**Why it was changed:**
This was added in response to needing to point to a orion-0 cluster, which all need an https connection. 


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [x] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

ION-47621 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
