### PR TITLE
[terra-functional-testing] Nexus screenshot download URL logic and fixes

### DIFF
--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Changed
+  * Updated logic in Nexus screenshots to still allow screenshot downloads when not authorized.
+  * Updated logic in Nexus screenshots to consume repository names more cleanly.
+
 ## 4.1.0 - (July 21, 2023)
 
 * Fixed

--- a/packages/terra-functional-testing/src/commands/utils/ScreenshotRequestor.js
+++ b/packages/terra-functional-testing/src/commands/utils/ScreenshotRequestor.js
@@ -117,15 +117,25 @@ class ScreenshotRequestor {
    * Downloads the screenshots and unzip it to the reference screenshot directory defined by referenceScreenshotsPath.
    */
   async downloadScreenshots() {
-    const archiveUrl = `${this.serviceUrl}/reference.zip`;
-    const response = await fetch(
-      archiveUrl,
-      {
+    var archiveUrl;
+    var fetchOptions;
+    if (this.serviceAuthHeader !== undefined) {
+      archiveUrl = `${this.serviceUrl}/reference.zip`;
+      fetchOptions = {
         method: 'GET',
         headers: {
           Authorization: this.serviceAuthHeader,
         },
-      },
+      };
+    } else {
+      archiveUrl = `${this.url}/reference.zip`;
+      fetchOptions = {
+        method: 'GET',
+      };
+    }
+    const response = await fetch(
+      archiveUrl,
+      fetchOptions,
     );
 
     if (response.status === 404) {

--- a/packages/terra-functional-testing/src/commands/utils/ScreenshotRequestor.js
+++ b/packages/terra-functional-testing/src/commands/utils/ScreenshotRequestor.js
@@ -117,8 +117,8 @@ class ScreenshotRequestor {
    * Downloads the screenshots and unzip it to the reference screenshot directory defined by referenceScreenshotsPath.
    */
   async downloadScreenshots() {
-    var archiveUrl;
-    var fetchOptions;
+    let archiveUrl;
+    let fetchOptions;
     if (this.serviceAuthHeader !== undefined) {
       archiveUrl = `${this.serviceUrl}/reference.zip`;
       fetchOptions = {

--- a/packages/terra-functional-testing/src/services/wdio-terra-service/WDIOTerraService.js
+++ b/packages/terra-functional-testing/src/services/wdio-terra-service/WDIOTerraService.js
@@ -49,7 +49,7 @@ class WDIOTerraService {
 
     return {
       owner: rOwner,
-      name: rName.split(".git")[0],
+      name: rName.split('.git')[0],
     };
   }
 

--- a/packages/terra-functional-testing/src/services/wdio-terra-service/WDIOTerraService.js
+++ b/packages/terra-functional-testing/src/services/wdio-terra-service/WDIOTerraService.js
@@ -49,7 +49,7 @@ class WDIOTerraService {
 
     return {
       owner: rOwner,
-      name: rName,
+      name: rName.split(".git")[0],
     };
   }
 

--- a/packages/terra-functional-testing/tests/jest/commands/utils/ScreenshotRequestor.test.js
+++ b/packages/terra-functional-testing/tests/jest/commands/utils/ScreenshotRequestor.test.js
@@ -13,9 +13,9 @@ jest.mock('@cerner/terra-cli/lib/utils/Logger', () => function mock() {
   };
 });
 
+const path = require('path');
 const extract = require('extract-zip');
 const fs = require('fs-extra');
-const path = require('path');
 const fetch = require('node-fetch');
 const archiver = require('archiver');
 const FormData = require('form-data');
@@ -157,19 +157,19 @@ describe('ScreenshotRequestor', () => {
         status: 200,
         body: {
           pipe: mockPipe,
-        }
+        },
       });
-      
+
       extract.mockResolvedValueOnce();
 
       const mockOnFinish = jest.fn();
       const mockWriteStream = {
-        on: mockOnFinish.mockImplementationOnce( (event, handler) => {
+        on: mockOnFinish.mockImplementationOnce((event, handler) => {
           handler();
         }),
       };
       fs.createWriteStream.mockReturnValueOnce(mockWriteStream);
-      
+
       const oldCheckStatus = ScreenshotRequestor.checkStatus;
       ScreenshotRequestor.checkStatus = jest.fn();
       const screenshotRequestor = new ScreenshotRequestor({
@@ -180,7 +180,6 @@ describe('ScreenshotRequestor', () => {
         url: 'https://nexus.com/blah/',
         zipFilePath: path.join(process.cwd(), 'zip-path'),
       });
-
 
       await expect(screenshotRequestor.downloadScreenshots()).resolves.toBe();
       expect(fetch).toHaveBeenCalledWith(
@@ -208,11 +207,11 @@ describe('ScreenshotRequestor', () => {
         status: 200,
       });
 
-      const mockThrowError = new TypeError("UNKNOWN ERROR");
-      fs.createWriteStream.mockImplementationOnce( () => {
+      const mockThrowError = new TypeError('UNKNOWN ERROR');
+      fs.createWriteStream.mockImplementationOnce(() => {
         throw mockThrowError;
       });
-      
+
       const oldCheckStatus = ScreenshotRequestor.checkStatus;
       ScreenshotRequestor.checkStatus = jest.fn();
       const screenshotRequestor = new ScreenshotRequestor({
@@ -246,7 +245,7 @@ describe('ScreenshotRequestor', () => {
         ok: true,
         status: 404,
       });
-      
+
       const screenshotRequestor = new ScreenshotRequestor({
         latestScreenshotsPath: path.join(process.cwd(), 'latest'),
         referenceScreenshotsPath: path.join(process.cwd(), 'reference'),
@@ -274,7 +273,7 @@ describe('ScreenshotRequestor', () => {
         ok: true,
         status: 404,
       });
-      
+
       const screenshotRequestor = new ScreenshotRequestor({
         latestScreenshotsPath: path.join(process.cwd(), 'latest'),
         referenceScreenshotsPath: path.join(process.cwd(), 'reference'),

--- a/packages/terra-functional-testing/tests/jest/commands/utils/ScreenshotRequestor.test.js
+++ b/packages/terra-functional-testing/tests/jest/commands/utils/ScreenshotRequestor.test.js
@@ -149,7 +149,7 @@ describe('ScreenshotRequestor', () => {
     });
   });
 
-  describe('downloadScreenshots', () => {
+  describe('function downloadScreenshots', () => {
     it('downloads the screenshots', async () => {
       const mockPipe = jest.fn();
       fetch.mockResolvedValueOnce({
@@ -162,18 +162,13 @@ describe('ScreenshotRequestor', () => {
       
       extract.mockResolvedValueOnce();
 
-      const mockCreateWriteStream = jest.fn();
-      const mockRemoveSync = jest.fn();
       const mockOnFinish = jest.fn();
       const mockWriteStream = {
-        on: mockOnFinish.mockImplementation( (event, handler) => {
+        on: mockOnFinish.mockImplementationOnce( (event, handler) => {
           handler();
         }),
       };
-      fs.removeSync = mockRemoveSync;
-      fs.createWriteStream = mockCreateWriteStream.mockImplementation( () => {
-        return mockWriteStream;
-      });
+      fs.createWriteStream.mockReturnValueOnce(mockWriteStream);
       
       const oldCheckStatus = ScreenshotRequestor.checkStatus;
       ScreenshotRequestor.checkStatus = jest.fn();
@@ -199,11 +194,11 @@ describe('ScreenshotRequestor', () => {
       );
       expect(ScreenshotRequestor.checkStatus).toHaveBeenCalled();
       ScreenshotRequestor.checkStatus = oldCheckStatus;
-      expect(mockCreateWriteStream).toHaveBeenCalledWith('terra-wdio-screenshots.zip');
+      expect(fs.createWriteStream).toHaveBeenCalledWith('terra-wdio-screenshots.zip');
       expect(mockPipe).toHaveBeenCalledWith(mockWriteStream);
       expect(mockOnFinish).toBeCalledWith('finish', expect.any(Function));
       expect(extract).toHaveBeenCalledWith('terra-wdio-screenshots.zip', { dir: screenshotRequestor.referenceScreenshotsPath });
-      expect(mockRemoveSync).toHaveBeenCalledWith('terra-wdio-screenshots.zip');
+      expect(fs.removeSync).toHaveBeenCalledWith('terra-wdio-screenshots.zip');
       expect(mockInfo).toHaveBeenCalledWith(`Screenshots downloaded from ${screenshotRequestor.url}`);
     });
 
@@ -213,11 +208,8 @@ describe('ScreenshotRequestor', () => {
         status: 200,
       });
 
-      const mockCreateWriteStream = jest.fn();
-      const mockRemoveSync = jest.fn();
       const mockThrowError = new TypeError("UNKNOWN ERROR");
-      fs.removeSync = mockRemoveSync;
-      fs.createWriteStream = mockCreateWriteStream.mockImplementation( () => {
+      fs.createWriteStream.mockImplementationOnce( () => {
         throw mockThrowError;
       });
       
@@ -244,8 +236,8 @@ describe('ScreenshotRequestor', () => {
       );
       expect(ScreenshotRequestor.checkStatus).toHaveBeenCalled();
       ScreenshotRequestor.checkStatus = oldCheckStatus;
-      expect(mockCreateWriteStream).toHaveBeenCalledWith('terra-wdio-screenshots.zip');
-      expect(mockRemoveSync).toHaveBeenCalledWith('terra-wdio-screenshots.zip');
+      expect(fs.createWriteStream).toHaveBeenCalledWith('terra-wdio-screenshots.zip');
+      expect(fs.removeSync).toHaveBeenCalledWith('terra-wdio-screenshots.zip');
       expect(mockError).toHaveBeenCalledWith(`Error occurred while extracting screenshots. ${mockThrowError}`);
     });
 

--- a/packages/terra-functional-testing/tests/jest/services/wdio-terra-service/WDIOTerraService.test.js
+++ b/packages/terra-functional-testing/tests/jest/services/wdio-terra-service/WDIOTerraService.test.js
@@ -13,7 +13,7 @@ const repoOwner = 'acme';
 const repoName = 'a-repo';
 fs.readJson.mockResolvedValue({
   repository: {
-    url: `git+https://github.com/${repoOwner}/${repoName}`,
+    url: `git+https://github.com/${repoOwner}/${repoName}.git`,
   },
 });
 


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->Adding in logic to download Nexus screenshots based on whether or not a credentials file is found. Also fixing issue with reading repo metadata for Nexus logic.

**What was changed:**
In the case that we have no credentials, we will download screenshots using the none credentials required URL. Otherwise we will download via the Service URL that requires credentials.
Splits `.git` of repo names for metadata object as well.

**Why it was changed:**
To allow tests to download screenshots without having to authenticate.


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [x] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-9299 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
