### PR TITLE
[terra-functional-testing] update logger output for the `--disable-server` flag

### DIFF
--- a/packages/terra-functional-testing/src/config/utils/getConfigurationOptions.js
+++ b/packages/terra-functional-testing/src/config/utils/getConfigurationOptions.js
@@ -37,8 +37,9 @@ const getConfigurationOptions = (options) => {
     useSeleniumStandaloneService,
   } = options;
 
+  const url = `http://${externalHost || getIpAddress()}:${externalPort || 8080}`;
   return {
-    baseUrl: `http://${externalHost || getIpAddress()}:${externalPort || 8080}`,
+    baseUrl: url,
     capabilities: getCapabilities(browsers, !!gridUrl),
     hostname: seleniumServiceUrl || gridUrl || (useSeleniumStandaloneService ? 'standalone-chrome' : 'localhost'),
     port: seleniumServicePort || (gridUrl ? 80 : 4444),
@@ -60,6 +61,7 @@ const getConfigurationOptions = (options) => {
       port: assetServerPort,
       site,
       updateScreenshots,
+      url,
       useHttps,
       useRemoteReferenceScreenshots,
       ...(theme ? { theme } : { theme: getDefaultThemeName() }),

--- a/packages/terra-functional-testing/src/services/wdio-asset-server-service.js
+++ b/packages/terra-functional-testing/src/services/wdio-asset-server-service.js
@@ -25,7 +25,7 @@ class AssetServerService {
 
     try {
       if (this.options.disableServer) {
-        logger.info(`Internal asset server disabled; Connecting to server on 0.0.0.0:${this.options.port}`);
+        logger.info(`Internal asset server disabled; Connecting to server on ${this.options.url}`);
         return;
       }
 


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

This PR corrects the logger output for the target ip address when the `--disable-server` flag is used. 

Before:

![CleanShot 2024-03-08 at 14 51 10](https://github.com/cerner/terra-toolkit/assets/38024451/12b216ce-fbd8-47d9-ad1b-cfa40e2c61a5)

After:
![CleanShot 2024-03-08 at 14 56 26](https://github.com/cerner/terra-toolkit/assets/38024451/9dc75e97-445d-4782-831a-2c60f8346663)

This will now display the correct ip address for debugging purposes.

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [x] Other (please describe below)
- [ ] No tests are needed

This was tested by installing a local copy in terra-framework and running the wdio test, resulting in the screenshots above.

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->
---

Thank you for contributing to Terra.
@cerner/terra
