### PR TITLE
[stylelint-config-terra][browserlist-config-terra] Update stylelint to v15 and remove IE 10 rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,8 +141,5 @@
     "webpack": "^5.28.0",
     "webpack-cli": "^4.6.0",
     "webpack-dev-server": "^4.7.2"
-  },
-  "peerDependencies": {
-    "rimraf": "^4.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -135,11 +135,14 @@
     "react": "^16.8.5",
     "react-dom": "^16.8.5",
     "react-intl": "^2.9.0",
-    "stylelint": "^13.0.0",
+    "stylelint": "^15.2.0",
     "terra-application": "^1.54.1",
     "utf-8-validate": "^5.0.2",
     "webpack": "^5.28.0",
     "webpack-cli": "^4.6.0",
     "webpack-dev-server": "^4.7.2"
+  },
+  "peerDependencies": {
+    "rimraf": "^4.4.1"
   }
 }

--- a/packages/browserslist-config-terra/CHANGELOG.md
+++ b/packages/browserslist-config-terra/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Breaking Change
+  * Dropped support for IE10.
+
 ## 3.4.0 - (August 31, 2023)
 
 * Changed

--- a/packages/browserslist-config-terra/browserslist.config.js
+++ b/packages/browserslist-config-terra/browserslist.config.js
@@ -1,10 +1,10 @@
 module.exports = [
+  'ie >= 11',
   'iOS >= 12',
   'last 2 and_chr versions',
   'last 2 android versions',
   'last 2 chrome versions',
   'last 2 edge versions',
   'last 2 firefox versions',
-  'last 2 ie versions',
   'last 2 safari versions',
 ];

--- a/packages/stylelint-config-terra/CHANGELOG.md
+++ b/packages/stylelint-config-terra/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Breaking Change
+  * Upgraded Stylelint from 13 to 15.
+
 ## 4.6.0 - (September 26, 2023)
 
 * Changed

--- a/packages/stylelint-config-terra/package.json
+++ b/packages/stylelint-config-terra/package.json
@@ -49,7 +49,6 @@
     "postcss-scss": "^4.0.6",
     "postcss-value-parser": "^4.0.0",
     "stylelint-config-sass-guidelines": "10.0.0",
-    "stylelint-config-standard-scss": "^11.0.0",
     "stylelint-no-unsupported-browser-features": "^4.1.0",
     "stylelint-order": "^4.1.0",
     "stylelint-scss": "^3.11.0"

--- a/packages/stylelint-config-terra/package.json
+++ b/packages/stylelint-config-terra/package.json
@@ -11,6 +11,14 @@
   "publishConfig": {
     "access": "public"
   },
+  "files": [
+    "CHANGELOG.md",
+    "README.md",
+    "LICENSE",
+    "NOTICE",
+    "lib",
+    "stylelint.config.js"
+  ],
   "keywords": [
     "stylelint",
     "stylelint-config",

--- a/packages/stylelint-config-terra/package.json
+++ b/packages/stylelint-config-terra/package.json
@@ -44,9 +44,12 @@
     "test": "npm run jest"
   },
   "dependencies": {
+    "@cerner/browserslist-config-terra": "3.2.0",
     "find-up": "^4.0.0",
+    "postcss-scss": "^4.0.6",
     "postcss-value-parser": "^4.0.0",
-    "stylelint-config-sass-guidelines": "^7.1.0",
+    "stylelint-config-sass-guidelines": "10.0.0",
+    "stylelint-config-standard-scss": "^11.0.0",
     "stylelint-no-unsupported-browser-features": "^4.1.0",
     "stylelint-order": "^4.1.0",
     "stylelint-scss": "^3.11.0"
@@ -59,6 +62,7 @@
     "eslint": "^7.32.0"
   },
   "peerDependencies": {
-    "stylelint": "^13.0.0"
+    "postscss": "8.3.11",
+    "stylelint": "^15.2.0"
   }
 }

--- a/packages/stylelint-config-terra/stylelint.config.js
+++ b/packages/stylelint-config-terra/stylelint.config.js
@@ -1,7 +1,7 @@
 const browserslist = require('@cerner/browserslist-config-terra');
 
 module.exports = {
-  extends: ['stylelint-config-sass-guidelines', 'stylelint-config-standard-scss'],
+  extends: 'stylelint-config-sass-guidelines',
   plugins: [
     'stylelint-no-unsupported-browser-features',
     './lib/rules/custom-property-no-duplicate-declaration/custom-property-no-duplicate-declaration',
@@ -21,7 +21,7 @@ module.exports = {
       },
     ],
     'declaration-property-unit-allowed-list': [{ 'line-height': [] }, { severity: 'warning' }],
-    'scss/no-global-function-names': false,
+    'scss/no-global-function-names': null,
     'terra/custom-property-name': true,
     'terra/custom-property-no-duplicate-declaration': true,
     'terra/custom-property-pattern': true,

--- a/packages/stylelint-config-terra/stylelint.config.js
+++ b/packages/stylelint-config-terra/stylelint.config.js
@@ -12,7 +12,6 @@ module.exports = {
   ],
   rules: {
     'max-nesting-depth': 3,
-    'no-extra-semicolons': [true, { severity: 'warning' }],
     'scss/at-mixin-pattern': '^[a-z]+([a-z0-9-]+[a-z0-9]+)?$',
     'custom-property-pattern': [
       '[a-z]+([a-z0-9-]+[a-z0-9]+)?$',
@@ -35,13 +34,13 @@ module.exports = {
           'calc', // "calc" is only partially supported by Android Browser 4.4.3-4.4.4
           'css-gradients', // is only partially supported by Safari 12,11.1, iOS Safari 10.0-10.2,10.3,11.0-11.2,11.3-11.4,12.0-12.1
           'cursor', // "css3-cursors" is not supported by iOS Safari 10.0-10.2,10.3,11.0-11.2,11.3-11.4, Android Browser 4.4.3-4.4.4
-          'flexbox', // "flexbox" is only partially supported by IE 10,11
-          'outline', // "outline" is only partially supported by IE 10,11
-          'rem', // "rem" is only partially supported by IE 10
-          'viewport-units', // is only partially supported by IE 10,11
+          'flexbox', // "flexbox" is only partially supported by IE 11
+          'outline', // "outline" is only partially supported by IE 11
+          'rem',
+          'viewport-units', // is only partially supported by IE 11
           'word-break', // "word-break" is only partially supported by Android Browser 4.3.4-4.4.4
-          'wordwrap', // is only partially supported by IE 10,11, Edge 17
-          'css-filters', // "Not supported by IE10,11",
+          'wordwrap', // is only partially supported by IE 11, Edge 17
+          'css-filters', // "Not supported by IE 11",
         ],
         severity: 'warning',
       },

--- a/packages/stylelint-config-terra/stylelint.config.js
+++ b/packages/stylelint-config-terra/stylelint.config.js
@@ -1,5 +1,7 @@
+const browserslist = require('@cerner/browserslist-config-terra');
+
 module.exports = {
-  extends: 'stylelint-config-sass-guidelines',
+  extends: ['stylelint-config-sass-guidelines', 'stylelint-config-standard-scss'],
   plugins: [
     'stylelint-no-unsupported-browser-features',
     './lib/rules/custom-property-no-duplicate-declaration/custom-property-no-duplicate-declaration',
@@ -19,6 +21,7 @@ module.exports = {
       },
     ],
     'declaration-property-unit-allowed-list': [{ 'line-height': [] }, { severity: 'warning' }],
+    'scss/no-global-function-names': false,
     'terra/custom-property-name': true,
     'terra/custom-property-no-duplicate-declaration': true,
     'terra/custom-property-pattern': true,
@@ -27,6 +30,7 @@ module.exports = {
     'plugin/no-unsupported-browser-features': [
       true,
       {
+        browsers: browserslist,
         ignore: [
           'calc', // "calc" is only partially supported by Android Browser 4.4.3-4.4.4
           'css-gradients', // is only partially supported by Safari 12,11.1, iOS Safari 10.0-10.2,10.3,11.0-11.2,11.3-11.4,12.0-12.1
@@ -37,6 +41,7 @@ module.exports = {
           'viewport-units', // is only partially supported by IE 10,11
           'word-break', // "word-break" is only partially supported by Android Browser 4.3.4-4.4.4
           'wordwrap', // is only partially supported by IE 10,11, Edge 17
+          'css-filters', // "Not supported by IE10,11",
         ],
         severity: 'warning',
       },

--- a/packages/stylelint-config-terra/stylelint.config.js
+++ b/packages/stylelint-config-terra/stylelint.config.js
@@ -36,7 +36,6 @@ module.exports = {
           'cursor', // "css3-cursors" is not supported by iOS Safari 10.0-10.2,10.3,11.0-11.2,11.3-11.4, Android Browser 4.4.3-4.4.4
           'flexbox', // "flexbox" is only partially supported by IE 11
           'outline', // "outline" is only partially supported by IE 11
-          'rem',
           'viewport-units', // is only partially supported by IE 11
           'word-break', // "word-break" is only partially supported by Android Browser 4.3.4-4.4.4
           'wordwrap', // is only partially supported by IE 11, Edge 17

--- a/packages/stylelint-config-terra/tests/jest/custom-property-name/__snapshots__/custom-property-name.test.js.snap
+++ b/packages/stylelint-config-terra/tests/jest/custom-property-name/__snapshots__/custom-property-name.test.js.snap
@@ -4,6 +4,8 @@ exports[`custom-property-name does error with a mismatched name 1`] = `
 Array [
   Object {
     "column": 9,
+    "endColumn": 47,
+    "endLine": 1,
     "line": 1,
     "rule": "terra/custom-property-name",
     "severity": "error",
@@ -16,6 +18,8 @@ exports[`custom-property-name does error with a mismatched name with hyphen 1`] 
 Array [
   Object {
     "column": 9,
+    "endColumn": 49,
+    "endLine": 1,
     "line": 1,
     "rule": "terra/custom-property-name",
     "severity": "error",

--- a/packages/stylelint-config-terra/tests/jest/custom-property-namespace/__snapshots__/custom-property-namespace.test.js.snap
+++ b/packages/stylelint-config-terra/tests/jest/custom-property-namespace/__snapshots__/custom-property-namespace.test.js.snap
@@ -4,6 +4,8 @@ exports[`custom-property-namespace does error with no custom namespace 1`] = `
 Array [
   Object {
     "column": 9,
+    "endColumn": 33,
+    "endLine": 1,
     "line": 1,
     "rule": "terra/custom-property-namespace",
     "severity": "error",
@@ -16,6 +18,8 @@ exports[`custom-property-namespace does error with no default namespace 1`] = `
 Array [
   Object {
     "column": 9,
+    "endColumn": 34,
+    "endLine": 1,
     "line": 1,
     "rule": "terra/custom-property-namespace",
     "severity": "error",

--- a/packages/stylelint-config-terra/tests/jest/custom-property-no-duplicate-declaration/__snapshots__/custom-property-no-duplicate-declaration.test.js.snap
+++ b/packages/stylelint-config-terra/tests/jest/custom-property-no-duplicate-declaration/__snapshots__/custom-property-no-duplicate-declaration.test.js.snap
@@ -4,6 +4,8 @@ exports[`custom-property-no-duplicate-declaration does error with nested duplica
 Array [
   Object {
     "column": 11,
+    "endColumn": 42,
+    "endLine": 1,
     "line": 1,
     "rule": "terra/custom-property-no-duplicate-declaration",
     "severity": "error",
@@ -16,6 +18,8 @@ exports[`custom-property-no-duplicate-declaration does error with reversed sibli
 Array [
   Object {
     "column": 11,
+    "endColumn": 42,
+    "endLine": 1,
     "line": 1,
     "rule": "terra/custom-property-no-duplicate-declaration",
     "severity": "error",
@@ -28,6 +32,8 @@ exports[`custom-property-no-duplicate-declaration does error with sibling duplic
 Array [
   Object {
     "column": 49,
+    "endColumn": 80,
+    "endLine": 1,
     "line": 1,
     "rule": "terra/custom-property-no-duplicate-declaration",
     "severity": "error",

--- a/packages/stylelint-config-terra/tests/jest/custom-property-pattern/__snapshots__/custom-property-pattern.test.js.snap
+++ b/packages/stylelint-config-terra/tests/jest/custom-property-pattern/__snapshots__/custom-property-pattern.test.js.snap
@@ -4,6 +4,8 @@ exports[`custom-property-pattern does error with custom property with underscore
 Array [
   Object {
     "column": 9,
+    "endColumn": 44,
+    "endLine": 1,
     "line": 1,
     "rule": "terra/custom-property-pattern",
     "severity": "error",
@@ -16,6 +18,8 @@ exports[`custom-property-pattern does error with custom property with uppercase 
 Array [
   Object {
     "column": 9,
+    "endColumn": 33,
+    "endLine": 1,
     "line": 1,
     "rule": "terra/custom-property-pattern",
     "severity": "error",

--- a/packages/stylelint-config-terra/tests/jest/custom-property-pseudo-selectors/__snapshots__/custom-properety-pseudo-selectors.test.js.snap
+++ b/packages/stylelint-config-terra/tests/jest/custom-property-pseudo-selectors/__snapshots__/custom-properety-pseudo-selectors.test.js.snap
@@ -4,6 +4,8 @@ exports[`custom-property-pseudo-selectors does error with a custom properties th
 Array [
   Object {
     "column": 27,
+    "endColumn": 63,
+    "endLine": 1,
     "line": 1,
     "rule": "terra/custom-property-pseudo-selectors",
     "severity": "error",
@@ -16,6 +18,8 @@ exports[`custom-property-pseudo-selectors does error with a custom properties th
 Array [
   Object {
     "column": 15,
+    "endColumn": 39,
+    "endLine": 1,
     "line": 1,
     "rule": "terra/custom-property-pseudo-selectors",
     "severity": "error",
@@ -28,6 +32,8 @@ exports[`custom-property-pseudo-selectors does error with a custom properties th
 Array [
   Object {
     "column": 15,
+    "endColumn": 39,
+    "endLine": 1,
     "line": 1,
     "rule": "terra/custom-property-pseudo-selectors",
     "severity": "error",

--- a/packages/terra-toolkit-docs/CHANGELOG.md
+++ b/packages/terra-toolkit-docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Updated upgrade guide for `stylelint-config-terra`.
+
 ## 2.23.0 - (September 26, 2023)
 
 * Added

--- a/packages/terra-toolkit-docs/src/terra-dev-site/tool/stylelintConfigTerra/UpgradeGuide.y.tool.mdx
+++ b/packages/terra-toolkit-docs/src/terra-dev-site/tool/stylelintConfigTerra/UpgradeGuide.y.tool.mdx
@@ -4,11 +4,17 @@ import { Badge } from '@cerner/stylelint-config-terra/package.json?dev-site-pack
 
 # stylelint-config-terra Upgrade Guide
 
+## Changes from stylelint-config-terra 4.0.0  to @cerner/stylelint-config-terra 5.0.0
+
+* Stylelint version 15 is now required. Refer to the [Stylelint 15 Migration Guide for more details](https://stylelint.io/migration-guide/to-15). 
+* Support for IE10 rules has been dropped. Make sure you are no longer using IE10 rules in your project before upgrading.
+* Stylint CLI no longer supports --syntax option. Refer to the [Stylelint 14 Migration Guide for more details](https://stylelint.io/migration-guide/to-14#syntax-option-and-automatic-inferral-of-syntax).
+
 ## Changes from stylelint-config-terra 3.x  to @cerner/stylelint-config-terra 4.0.0
 
 ### Node 10
 
-Node 10 is not the minimum supported version. Upgrade to node 10.
+Node 10 is not the minimum supported version. Upgrade to node 14.
 
 ### Stylelint 13
 


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

Stylelint-config-terra upgrading stylelint from v13 to v15. 

The stylelint rules also have outdated rules for IE10 which is no longer supported. 

**What was changed:**


**Why it was changed:**

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [x] Other (please describe below)
- [ ] No tests are needed

Checking lint tests in terra-core
### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-9445 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
