### PR TITLE
[terra-functional-testing] update docker compose to v2

### DIFF
--- a/packages/terra-functional-testing/CHANGELOG.md
+++ b/packages/terra-functional-testing/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Updated to support Docker Compose V2.
+
 ## 4.7.0 - (March 8, 2024)
 
 * Added

--- a/packages/terra-functional-testing/src/services/wdio-selenium-docker-service.js
+++ b/packages/terra-functional-testing/src/services/wdio-selenium-docker-service.js
@@ -91,7 +91,7 @@ class SeleniumDockerService {
 
     const envVars = this.seleniumVersion ? `TERRA_SELENIUM_DOCKER_VERSION=${this.seleniumVersion} ` : '';
 
-    await exec(`${envVars}docker-compose -f "${this.getDockerComposeFilePath()}" up -d`);
+    await exec(`${envVars}docker compose -f "${this.getDockerComposeFilePath()}" up -d`);
     await this.waitForSeleniumHubReady();
 
     logger.info('Successfully started the docker selenium hub.');
@@ -126,7 +126,7 @@ class SeleniumDockerService {
     if (!this.keepAliveSeleniumDockerService && !this.disableSeleniumService) {
       logger.info('Shutting down the docker selenium hub...');
 
-      await exec(`docker-compose -f "${this.getDockerComposeFilePath()}" down`);
+      await exec(`docker compose -f "${this.getDockerComposeFilePath()}" down`);
     }
   }
 }

--- a/packages/terra-functional-testing/tests/jest/services/wdio-selenium-docker-service.test.js
+++ b/packages/terra-functional-testing/tests/jest/services/wdio-selenium-docker-service.test.js
@@ -143,7 +143,7 @@ describe('WDIO Selenium Docker Service', () => {
 
       service.startSeleniumHub();
 
-      expect(mockExec).toHaveBeenCalledWith('docker-compose -f "mock-compose-path" up -d');
+      expect(mockExec).toHaveBeenCalledWith('docker compose -f "mock-compose-path" up -d');
     });
 
     it('should start the selenium hub with the specified version', () => {
@@ -154,7 +154,7 @@ describe('WDIO Selenium Docker Service', () => {
 
       service.startSeleniumHub();
 
-      expect(mockExec).toHaveBeenCalledWith('TERRA_SELENIUM_DOCKER_VERSION=1234 docker-compose -f "mock-compose-path" up -d');
+      expect(mockExec).toHaveBeenCalledWith('TERRA_SELENIUM_DOCKER_VERSION=1234 docker compose -f "mock-compose-path" up -d');
     });
   });
 
@@ -225,7 +225,7 @@ describe('WDIO Selenium Docker Service', () => {
 
       await service.onComplete();
 
-      expect(mockExec).toHaveBeenCalledWith('docker-compose -f "mock-compose-path" down');
+      expect(mockExec).toHaveBeenCalledWith('docker compose -f "mock-compose-path" down');
     });
   });
 });


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

Docker Compose V1 has been deprecated. This PR updates terra-functional-testing to support Docker Compose V2.

Additional Info: https://github.com/orgs/community/discussions/116610

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [x] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

---

Thank you for contributing to Terra.
@cerner/terra
