### PR TITLE
[eslint-config-terra] Update dependencies

### DIFF
--- a/packages/eslint-config-terra/CHANGELOG.md
+++ b/packages/eslint-config-terra/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+ * Fixed
+  * Moved `eslint` from dependencies to the correct peerDependencies section to fix npm 6 install errors. 
+
 ## 5.5.0 - (August 24, 2023)
 
 * Changed

--- a/packages/eslint-config-terra/package.json
+++ b/packages/eslint-config-terra/package.json
@@ -35,7 +35,6 @@
   },
   "dependencies": {
     "@babel/eslint-parser": "^7.12.13",
-    "eslint": "^7.32.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-plugin-compat": "^3.9.0",
     "eslint-plugin-formatjs": "^2.17.8",
@@ -43,5 +42,8 @@
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "7.22.0",
     "eslint-plugin-react-hooks": "^4.2.0"
+  },
+  "peerDependencies": {
+    "eslint": "^7.32.0"
   }
 }


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

This PR moves the `eslint` to peerDependencies. It was accidentally moved to dependencies as part of #811 . This unintended change resulted in webpack failures with NPM 6 as the dependencies weren't getting installed correctly. NPM 9 was not affected due to how it handles dependencies differently.

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [x] Other (please describe below)
- [ ] No tests are needed

This change was tested by setting the dev environment to NPM 6 and running `npm run clean:install && npm start` on terra-framework locally. This resulted in the following failure:

<kbd>
  <img src="https://github.com/cerner/terra-toolkit/assets/38024451/704d91d5-12a7-4faa-916c-3d173900f0d7">
</kbd>  

### 

This was again tested by running `npm pack` and using the local `eslint-config-terra` with `npm install -D path/to/tgz` which resulted in the same error.

The error was fixed by moving `eslint` to peerDepndencies and then repeating the steps above to test the change locally. The result was `npm start` successfully executing:

<kbd>
  <img src="https://github.com/cerner/terra-toolkit/assets/38024451/de3458c2-5e3d-48ab-be55-95a1ed14686c">
</kbd>


### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review
- [x] Tech verification

---

Thank you for contributing to Terra.
@cerner/terra
