### PR TITLE
Whitespace in path prevents docker compose

### DIFF
--- a/packages/duplicate-package-checker-webpack-plugin/tests/jest/npm-2/index.test.js
+++ b/packages/duplicate-package-checker-webpack-plugin/tests/jest/npm-2/index.test.js
@@ -1,5 +1,5 @@
-const webpack = require('webpack');
 const assert = require('assert');
+const webpack = require('webpack');
 const chalk = require('chalk');
 const config = require('./webpack.config');
 

--- a/packages/duplicate-package-checker-webpack-plugin/tests/jest/simple/index.test.js
+++ b/packages/duplicate-package-checker-webpack-plugin/tests/jest/simple/index.test.js
@@ -2,8 +2,8 @@
  * @jest-environment node
  */
 
-const webpack = require('webpack');
 const assert = require('assert');
+const webpack = require('webpack');
 const chalk = require('chalk');
 const MakeConfig = require('./make.webpack.config');
 

--- a/packages/duplicate-package-checker-webpack-plugin/tests/jest/strict/index.test.js
+++ b/packages/duplicate-package-checker-webpack-plugin/tests/jest/strict/index.test.js
@@ -1,5 +1,5 @@
-const webpack = require('webpack');
 const assert = require('assert');
+const webpack = require('webpack');
 const chalk = require('chalk');
 const MakeConfig = require('./make.webpack.config');
 

--- a/packages/jest-config-terra/src/reporters/verbose-reporter/TerraVerboseReporter.js
+++ b/packages/jest-config-terra/src/reporters/verbose-reporter/TerraVerboseReporter.js
@@ -1,8 +1,8 @@
-const VerboseReporter = require('@jest/reporters/build/verbose_reporter').default;
-const stripAnsi = require('strip-ansi');
+const endOfLine = require('os').EOL;
 const fs = require('fs');
 const path = require('path');
-const endOfLine = require('os').EOL;
+const VerboseReporter = require('@jest/reporters/build/verbose_reporter').default;
+const stripAnsi = require('strip-ansi');
 const { Logger } = require('@cerner/terra-cli');
 
 const logger = new Logger({ prefix: '[jest-config-terra:TerraVerboseReporter]' });
@@ -27,8 +27,8 @@ class TerraVerboseReporter extends VerboseReporter {
     this.ensureResultsDir();
 
     // Disable _out and _err so that we don't write out anything as part of this reporter
-    this._out = () => {}; // eslint-disable-line no-underscore-dangle
-    this._err = () => {}; // eslint-disable-line no-underscore-dangle
+    this._out = () => { }; // eslint-disable-line no-underscore-dangle
+    this._err = () => { }; // eslint-disable-line no-underscore-dangle
   }
 
   // eslint-disable-next-line class-methods-use-this

--- a/packages/package-json-lint/src/config/index.js
+++ b/packages/package-json-lint/src/config/index.js
@@ -1,5 +1,5 @@
-const { cosmiconfig } = require('cosmiconfig');
 const path = require('path');
+const { cosmiconfig } = require('cosmiconfig');
 const { Logger } = require('@cerner/terra-cli');
 
 const logger = new Logger({ prefix: '[package-json-lint:config]' });

--- a/packages/package-json-lint/src/project-structure/index.js
+++ b/packages/package-json-lint/src/project-structure/index.js
@@ -1,5 +1,5 @@
-const fs = require('fs-extra');
 const path = require('path');
+const fs = require('fs-extra');
 const ignore = require('ignore');
 const spawn = require('@npmcli/promise-spawn');
 

--- a/packages/package-json-lint/tests/jest/config/index.test.js
+++ b/packages/package-json-lint/tests/jest/config/index.test.js
@@ -1,7 +1,7 @@
 jest.mock('cosmiconfig');
 
-const { cosmiconfig } = require('cosmiconfig');
 const path = require('path');
+const { cosmiconfig } = require('cosmiconfig');
 
 const { getConfigForFile } = require('../../../src/config');
 

--- a/packages/package-json-lint/tests/jest/project-structure/index.test.js
+++ b/packages/package-json-lint/tests/jest/project-structure/index.test.js
@@ -1,9 +1,9 @@
 jest.mock('fs-extra');
 jest.mock('@npmcli/promise-spawn');
 
+const path = require('path');
 const fs = require('fs-extra');
 const spawn = require('@npmcli/promise-spawn');
-const path = require('path');
 
 const { getPathsForPackages } = require('../../../src/project-structure');
 

--- a/packages/stylelint-config-terra/tests/jest/custom-property-name/custom-property-name.test.js
+++ b/packages/stylelint-config-terra/tests/jest/custom-property-name/custom-property-name.test.js
@@ -1,8 +1,8 @@
 /**
  * @jest-environment node
  */
-const stylelint = require('stylelint');
 const path = require('path');
+const stylelint = require('stylelint');
 
 const config = {
   plugins: [

--- a/packages/stylelint-config-terra/tests/jest/custom-property-namespace/custom-property-namespace.test.js
+++ b/packages/stylelint-config-terra/tests/jest/custom-property-namespace/custom-property-namespace.test.js
@@ -1,8 +1,8 @@
 /**
  * @jest-environment node
  */
-const stylelint = require('stylelint');
 const path = require('path');
+const stylelint = require('stylelint');
 
 const config = {
   plugins: [

--- a/packages/stylelint-config-terra/tests/jest/custom-property-no-duplicate-declaration/custom-property-no-duplicate-declaration.test.js
+++ b/packages/stylelint-config-terra/tests/jest/custom-property-no-duplicate-declaration/custom-property-no-duplicate-declaration.test.js
@@ -1,8 +1,8 @@
 /**
  * @jest-environment node
  */
-const stylelint = require('stylelint');
 const path = require('path');
+const stylelint = require('stylelint');
 
 const config = {
   plugins: [

--- a/packages/stylelint-config-terra/tests/jest/custom-property-pattern/custom-property-pattern.test.js
+++ b/packages/stylelint-config-terra/tests/jest/custom-property-pattern/custom-property-pattern.test.js
@@ -1,8 +1,8 @@
 /**
  * @jest-environment node
  */
-const stylelint = require('stylelint');
 const path = require('path');
+const stylelint = require('stylelint');
 
 const config = {
   plugins: [

--- a/packages/stylelint-config-terra/tests/jest/custom-property-pseudo-selectors/custom-properety-pseudo-selectors.test.js
+++ b/packages/stylelint-config-terra/tests/jest/custom-property-pseudo-selectors/custom-properety-pseudo-selectors.test.js
@@ -1,8 +1,8 @@
 /**
  * @jest-environment node
  */
-const stylelint = require('stylelint');
 const path = require('path');
+const stylelint = require('stylelint');
 
 const config = {
   plugins: [

--- a/packages/terra-aggregate-translations/tests/jest/aggregate-translations-react-intl-v5.test.js
+++ b/packages/terra-aggregate-translations/tests/jest/aggregate-translations-react-intl-v5.test.js
@@ -1,7 +1,7 @@
 /* globals spyOn */
+const path = require('path');
 const fse = require('fs-extra');
 const glob = require('glob');
-const path = require('path');
 const i18nSupportedLocales = require('../../src/config/i18nSupportedLocales');
 const aggregateTranslations = require('../../src/aggregate-translations');
 

--- a/packages/terra-aggregate-translations/tests/jest/aggregate-translations.test.js
+++ b/packages/terra-aggregate-translations/tests/jest/aggregate-translations.test.js
@@ -1,7 +1,7 @@
 /* globals spyOn */
+const path = require('path');
 const fse = require('fs-extra');
 const glob = require('glob');
-const path = require('path');
 // eslint-disable-next-line import/no-extraneous-dependencies
 const MemoryFileSystem = require('memory-fs');
 const defaultSearchPatterns = require('../../src/config/defaultSearchPatterns');

--- a/packages/terra-aggregate-translations/tests/jest/write-aggregated-translations.test.js
+++ b/packages/terra-aggregate-translations/tests/jest/write-aggregated-translations.test.js
@@ -1,6 +1,6 @@
 /* globals spyOn */
-const fse = require('fs-extra');
 const path = require('path');
+const fse = require('fs-extra');
 // eslint-disable-next-line import/no-extraneous-dependencies
 const MemoryFileSystem = require('memory-fs');
 const writeAggregatedTranslations = require('../../src/write-aggregated-translations');

--- a/packages/terra-aggregate-translations/tests/jest/write-i18n-loaders.test.js
+++ b/packages/terra-aggregate-translations/tests/jest/write-i18n-loaders.test.js
@@ -1,6 +1,6 @@
 /* globals spyOn */
-const fse = require('fs-extra');
 const path = require('path');
+const fse = require('fs-extra');
 // eslint-disable-next-line import/no-extraneous-dependencies
 const MemoryFileSystem = require('memory-fs');
 const writeI18nLoaders = require('../../src/write-i18n-loaders');

--- a/packages/terra-cli/index.js
+++ b/packages/terra-cli/index.js
@@ -1,5 +1,5 @@
-const yargs = require('yargs/yargs');
 const path = require('path');
+const yargs = require('yargs/yargs');
 const fs = require('fs-extra');
 
 const Logger = require('./lib/utils/Logger');

--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Fixed
-  * Fixed when a pathname with whitespaces was passed in would prevent a docker compose.
+  * Fixed an issue with whitespaces in the docker-compose file path causing failures.
 
 ## 4.1.0 - (July 21, 2023)
 

--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Fixed when a pathname with whitespaces was passed in would prevent a docker compose.
+
 ## 4.1.0 - (July 21, 2023)
 
 * Fixed

--- a/packages/terra-functional-testing/src/commands/utils/ScreenshotRequestor.js
+++ b/packages/terra-functional-testing/src/commands/utils/ScreenshotRequestor.js
@@ -1,8 +1,8 @@
+const path = require('path');
 const archiver = require('archiver');
 const extract = require('extract-zip');
 const fetch = require('node-fetch');
 const fs = require('fs-extra');
-const path = require('path');
 const FormData = require('form-data');
 const { Logger } = require('@cerner/terra-cli');
 const MemoryStream = require('./MemoryStream');

--- a/packages/terra-functional-testing/src/commands/utils/cleanScreenshots.js
+++ b/packages/terra-functional-testing/src/commands/utils/cleanScreenshots.js
@@ -1,6 +1,6 @@
+const path = require('path');
 const fs = require('fs-extra');
 const glob = require('glob');
-const path = require('path');
 const { Logger } = require('@cerner/terra-cli');
 
 const logger = new Logger({ prefix: '[terra-functional-testing:cleanScreenshots]' });

--- a/packages/terra-functional-testing/src/config/utils/getIpAddress.js
+++ b/packages/terra-functional-testing/src/config/utils/getIpAddress.js
@@ -1,5 +1,5 @@
-const ip = require('ip');
 const os = require('os');
+const ip = require('ip');
 
 module.exports = () => {
   const utun = Object.entries(os.networkInterfaces()).filter(([key]) => key.includes(('utun'))).flat();

--- a/packages/terra-functional-testing/src/reporters/file-output-reporter/index.js
+++ b/packages/terra-functional-testing/src/reporters/file-output-reporter/index.js
@@ -1,8 +1,8 @@
-const fs = require('fs-extra');
+const endOfLine = require('os').EOL;
 const path = require('path');
+const fs = require('fs-extra');
 const stripAnsi = require('strip-ansi');
 const SpecReporter = require('@wdio/spec-reporter').default;
-const endOfLine = require('os').EOL;
 const { Logger } = require('@cerner/terra-cli');
 
 const LOG_CONTEXT = '[terra-functional-testing:file-output-reporter]';

--- a/packages/terra-functional-testing/src/reporters/spec-reporter/wdio-spec-reporter.js
+++ b/packages/terra-functional-testing/src/reporters/spec-reporter/wdio-spec-reporter.js
@@ -1,5 +1,5 @@
-const fs = require('fs-extra');
 const path = require('path');
+const fs = require('fs-extra');
 const WDIOReporter = require('@wdio/reporter').default;
 const getOutputDir = require('./get-output-dir');
 const { eventEmitter } = require('../../commands/utils');

--- a/packages/terra-functional-testing/src/services/wdio-selenium-docker-service.js
+++ b/packages/terra-functional-testing/src/services/wdio-selenium-docker-service.js
@@ -91,7 +91,7 @@ class SeleniumDockerService {
 
     const envVars = this.seleniumVersion ? `TERRA_SELENIUM_DOCKER_VERSION=${this.seleniumVersion} ` : '';
 
-    await exec(`${envVars}docker-compose -f ${this.getDockerComposeFilePath()} up -d`);
+    await exec(`${envVars}docker-compose -f "${this.getDockerComposeFilePath()}" up -d`);
     await this.waitForSeleniumHubReady();
 
     logger.info('Successfully started the docker selenium hub.');
@@ -126,7 +126,7 @@ class SeleniumDockerService {
     if (!this.keepAliveSeleniumDockerService && !this.disableSeleniumService) {
       logger.info('Shutting down the docker selenium hub...');
 
-      await exec(`docker-compose -f ${this.getDockerComposeFilePath()} down`);
+      await exec(`docker-compose -f "${this.getDockerComposeFilePath()}" down`);
     }
   }
 }

--- a/packages/terra-functional-testing/src/services/wdio-terra-service/WDIOTerraService.js
+++ b/packages/terra-functional-testing/src/services/wdio-terra-service/WDIOTerraService.js
@@ -1,6 +1,6 @@
+const path = require('path');
 const expect = require('expect');
 const fs = require('fs-extra');
-const path = require('path');
 const { SevereServiceError } = require('webdriverio');
 const { accessibility, element, screenshot } = require('../../commands/validates');
 const { toBeAccessible, toMatchReference } = require('../../commands/expect');

--- a/packages/terra-functional-testing/src/services/wdio-visual-regression-service/modules/makeAreaScreenshot.js
+++ b/packages/terra-functional-testing/src/services/wdio-visual-regression-service/modules/makeAreaScreenshot.js
@@ -1,5 +1,5 @@
-const fsExtra = require('fs-extra');
 const path = require('path');
+const fsExtra = require('fs-extra');
 const { v4: uuidv4 } = require('uuid');
 const { Logger } = require('@cerner/terra-cli');
 

--- a/packages/terra-functional-testing/src/services/wdio-visual-regression-service/utils/image/gm.js
+++ b/packages/terra-functional-testing/src/services/wdio-visual-regression-service/utils/image/gm.js
@@ -1,6 +1,6 @@
+const path = require('path');
 const gm = require('gm');
 const fsExtra = require('fs-extra');
-const path = require('path');
 const { v4: uuidv4 } = require('uuid');
 const CropDimension = require('../CropDimension');
 

--- a/packages/terra-functional-testing/src/webpack-server/webpack-server.js
+++ b/packages/terra-functional-testing/src/webpack-server/webpack-server.js
@@ -1,7 +1,7 @@
+const http = require('http');
 const WebpackDevServer = require('webpack-dev-server');
 const webpack = require('webpack');
 const { Logger } = require('@cerner/terra-cli');
-const http = require('http');
 
 const logger = new Logger({ prefix: '[terra-functional-testing:webpack-server]' });
 

--- a/packages/terra-functional-testing/tests/jest/commands/utils/ScreenshotRequestor.test.js
+++ b/packages/terra-functional-testing/tests/jest/commands/utils/ScreenshotRequestor.test.js
@@ -9,8 +9,8 @@ jest.mock('@cerner/terra-cli/lib/utils/Logger', () => function mock() {
   };
 });
 
-const fetch = require('node-fetch');
 const path = require('path');
+const fetch = require('node-fetch');
 const archiver = require('archiver');
 const FormData = require('form-data');
 const MemoryStream = require('../../../../src/commands/utils/MemoryStream');

--- a/packages/terra-functional-testing/tests/jest/commands/utils/cleanScreenshots.test.js
+++ b/packages/terra-functional-testing/tests/jest/commands/utils/cleanScreenshots.test.js
@@ -1,6 +1,6 @@
+const path = require('path');
 const fs = require('fs-extra');
 const glob = require('glob');
-const path = require('path');
 const { cleanScreenshots } = require('../../../../src/commands/utils');
 
 jest.mock('@cerner/terra-cli/lib/utils/Logger');

--- a/packages/terra-functional-testing/tests/jest/reporters/spec-reporter/wdio-spec-reporter.test.js
+++ b/packages/terra-functional-testing/tests/jest/reporters/spec-reporter/wdio-spec-reporter.test.js
@@ -1,5 +1,5 @@
-const fs = require('fs-extra');
 const path = require('path');
+const fs = require('fs-extra');
 const SpecReporter = require('../../../../src/reporters/spec-reporter/wdio-spec-reporter');
 const testData1 = require('../../../fixtures/reporters/test-data-1.json');
 const { eventEmitter } = require('../../../../src/commands/utils');

--- a/packages/terra-functional-testing/tests/jest/services/wdio-selenium-docker-service.test.js
+++ b/packages/terra-functional-testing/tests/jest/services/wdio-selenium-docker-service.test.js
@@ -143,7 +143,7 @@ describe('WDIO Selenium Docker Service', () => {
 
       service.startSeleniumHub();
 
-      expect(mockExec).toHaveBeenCalledWith('docker-compose -f mock-compose-path up -d');
+      expect(mockExec).toHaveBeenCalledWith('docker-compose -f \"mock-compose-path\" up -d');
     });
 
     it('should start the selenium hub with the specified version', () => {
@@ -154,7 +154,7 @@ describe('WDIO Selenium Docker Service', () => {
 
       service.startSeleniumHub();
 
-      expect(mockExec).toHaveBeenCalledWith('TERRA_SELENIUM_DOCKER_VERSION=1234 docker-compose -f mock-compose-path up -d');
+      expect(mockExec).toHaveBeenCalledWith('TERRA_SELENIUM_DOCKER_VERSION=1234 docker-compose -f \"mock-compose-path\" up -d');
     });
   });
 
@@ -225,7 +225,7 @@ describe('WDIO Selenium Docker Service', () => {
 
       await service.onComplete();
 
-      expect(mockExec).toHaveBeenCalledWith('docker-compose -f mock-compose-path down');
+      expect(mockExec).toHaveBeenCalledWith('docker-compose -f \"mock-compose-path\" down');
     });
   });
 });

--- a/packages/terra-functional-testing/tests/jest/services/wdio-selenium-docker-service.test.js
+++ b/packages/terra-functional-testing/tests/jest/services/wdio-selenium-docker-service.test.js
@@ -143,7 +143,7 @@ describe('WDIO Selenium Docker Service', () => {
 
       service.startSeleniumHub();
 
-      expect(mockExec).toHaveBeenCalledWith('docker-compose -f \"mock-compose-path\" up -d');
+      expect(mockExec).toHaveBeenCalledWith('docker-compose -f "mock-compose-path" up -d');
     });
 
     it('should start the selenium hub with the specified version', () => {
@@ -154,7 +154,7 @@ describe('WDIO Selenium Docker Service', () => {
 
       service.startSeleniumHub();
 
-      expect(mockExec).toHaveBeenCalledWith('TERRA_SELENIUM_DOCKER_VERSION=1234 docker-compose -f \"mock-compose-path\" up -d');
+      expect(mockExec).toHaveBeenCalledWith('TERRA_SELENIUM_DOCKER_VERSION=1234 docker-compose -f "mock-compose-path" up -d');
     });
   });
 
@@ -225,7 +225,7 @@ describe('WDIO Selenium Docker Service', () => {
 
       await service.onComplete();
 
-      expect(mockExec).toHaveBeenCalledWith('docker-compose -f \"mock-compose-path\" down');
+      expect(mockExec).toHaveBeenCalledWith('docker-compose -f "mock-compose-path" down');
     });
   });
 });

--- a/packages/terra-functional-testing/tests/jest/webpack-server/webpack-server.test.js
+++ b/packages/terra-functional-testing/tests/jest/webpack-server/webpack-server.test.js
@@ -1,14 +1,13 @@
+const http = require('http');
+const path = require('path');
+const WebpackDevServer = require('webpack-dev-server');
+const webpack = require('webpack');
 const { Logger } = require('@cerner/terra-cli');
+const WebpackServer = require('../../../src/webpack-server/webpack-server');
 
 jest.mock('webpack');
 jest.mock('@cerner/terra-cli');
 jest.mock('webpack-dev-server');
-
-const http = require('http');
-const WebpackDevServer = require('webpack-dev-server');
-const webpack = require('webpack');
-const path = require('path');
-const WebpackServer = require('../../../src/webpack-server/webpack-server');
 
 const mockLoggerInstance = Logger.mock.instances[0];
 const mockWebpackSpy = jest.fn();
@@ -135,7 +134,7 @@ describe('Webpack Server', () => {
             }),
           },
           failed: {
-            tap: () => {},
+            tap: () => { },
           },
         },
         options: {
@@ -164,7 +163,7 @@ describe('Webpack Server', () => {
             }),
           },
           failed: {
-            tap: () => {},
+            tap: () => { },
           },
         },
         options: {
@@ -184,10 +183,10 @@ describe('Webpack Server', () => {
         watch: jest.fn(),
         hooks: {
           done: {
-            tap: () => {},
+            tap: () => { },
           },
           failed: {
-            tap: () => {},
+            tap: () => { },
           },
         },
         options: {
@@ -236,7 +235,7 @@ describe('Webpack Server', () => {
             }),
           },
           failed: {
-            tap: () => {},
+            tap: () => { },
           },
         },
         options: {
@@ -276,7 +275,7 @@ describe('Webpack Server', () => {
             }),
           },
           failed: {
-            tap: () => {},
+            tap: () => { },
           },
         },
         options: {
@@ -306,7 +305,7 @@ describe('Webpack Server', () => {
             tap: jest.fn((arg1, callback) => callback(mockStats)),
           },
           failed: {
-            tap: () => {},
+            tap: () => { },
           },
         },
         options: {
@@ -338,7 +337,7 @@ describe('Webpack Server', () => {
             }),
           },
           failed: {
-            tap: () => {},
+            tap: () => { },
           },
         },
         options: {

--- a/packages/terra-functional-testing/tests/mocha/services/wdio-visual-regression-service/unit/utils/normalizeScreenshot.test.js
+++ b/packages/terra-functional-testing/tests/mocha/services/wdio-visual-regression-service/unit/utils/normalizeScreenshot.test.js
@@ -1,6 +1,6 @@
+const path = require('path');
 const { assert } = require('chai');
 const glob = require('glob');
-const path = require('path');
 const lodashGroupBy = require('lodash.groupby');
 const lodashMap = require('lodash.map');
 const lodashMapKeys = require('lodash.mapkeys');

--- a/packages/terra-functional-testing/tests/mocha/services/wdio-visual-regression-service/unit/utils/saveBase64Image.test.js
+++ b/packages/terra-functional-testing/tests/mocha/services/wdio-visual-regression-service/unit/utils/saveBase64Image.test.js
@@ -1,8 +1,8 @@
+import path from 'path';
 import { assert } from 'chai';
 
 import sizeOf from 'image-size';
 import fsExtra from 'fs-extra';
-import path from 'path';
 
 import saveBase64Image from '../../../../../../src/services/wdio-visual-regression-service/utils/saveBase64Image';
 

--- a/packages/terra-open-source-scripts/src/terra-cli/prepare-for-release/prepareForReleaseMonoRepoHandler.js
+++ b/packages/terra-open-source-scripts/src/terra-cli/prepare-for-release/prepareForReleaseMonoRepoHandler.js
@@ -1,6 +1,6 @@
 const childProcess = require('child_process');
-const fs = require('fs-extra');
 const path = require('path');
+const fs = require('fs-extra');
 const stripAnsi = require('strip-ansi');
 const { Logger } = require('@cerner/terra-cli');
 

--- a/packages/terra-open-source-scripts/src/terra-cli/prepare-for-release/prepareForReleaseRepoHandler.js
+++ b/packages/terra-open-source-scripts/src/terra-cli/prepare-for-release/prepareForReleaseRepoHandler.js
@@ -1,6 +1,6 @@
+const path = require('path');
 const prompts = require('prompts');
 const fs = require('fs-extra');
-const path = require('path');
 const log = require('npmlog');
 const spawn = require('@npmcli/promise-spawn');
 const updateChangelogForPackage = require('./updateChangelogForPackage');

--- a/packages/terra-open-source-scripts/src/terra-cli/prepare-for-release/updateChangelogForPackage.js
+++ b/packages/terra-open-source-scripts/src/terra-cli/prepare-for-release/updateChangelogForPackage.js
@@ -1,5 +1,5 @@
-const fs = require('fs-extra');
 const path = require('path');
+const fs = require('fs-extra');
 
 module.exports = async (packagePath) => {
   const packageFile = path.resolve(packagePath, 'package.json');

--- a/packages/terra-open-source-scripts/src/terra-cli/release/releaseRepoHandler.js
+++ b/packages/terra-open-source-scripts/src/terra-cli/release/releaseRepoHandler.js
@@ -1,5 +1,5 @@
-const pacote = require('pacote');
 const path = require('path');
+const pacote = require('pacote');
 const fs = require('fs-extra');
 const spawn = require('@npmcli/promise-spawn');
 const { Logger } = require('@cerner/terra-cli');

--- a/packages/terra-open-source-scripts/src/utils/isMonoRepo.js
+++ b/packages/terra-open-source-scripts/src/utils/isMonoRepo.js
@@ -1,5 +1,5 @@
-const fs = require('fs-extra');
 const path = require('path');
+const fs = require('fs-extra');
 
 // Check if lerna.json is present to determine if we're in a monorepo.
 const isMonoRepo = async () => fs.pathExists(path.join(process.cwd(), 'lerna.json'));

--- a/packages/terra-open-source-scripts/tests/jest/terra-cli/prepare-for-release/prepareForReleaseMonoRepoHandler.test.js
+++ b/packages/terra-open-source-scripts/tests/jest/terra-cli/prepare-for-release/prepareForReleaseMonoRepoHandler.test.js
@@ -5,8 +5,8 @@ jest.mock('../../../../src/terra-cli/prepare-for-release/updateChangelogForPacka
 jest.mock('../../../../src/terra-cli/prepare-for-release/logReleasingPackages');
 
 const childProcess = require('child_process');
-const fs = require('fs-extra');
 const path = require('path');
+const fs = require('fs-extra');
 
 const updateChangelogForPackage = require('../../../../src/terra-cli/prepare-for-release/updateChangelogForPackage');
 const logReleasingPackages = require('../../../../src/terra-cli/prepare-for-release/logReleasingPackages');

--- a/packages/terra-open-source-scripts/tests/jest/terra-cli/prepare-for-release/prepareForReleaseRepoHandler.test.js
+++ b/packages/terra-open-source-scripts/tests/jest/terra-cli/prepare-for-release/prepareForReleaseRepoHandler.test.js
@@ -6,8 +6,8 @@ jest.mock('@npmcli/promise-spawn');
 jest.mock('../../../../src/terra-cli/prepare-for-release/updateChangelogForPackage');
 jest.mock('../../../../src/terra-cli/prepare-for-release/logReleasingPackages');
 
-const prompts = require('prompts');
 const path = require('path');
+const prompts = require('prompts');
 const log = require('npmlog');
 const fs = require('fs-extra');
 const spawn = require('@npmcli/promise-spawn');

--- a/packages/terra-open-source-scripts/tests/jest/terra-cli/release/releaseRepoHandler.test.js
+++ b/packages/terra-open-source-scripts/tests/jest/terra-cli/release/releaseRepoHandler.test.js
@@ -4,9 +4,9 @@ jest.mock('pacote');
 jest.mock('../../../../src/terra-cli/release/setupNPM');
 jest.mock('../../../../src/terra-cli/release/setupGit');
 
+const path = require('path');
 const spawn = require('@npmcli/promise-spawn');
 const pacote = require('pacote');
-const path = require('path');
 const fs = require('fs-extra');
 
 const setupNPM = require('../../../../src/terra-cli/release/setupNPM');

--- a/packages/terra-open-source-scripts/tests/jest/terra-cli/release/setupNPM.test.js
+++ b/packages/terra-open-source-scripts/tests/jest/terra-cli/release/setupNPM.test.js
@@ -1,7 +1,7 @@
 jest.mock('fs-extra');
 
-const fs = require('fs-extra');
 const path = require('path');
+const fs = require('fs-extra');
 const setupNPM = require('../../../../src/terra-cli/release/setupNPM');
 
 describe('setupNPM', () => {

--- a/packages/terra-open-source-scripts/tests/jest/utils/isMonoRepo.test.js
+++ b/packages/terra-open-source-scripts/tests/jest/utils/isMonoRepo.test.js
@@ -1,7 +1,7 @@
 jest.mock('fs-extra');
 
-const fs = require('fs-extra');
 const path = require('path');
+const fs = require('fs-extra');
 const isMonoRepo = require('../../../src/utils/isMonoRepo');
 
 describe('isMonoRepo', () => {

--- a/packages/webpack-config-terra/src/aggregate-themes/getThemeWebpackPromise.js
+++ b/packages/webpack-config-terra/src/aggregate-themes/getThemeWebpackPromise.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const webpack = require('webpack');
 const MemoryFS = require('memory-fs');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
@@ -5,7 +6,6 @@ const rtl = require('@mjhenkes/postcss-rtl');
 const Autoprefixer = require('autoprefixer');
 const PostCSSAssetsPlugin = require('postcss-assets-webpack-plugin');
 const PostCSSCustomProperties = require('postcss-custom-properties');
-const path = require('path');
 const logging = require('webpack/lib/logging/runtime');
 const ThemePlugin = require('../postcss/ThemePlugin');
 

--- a/packages/webpack-config-terra/src/aggregate-themes/theme-aggregator.js
+++ b/packages/webpack-config-terra/src/aggregate-themes/theme-aggregator.js
@@ -1,6 +1,6 @@
+const path = require('path');
 const fs = require('fs-extra');
 const glob = require('glob');
-const path = require('path');
 const logging = require('webpack/lib/logging/runtime');
 
 const CONFIG = 'terra-theme.config.js';

--- a/packages/webpack-config-terra/src/webpack.config.js
+++ b/packages/webpack-config-terra/src/webpack.config.js
@@ -1,7 +1,7 @@
+const path = require('path');
 const Autoprefixer = require('autoprefixer');
 const PostCSSAssetsPlugin = require('postcss-assets-webpack-plugin');
 const PostCSSCustomProperties = require('postcss-custom-properties');
-const path = require('path');
 const rtl = require('@mjhenkes/postcss-rtl');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**

Added quotations around the pathname to treat the whole path like one string in `packages/terra-functional-testing/src/services/wdio-selenium-docker-service.js`

A bunch of eslint fixes too.

**Why it was changed:**

When running wdio tests, if the pathname to the target directory includes a whitespace, e.g. `.../Whitespace Folder/terra-framework/`, it would error at the docker compose step.

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [x] WDIO
- [x] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-XXXX <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
