### PR TITLE
[terra-functional-testing] Allow consumers to set maxInstances while executing WDIO.

### DIFF
--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Allow consumers to set maxInstances while executing wdio scripts.
+
 ## 4.4.0 - (September 26, 2023)
 
 * Changed

--- a/packages/terra-functional-testing/src/config/capabilities.js
+++ b/packages/terra-functional-testing/src/config/capabilities.js
@@ -1,11 +1,12 @@
 /**
  * This file contains the capability configurations for each supported browser.
  */
+const getMaxInstances = require('./utils/getMaxInstances');
 
 module.exports = {
   chrome: {
     browserName: 'chrome',
-    maxInstances: 1,
+    maxInstances: getMaxInstances(),
     'goog:chromeOptions': {
       /**
        * Run in headless mode because Chrome 69+ cannot be resized to the tiny viewport due to a omnibox size change
@@ -19,7 +20,7 @@ module.exports = {
   },
   firefox: {
     browserName: 'firefox',
-    maxInstances: 1,
+    maxInstances: getMaxInstances(),
     'moz:firefoxOptions': {
       prefs: {
         'dom.disable_beforeunload': false,
@@ -28,7 +29,7 @@ module.exports = {
   },
   ie: {
     browserName: 'internet explorer',
-    maxInstances: 1,
+    maxInstances: getMaxInstances(),
     'se:ieOptions': {
       javascriptEnabled: true,
       locationContextEnabled: true,

--- a/packages/terra-functional-testing/src/config/utils/getMaxInstances.js
+++ b/packages/terra-functional-testing/src/config/utils/getMaxInstances.js
@@ -1,0 +1,7 @@
+module.exports = () => {
+  const args = process.argv.slice(2);
+  const maxInstancesIndex = args.indexOf('--maxInstances');
+  const maxInstances = maxInstancesIndex !== -1 ? parseInt(args[maxInstancesIndex + 1], 10) : 1;
+
+  return maxInstances;
+};

--- a/packages/terra-functional-testing/src/config/utils/getMaxInstances.js
+++ b/packages/terra-functional-testing/src/config/utils/getMaxInstances.js
@@ -1,5 +1,5 @@
 module.exports = () => {
-  const args = process.argv.slice(2);
+  const args = process.argv;
   const maxInstancesIndex = args.indexOf('--maxInstances');
   const maxInstances = maxInstancesIndex !== -1 ? parseInt(args[maxInstancesIndex + 1], 10) : 1;
 

--- a/packages/terra-functional-testing/src/terra-cli/wdio/index.js
+++ b/packages/terra-functional-testing/src/terra-cli/wdio/index.js
@@ -181,6 +181,17 @@ const cli = {
           return ['en'];
         },
       },
+      maxInstances: {
+        type: 'number',
+        describe: 'The number of tests running concurrently.',
+        default: () => {
+          if (process.env.MAX_INSTANCES) {
+            return [process.env.MAX_INSTANCES];
+          }
+
+          return 1;
+        },
+      },
       screenshotUrl: {
         type: 'string',
         describe: 'The url to the registry that stores the screenshots',

--- a/packages/terra-functional-testing/tests/jest/terra-cli/wdio/__snapshots__/index.test.js.snap
+++ b/packages/terra-functional-testing/tests/jest/terra-cli/wdio/__snapshots__/index.test.js.snap
@@ -44,6 +44,9 @@ Options:
                                                       [boolean] [default: false]
       --locales                         A list of language locales for the test
                                         run.       [array] [default: (_default)]
+      --maxInstances                    The number of tests running
+                                        concurrently.
+                                                  [number] [default: (_default)]
       --screenshotUrl                   The url to the registry that stores the
                                         screenshots
                                                   [string] [default: (_default)]


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**
Added feature to allow consumers to set maxInstances while running wdio.

**Why it was changed:**

It was required by a consuming team.

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [x] WDIO
- [x] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-9130 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra

Tested with terra-core: 10 instances
<img width="811" alt="image" src="https://github.com/cerner/terra-toolkit/assets/40137430/cd2c9000-a9a6-46e6-a1f1-0f12683b64b5">

